### PR TITLE
LCAM-1102|Fix the missing Extra expenditure reason display

### DIFF
--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/maat/orchestration/enums/HardshipReviewDetailReason.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/maat/orchestration/enums/HardshipReviewDetailReason.java
@@ -12,21 +12,22 @@ import java.util.stream.Stream;
 @AllArgsConstructor
 public enum HardshipReviewDetailReason {
 
-    EVIDENCE_SUPPLIED("Evidence Supplied"),
-    ALLOWABLE_EXPENSE("Allowable Expense"),
-    ESSENTIAL_NEED_FOR_WORK("Essential - need for work"),
-    ESSENTIAL_ITEM("Essential Item"),
-    ARRANGEMENT_IN_PLACE("Arrangement in place"),
-    NO_EVIDENCE_SUPPLIED("No evidence supplied"),
-    INSUFFICIENT_EVIDENCE_SUPPLIED("Insufficient evidence supplied"),
-    NON_ESSENTIAL_ITEM_EXPENSE("Non-essential item/expense"),
-    COVERED_BY_LIVING_EXPENSE("Covered by living expense"),
-    NOT_ALLOWABLE_DIFF_FROM_NON_ESSENTIAL("Not allowable (diff from non-essential)"),
-    NOT_IN_COMPUTATION_PERIOD("Not in computation period");
+    EVIDENCE_SUPPLIED("Evidence Supplied", 7),
+    ALLOWABLE_EXPENSE("Allowable Expense", 8),
+    ESSENTIAL_NEED_FOR_WORK("Essential - need for work", 9),
+    ESSENTIAL_ITEM("Essential Item", 10),
+    ARRANGEMENT_IN_PLACE("Arrangement in place", 11),
+    NO_EVIDENCE_SUPPLIED("No evidence supplied", 11010331),
+    INSUFFICIENT_EVIDENCE_SUPPLIED("Insufficient evidence supplied", 11010332),
+    NON_ESSENTIAL_ITEM_EXPENSE("Non-essential item/expense", 11010333),
+    COVERED_BY_LIVING_EXPENSE("Covered by living expense", 11010334),
+    NOT_ALLOWABLE_DIFF_FROM_NON_ESSENTIAL("Not allowable (diff from non-essential)", 11010335),
+    NOT_IN_COMPUTATION_PERIOD("Not in computation period", 11010336);
 
     @JsonPropertyDescription("Hardship review detail reasons")
     @JsonValue
     private final String reason;
+    private final int id;
 
     public static HardshipReviewDetailReason getFrom(String reason) {
         if (StringUtils.isBlank(reason)) return null;

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/maat/orchestration/mapper/HardshipReviewMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/maat/orchestration/mapper/HardshipReviewMapper.java
@@ -67,6 +67,7 @@ public class HardshipReviewMapper implements ResponseMapper<ApiFindHardshipRespo
         if (detailReason != null) {
             return HRReasonDTO.builder()
                     .reason(detailReason.getReason())
+                    .id((long) detailReason.getId())
                     .build();
         }
         return null;
@@ -81,10 +82,13 @@ public class HardshipReviewMapper implements ResponseMapper<ApiFindHardshipRespo
     }
 
     private HRDetailDescriptionDTO getHRDetailDescriptionDTO(HardshipReviewDetailCode detailCode) {
-        return HRDetailDescriptionDTO.builder()
-                .description(detailCode.getDescription())
-                .code(detailCode.getCode())
-                .build();
+        if (detailCode != null) {
+            return HRDetailDescriptionDTO.builder()
+                    .description(detailCode.getDescription())
+                    .code(detailCode.getCode())
+                    .build();
+        }
+        return null;
     }
 
     private HRDetailTypeDTO getHRDetailType(HardshipReviewDetailType hrDetailType) {
@@ -131,6 +135,7 @@ public class HardshipReviewMapper implements ResponseMapper<ApiFindHardshipRespo
         return NewWorkReasonDTO.builder()
                 .description(newWorkReason.getDescription())
                 .code(newWorkReason.getCode())
+                .type(newWorkReason.getType())
                 .build();
     }
 

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/maat/orchestration/data/builder/TestModelDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/maat/orchestration/data/builder/TestModelDataBuilder.java
@@ -30,6 +30,7 @@ public class TestModelDataBuilder {
     public static final BigDecimal TEST_SOLICITOR_DISBURSEMENTS = BigDecimal.valueOf(375);
     public static final BigDecimal TEST_SOLICITOR_VAT = BigDecimal.valueOf(250);
     public static final BigDecimal TEST_SOLICITOR_ESTIMATED_COST = BigDecimal.valueOf(2500);
+    public static final BigDecimal AMOUNT = BigDecimal.valueOf(99.99);
 
     public static ApiFindHardshipResponse getApiFindHardshipResponse() {
         return new ApiFindHardshipResponse()
@@ -44,7 +45,7 @@ public class TestModelDataBuilder {
                 .withNewWorkReason(NewWorkReason.PRI)
                 .withSolicitorCosts(getSolicitorsCosts())
                 .withStatus(HardshipReviewStatus.COMPLETE)
-                .withReviewDetails(getApiHardshipReviewDetails(BigDecimal.valueOf(99.99), HardshipReviewDetailType.EXPENDITURE))
+                .withReviewDetails(getApiHardshipReviewDetails(AMOUNT, HardshipReviewDetailType.EXPENDITURE))
                 .withReviewProgressItems(getReviewProgressItems());
     }
 

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/maat/orchestration/enums/HardshipReviewDetailReasonTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/maat/orchestration/enums/HardshipReviewDetailReasonTest.java
@@ -34,6 +34,7 @@ class HardshipReviewDetailReasonTest {
     @Test
     void givenValidInput_ValidateEnumValues() {
         assertThat("Evidence Supplied").isEqualTo(HardshipReviewDetailReason.EVIDENCE_SUPPLIED.getReason());
+        assertThat(7).isEqualTo(HardshipReviewDetailReason.EVIDENCE_SUPPLIED.getId());
     }
 
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/maat/orchestration/mapper/HardshipReviewMapperTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/maat/orchestration/mapper/HardshipReviewMapperTest.java
@@ -6,9 +6,19 @@ import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import uk.gov.justice.laa.maat.orchestration.data.builder.TestModelDataBuilder;
+import uk.gov.justice.laa.maat.orchestration.dto.HRDetailDTO;
+import uk.gov.justice.laa.maat.orchestration.dto.HRSectionDTO;
 import uk.gov.justice.laa.maat.orchestration.dto.HardshipReviewDTO;
+import uk.gov.justice.laa.maat.orchestration.enums.Frequency;
+import uk.gov.justice.laa.maat.orchestration.enums.HardshipReviewDetailCode;
+import uk.gov.justice.laa.maat.orchestration.enums.HardshipReviewDetailReason;
+import uk.gov.justice.laa.maat.orchestration.enums.HardshipReviewDetailType;
 import uk.gov.justice.laa.maat.orchestration.model.ApiFindHardshipResponse;
 import uk.gov.justice.laa.maat.orchestration.util.DateUtil;
+
+import java.util.Optional;
+
+import static uk.gov.justice.laa.maat.orchestration.data.builder.TestModelDataBuilder.HARDSHIP_DETAIL_ID;
 
 @ExtendWith(SoftAssertionsExtension.class)
 class HardshipReviewMapperTest {
@@ -62,5 +72,34 @@ class HardshipReviewMapperTest {
                 .isEqualTo(hardship.getSolicitorCosts().getRate().doubleValue());
         softly.assertThat(reviewDTO.getSolictorsCosts().getSolicitorVat().doubleValue())
                 .isEqualTo(hardship.getSolicitorCosts().getVat().doubleValue());
+        Optional<HRSectionDTO> optionalHRSectionDTO = reviewDTO.getSection().stream().findFirst();
+        softly.assertThat(optionalHRSectionDTO.isPresent()).isTrue();
+        if (optionalHRSectionDTO.isPresent()) {
+            HRSectionDTO hrSectionDTO = optionalHRSectionDTO.get();
+            softly.assertThat(hrSectionDTO.getDetailType().getType())
+                    .isEqualTo(HardshipReviewDetailType.EXPENDITURE.getType());
+            softly.assertThat(hrSectionDTO.getDetailType().getDescription())
+                    .isEqualTo("Extra Expenditure");
+            Optional<HRDetailDTO> optionalHRDetailDTO = hrSectionDTO.getDetail().stream().findFirst();
+            softly.assertThat(optionalHRDetailDTO.isPresent()).isTrue();
+            if (optionalHRDetailDTO.isPresent()) {
+                HRDetailDTO hrDetailDTO = optionalHRDetailDTO.get();
+                softly.assertThat(hrDetailDTO.getAmountNumber().doubleValue())
+                        .isEqualTo(TestModelDataBuilder.AMOUNT.doubleValue());
+                softly.assertThat(hrDetailDTO.getId().intValue())
+                        .isEqualTo(HARDSHIP_DETAIL_ID);
+                softly.assertThat(hrDetailDTO.getOtherDescription())
+                        .isEqualTo("Loan to family members");
+                softly.assertThat(hrDetailDTO.getFrequency().getCode())
+                        .isEqualTo(Frequency.TWO_WEEKLY.getCode());
+                softly.assertThat(hrDetailDTO.getReason().getReason())
+                        .isEqualTo(HardshipReviewDetailReason.COVERED_BY_LIVING_EXPENSE.getReason());
+                softly.assertThat(hrDetailDTO.getReason().getId())
+                        .isEqualTo(HardshipReviewDetailReason.COVERED_BY_LIVING_EXPENSE.getId());
+                softly.assertThat(hrDetailDTO.getDetailDescription().getDescription())
+                        .isEqualTo(HardshipReviewDetailCode.OTHER.getDescription());
+                softly.assertThat(hrDetailDTO.isAccepted()).isTrue();
+            }
+        }
     }
 }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1102)

In order to fix the Extra expenditure Reason populating the id field on the HRReasonDTO.
Add a null check around HardshipReviewDetailCode mapping.
Add missing mapping on NewWorkReasonDTO.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
