### PR TITLE
LCAM-1282

### DIFF
--- a/maat-orchestration/build.gradle
+++ b/maat-orchestration/build.gradle
@@ -4,7 +4,7 @@ plugins {
 	id "org.sonarqube" version "4.4.1.3373"
 	id "info.solidsoft.pitest" version "1.15.0"
 	id "org.springframework.boot" version "3.1.5"
-	id 'io.spring.dependency-management' version '1.1.4'
+	id "io.spring.dependency-management" version "1.1.4"
 	id "org.jsonschema2dataclass" version "6.0.0"
 }
 

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/jackson/LocalDateTimeDeserializer.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/jackson/LocalDateTimeDeserializer.java
@@ -3,6 +3,7 @@ package uk.gov.justice.laa.crime.orchestration.jackson;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -11,11 +12,20 @@ import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 
 public class LocalDateTimeDeserializer extends JsonDeserializer<LocalDateTime> {
 
+    private static final String NULL_VALUE = "null";
+
     @Override
     public LocalDateTime deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws
             IOException {
 
         String dateTime = jsonParser.getValueAsString();
-        return LocalDateTime.parse(dateTime, ISO_LOCAL_DATE_TIME);
+        try {
+            if (StringUtils.isNotBlank(dateTime) && !dateTime.trim().equals(NULL_VALUE)) {
+                return LocalDateTime.parse(dateTime, ISO_LOCAL_DATE_TIME);
+            }
+        } catch (RuntimeException e) {
+            throw new IllegalArgumentException("Invalid date value: " + dateTime, e);
+        }
+        return null;
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/jackson/LocalDateTimeDeserializer.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/jackson/LocalDateTimeDeserializer.java
@@ -5,9 +5,9 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 
 import java.io.IOException;
-import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
+
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 
 public class LocalDateTimeDeserializer extends JsonDeserializer<LocalDateTime> {
 
@@ -15,8 +15,7 @@ public class LocalDateTimeDeserializer extends JsonDeserializer<LocalDateTime> {
     public LocalDateTime deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws
             IOException {
 
-        long value = jsonParser.getValueAsLong();
-        Instant instant = Instant.ofEpochMilli(value);
-        return LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
+        String dateTime = jsonParser.getValueAsString();
+        return LocalDateTime.parse(dateTime, ISO_LOCAL_DATE_TIME);
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/TestModelDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/TestModelDataBuilder.java
@@ -481,6 +481,7 @@ public class TestModelDataBuilder {
                 .repOrderDecision(getRepOrderDecisionDTO())
                 .iojResult(RESULT_PASS)
                 .assessmentSummary(Collections.emptyList())
+                .timestamp(APPLICATION_TIMESTAMP)
                 .build();
     }
 
@@ -663,6 +664,7 @@ public class TestModelDataBuilder {
                 .caseManagementUnitDTO(getCaseManagementUnitDTO())
                 .crownCourtOverviewDTO(CrownCourtOverviewDTO.builder().build())
                 .statusDTO(getRepStatusDTO())
+                .timestamp(APPLICATION_TIMESTAMP)
                 .assessmentDTO(
                         AssessmentDTO.builder()
                                 .financialAssessmentDTO(getFinancialAssessmentDTO(courtType))

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/jackson/LocalDateTimeDeserializerTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/jackson/LocalDateTimeDeserializerTest.java
@@ -6,12 +6,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class LocalDateTimeDeserializerTest {
 
@@ -31,5 +29,28 @@ class LocalDateTimeDeserializerTest {
         LocalDateTime expected = LocalDateTime.of(2024, 1, 27, 10, 15, 30);
         LocalDateTime result = deserializer.deserialize(parser, mapper.getDeserializationContext());
         assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void givenNullDate_whenDeserializeIsInvoked_thenNullIsReturned() throws IOException {
+        String content = "\"null\"";
+        JsonParser parser = factory.createParser(content);
+        parser.setCodec(mapper);
+        parser.nextToken();
+
+        LocalDateTime result = deserializer.deserialize(parser, mapper.getDeserializationContext());
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void givenInvalidDate_whenDeserializeIsInvoked_thenExceptionIsThrown() throws IOException {
+        String content = "\"invalid-date\"";
+        JsonParser parser = factory.createParser(content);
+        parser.setCodec(mapper);
+        parser.nextToken();
+
+        assertThatThrownBy(() -> deserializer.deserialize(parser, mapper.getDeserializationContext()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid date value: invalid-date");
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/jackson/LocalDateTimeDeserializerTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/jackson/LocalDateTimeDeserializerTest.java
@@ -19,18 +19,17 @@ class LocalDateTimeDeserializerTest {
     private final ObjectMapper mapper = new ObjectMapper();
     private final LocalDateTimeDeserializer deserializer = new LocalDateTimeDeserializer();
 
+    private static final String ISO_DATE = "2024-01-27T10:15:30";
+
     @Test
     void givenValidDate_whenDeserializeIsInvoked_thenLocalDateTimeIsDeserialized() throws IOException {
-        JsonParser parser = factory.createParser("1633027200000");
+        String content = String.format("\"%s\"", ISO_DATE);
+        JsonParser parser = factory.createParser(content);
         parser.setCodec(mapper);
         parser.nextToken();
 
+        LocalDateTime expected = LocalDateTime.of(2024, 1, 27, 10, 15, 30);
         LocalDateTime result = deserializer.deserialize(parser, mapper.getDeserializationContext());
-
-        LocalDateTime expected =
-                ZonedDateTime.ofInstant(Instant.ofEpochMilli(1633027200000L), ZoneId.systemDefault())
-                        .toLocalDateTime();
-
         assertThat(result).isEqualTo(expected);
     }
 }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1282)

- Fixed `LocalDateTime` deserialisation that was causing validation failures.
  - The `LocalDateTimeDeserializer` now expects dates in ISO format, not Unix time.
