### PR TITLE
LCAM-1305|Use custom deserializers for the different timestamp formats

### DIFF
--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/jackson/LocalDateTimeDeserializer.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/jackson/LocalDateTimeDeserializer.java
@@ -7,8 +7,13 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
 
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 
 public class LocalDateTimeDeserializer extends JsonDeserializer<LocalDateTime> {
 
@@ -21,7 +26,16 @@ public class LocalDateTimeDeserializer extends JsonDeserializer<LocalDateTime> {
         String dateTime = jsonParser.getValueAsString();
         try {
             if (StringUtils.isNotBlank(dateTime) && !dateTime.trim().equals(NULL_VALUE)) {
-                return LocalDateTime.parse(dateTime, ISO_LOCAL_DATE_TIME);
+                if (!dateTime.contains(".") && !dateTime.contains("+")) {
+                    return LocalDateTime.parse(dateTime, ISO_LOCAL_DATE_TIME);
+                }
+                else if (dateTime.contains(".") && !dateTime.contains("+")) {
+                    DateTimeFormatter formatter = new DateTimeFormatterBuilder()
+                            .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
+                            .appendFraction(ChronoField.NANO_OF_SECOND, 1, 9, true)
+                            .toFormatter();
+                    return LocalDateTime.parse(dateTime, formatter).truncatedTo(ChronoUnit.SECONDS);
+                } else return LocalDateTime.parse(dateTime, ISO_OFFSET_DATE_TIME).truncatedTo(ChronoUnit.SECONDS);
             }
         } catch (RuntimeException e) {
             throw new IllegalArgumentException("Invalid date value: " + dateTime, e);

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/controller/HardshipControllerTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/controller/HardshipControllerTest.java
@@ -76,8 +76,10 @@ class HardshipControllerTest {
         when(orchestrationService.create(any(WorkflowRequest.class)))
                 .thenReturn(new ApplicationDTO());
 
-        mvc.perform(buildRequestWithTransactionIdGivenContent(HttpMethod.POST, objectMapper.writeValueAsString(
-                        TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.MAGISTRATE)), ENDPOINT_URL, true))
+        String requestBody = objectMapper.writeValueAsString(
+                TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.MAGISTRATE))
+                .replace("10:15:30", "10:15:30.423+00:00");
+        mvc.perform(buildRequestWithTransactionIdGivenContent(HttpMethod.POST, requestBody, ENDPOINT_URL, true))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
     }
@@ -93,8 +95,10 @@ class HardshipControllerTest {
         when(orchestrationService.create(any(WorkflowRequest.class)))
                 .thenThrow(new APIClientException());
 
-        mvc.perform(buildRequestWithTransactionIdGivenContent(HttpMethod.POST, objectMapper.writeValueAsString(
-                        TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.MAGISTRATE)), ENDPOINT_URL, true))
+        String requestBody = objectMapper.writeValueAsString(
+                TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.MAGISTRATE))
+                .replace("10:15:30", "10:15:30.423+00:00");
+        mvc.perform(buildRequestWithTransactionIdGivenContent(HttpMethod.POST, requestBody, ENDPOINT_URL, true))
                 .andExpect(status().isInternalServerError())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
     }
@@ -105,8 +109,10 @@ class HardshipControllerTest {
         when(orchestrationService.update(any(WorkflowRequest.class)))
                 .thenReturn(new ApplicationDTO());
 
-        mvc.perform(buildRequestWithTransactionIdGivenContent(HttpMethod.PUT, objectMapper.writeValueAsString(
-                        TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.MAGISTRATE)), ENDPOINT_URL, true))
+        String requestBody = objectMapper.writeValueAsString(
+                TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.MAGISTRATE))
+                .replace("10:15:30", "10:15:30.423+00:00");
+        mvc.perform(buildRequestWithTransactionIdGivenContent(HttpMethod.PUT, requestBody, ENDPOINT_URL, true))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
     }
@@ -123,8 +129,10 @@ class HardshipControllerTest {
         when(orchestrationService.update(any(WorkflowRequest.class)))
                 .thenThrow(new APIClientException());
 
-        mvc.perform(buildRequestWithTransactionIdGivenContent(HttpMethod.PUT, objectMapper.writeValueAsString(
-                        TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.MAGISTRATE)), ENDPOINT_URL, true))
+        String requestBody = objectMapper.writeValueAsString(
+                TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.MAGISTRATE))
+                .replace("10:15:30", "10:15:30.423+00:00");
+        mvc.perform(buildRequestWithTransactionIdGivenContent(HttpMethod.PUT, requestBody, ENDPOINT_URL, true))
                 .andExpect(status().isInternalServerError())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
     }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/controller/MeansAssessmentControllerTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/controller/MeansAssessmentControllerTest.java
@@ -79,8 +79,9 @@ class MeansAssessmentControllerTest {
         when(orchestrationService.create(any(WorkflowRequest.class)))
                 .thenReturn(new ApplicationDTO());
 
-        mvc.perform(buildRequestWithTransactionIdGivenContent(HttpMethod.POST, objectMapper.writeValueAsString(
-                        TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.MAGISTRATE)), ENDPOINT_URL, true))
+        String requestBody = objectMapper.writeValueAsString(TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.MAGISTRATE))
+                .replace("10:15:30", "10:15:30.423+00:00");
+        mvc.perform(buildRequestWithTransactionIdGivenContent(HttpMethod.POST, requestBody, ENDPOINT_URL, true))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
     }
@@ -97,8 +98,9 @@ class MeansAssessmentControllerTest {
         when(orchestrationService.create(any(WorkflowRequest.class)))
                 .thenThrow(new APIClientException());
 
-        mvc.perform(buildRequestWithTransactionIdGivenContent(HttpMethod.POST, objectMapper.writeValueAsString(
-                        TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.MAGISTRATE)), ENDPOINT_URL, true))
+        String requestBody = objectMapper.writeValueAsString(TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.MAGISTRATE))
+                .replace("10:15:30", "10:15:30.423+00:00");
+        mvc.perform(buildRequestWithTransactionIdGivenContent(HttpMethod.POST, requestBody, ENDPOINT_URL, true))
                 .andExpect(status().isInternalServerError())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
     }
@@ -109,8 +111,9 @@ class MeansAssessmentControllerTest {
         when(orchestrationService.update(any(WorkflowRequest.class)))
                 .thenReturn(new ApplicationDTO());
 
-        mvc.perform(buildRequestWithTransactionIdGivenContent(HttpMethod.PUT, objectMapper.writeValueAsString(
-                        TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.MAGISTRATE)), ENDPOINT_URL, true))
+        String requestBody = objectMapper.writeValueAsString(TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.MAGISTRATE))
+                .replace("10:15:30", "10:15:30.423+00:00");
+        mvc.perform(buildRequestWithTransactionIdGivenContent(HttpMethod.PUT, requestBody, ENDPOINT_URL, true))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
     }
@@ -127,8 +130,9 @@ class MeansAssessmentControllerTest {
         when(orchestrationService.update(any(WorkflowRequest.class)))
                 .thenThrow(new APIClientException());
 
-        mvc.perform(buildRequestWithTransactionIdGivenContent(HttpMethod.PUT, objectMapper.writeValueAsString(
-                        TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.MAGISTRATE)), ENDPOINT_URL, true))
+        String requestBody = objectMapper.writeValueAsString(TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.MAGISTRATE))
+                .replace("10:15:30", "10:15:30.423+00:00");
+        mvc.perform(buildRequestWithTransactionIdGivenContent(HttpMethod.PUT, requestBody, ENDPOINT_URL, true))
                 .andExpect(status().isInternalServerError())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
     }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/MeansAssessmentDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/MeansAssessmentDataBuilder.java
@@ -23,7 +23,6 @@ import java.util.*;
 
 import static uk.gov.justice.laa.crime.orchestration.data.Constants.FINANCIAL_ASSESSMENT_ID;
 import static uk.gov.justice.laa.crime.util.DateUtil.toDate;
-import static uk.gov.justice.laa.crime.util.DateUtil.toTimeStamp;
 
 @Component
 public class MeansAssessmentDataBuilder {
@@ -103,7 +102,8 @@ public class MeansAssessmentDataBuilder {
     public static final String CRITERIA_DETAIL_CODE = "Mock assessment detail code";
     public static final String ASSESSMENT_DESCRIPTION = "Mock assessment description";
     public static final BigDecimal PARTNER_AMOUNT = BigDecimal.valueOf(2000);
-    private static final LocalDateTime DATE_MODIFIED = LocalDateTime.of(2023, 10, 13, 0, 0, 0);
+    private static final LocalDateTime DATE_MODIFIED = LocalDateTime.of(2023, 10, 13, 10, 15, 30);
+    private static final LocalDateTime TIME_STAMP =  LocalDateTime.parse("2023-10-13T10:15:30");
     public static final String SECTION = "INITA";
     public static final Integer INIT_MEANS_ID = 90;
     private static final LocalDateTime PARTNER_EVIDENCE_RECEIVED_DATE = LocalDateTime.of(2020, 9, 13, 0, 0, 0);
@@ -306,7 +306,7 @@ public class MeansAssessmentDataBuilder {
                 .detailCode(CRITERIA_DETAIL_CODE)
                 .partnerAmount(PARTNER_AMOUNT.doubleValue())
                 .partnerFrequency(getFrequencyDTO(PARTNER_FREQUENCY))
-                .timestamp(DATE_MODIFIED)
+                .timestamp(TIME_STAMP)
                 .build();
     }
 
@@ -401,7 +401,7 @@ public class MeansAssessmentDataBuilder {
                 .dateReceived(toDate(DATETIME_RECEIVED))
                 .otherText(OTHER_DESCRIPTION)
                 .mandatory(true)
-                .timestamp(DATE_MODIFIED)
+                .timestamp(TIME_STAMP)
                 .build();
     }
 
@@ -410,7 +410,7 @@ public class MeansAssessmentDataBuilder {
                 .id(APPLICANT_EVIDENCE_ID.longValue())
                 .evidenceTypeDTO(getEvidenceTypeDTO())
                 .dateReceived(toDate(APPLICANT_EVIDENCE_RECEIVED_DATE))
-                .timestamp(DATE_MODIFIED)
+                .timestamp(TIME_STAMP)
                 .build();
     }
 
@@ -419,7 +419,7 @@ public class MeansAssessmentDataBuilder {
                 .id(PARTNER_EVIDENCE_ID.longValue())
                 .evidenceTypeDTO(getEvidenceTypeDTO())
                 .dateReceived(toDate(PARTNER_EVIDENCE_RECEIVED_DATE))
-                .timestamp(DATE_MODIFIED)
+                .timestamp(TIME_STAMP)
                 .build();
     }
 

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/integration/HardshipIntegrationTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/integration/HardshipIntegrationTest.java
@@ -102,8 +102,10 @@ class HardshipIntegrationTest {
         stubForOAuth();
         stubForGetUserSummary(objectMapper.writeValueAsString(TestModelDataBuilder.getUserSummaryDTO(CREATE_ROLE_ACTIONS, NewWorkReason.NEW)));
         stubForGetRepOrders(objectMapper.writeValueAsString(TestModelDataBuilder.buildRepOrderDTO(null)));
+        String requestBody = objectMapper.writeValueAsString(TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.MAGISTRATE))
+                .replace("10:15:30", "10:15:30.423+00:00");
         mvc.perform(buildRequestGivenContent(HttpMethod.POST,
-                        objectMapper.writeValueAsString(TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.MAGISTRATE)), ENDPOINT_URL))
+                        requestBody, ENDPOINT_URL))
                 .andExpect(status().is5xxServerError());
         verify(exactly(1), postRequestedFor(urlPathMatching("/api/internal/v1/hardship/.*")));
         verify(exactly(1), patchRequestedFor(urlPathMatching("/api/internal/v1/hardship/.*")));
@@ -114,8 +116,10 @@ class HardshipIntegrationTest {
         stubForOAuth();
         stubForGetUserSummary(objectMapper.writeValueAsString(TestModelDataBuilder.getUserSummaryDTO(null, NewWorkReason.NEW)));
         stubForGetRepOrders(objectMapper.writeValueAsString(TestModelDataBuilder.buildRepOrderDTO(null)));
+        String requestBody = objectMapper.writeValueAsString(TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.MAGISTRATE))
+                .replace("10:15:30", "10:15:30.423+00:00");
         mvc.perform(buildRequestGivenContent(HttpMethod.POST,
-                        objectMapper.writeValueAsString(TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.MAGISTRATE)), ENDPOINT_URL))
+                        requestBody, ENDPOINT_URL))
                 .andExpect(status().is5xxServerError());
         verify(exactly(1), getRequestedFor(urlPathMatching("/api/internal/v1/users/summary/.*")));
         verify(exactly(0), patchRequestedFor(urlPathMatching("/api/internal/v1/hardship/.*")));
@@ -126,7 +130,9 @@ class HardshipIntegrationTest {
 
         stubForCreateHardship();
 
-        mvc.perform(buildRequestGivenContent(HttpMethod.POST, objectMapper.writeValueAsString(TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.MAGISTRATE)), ENDPOINT_URL))
+        String requestBody = objectMapper.writeValueAsString(TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.MAGISTRATE))
+                .replace("10:15:30", "10:15:30.423+00:00");
+        mvc.perform(buildRequestGivenContent(HttpMethod.POST, requestBody, ENDPOINT_URL))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.crownCourtOverviewDTO.contribution.monthlyContribs").value(150.0));
 
@@ -144,8 +150,10 @@ class HardshipIntegrationTest {
     void givenAValidContentAndIfAnyException_whenUpdateIsInvoked_thenShouldRollback() throws Exception {
         stubForOAuth();
         stubForUpdateHardship();
+        String requestBody = objectMapper.writeValueAsString(TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.CROWN_COURT))
+                .replace("10:15:30", "10:15:30.423+00:00");
         mvc.perform(buildRequestGivenContent(HttpMethod.PUT,
-                        objectMapper.writeValueAsString(TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.CROWN_COURT)), ENDPOINT_URL))
+                        requestBody, ENDPOINT_URL))
                 .andExpect(status().is5xxServerError());
         verify(exactly(1), putRequestedFor(urlPathMatching("/api/internal/v1/hardship/.*")));
         verify(exactly(1), patchRequestedFor(urlPathMatching("/api/internal/v1/hardship/.*")));
@@ -157,8 +165,10 @@ class HardshipIntegrationTest {
         stubForOAuth();
         stubForGetUserSummary(objectMapper.writeValueAsString(TestModelDataBuilder.getUserSummaryDTO(null, NewWorkReason.NEW)));
         stubForGetRepOrders(objectMapper.writeValueAsString(TestModelDataBuilder.buildRepOrderDTO(null)));
+        String requestBody = objectMapper.writeValueAsString(TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.MAGISTRATE))
+                .replace("10:15:30", "10:15:30.423+00:00");
         mvc.perform(buildRequestGivenContent(HttpMethod.PUT,
-                        objectMapper.writeValueAsString(TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.MAGISTRATE)), ENDPOINT_URL))
+                        requestBody, ENDPOINT_URL))
                 .andExpect(status().is5xxServerError());
         verify(exactly(1), getRequestedFor(urlPathMatching("/api/internal/v1/users/summary/.*")));
         verify(exactly(0), patchRequestedFor(urlPathMatching("/api/internal/v1/hardship/.*")));
@@ -167,8 +177,10 @@ class HardshipIntegrationTest {
     @Test
     void givenAValidContent_whenUpdateIsInvoked_thenShouldSuccess() throws Exception {
         stubForUpdateHardship();
+        String requestBody = objectMapper.writeValueAsString(TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.MAGISTRATE))
+                .replace("10:15:30", "10:15:30.423+00:00");
         mvc.perform(buildRequestGivenContent(HttpMethod.PUT,
-                        objectMapper.writeValueAsString(TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.MAGISTRATE)),
+                        requestBody,
                         ENDPOINT_URL))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -185,7 +197,9 @@ class HardshipIntegrationTest {
                                 .withBody(objectMapper.writeValueAsString(TestModelDataBuilder.getApiPerformHardshipResponse()))
                 )
         );
-        stubForInvokeStoredProcedure(objectMapper.writeValueAsString(TestModelDataBuilder.getApplicationDTO()));
+        String applicationDto = objectMapper.writeValueAsString(TestModelDataBuilder.getApplicationDTO())
+                .replace("10:15:30", "10:15:30.423+00:00");
+        stubForInvokeStoredProcedure(applicationDto);
         stubForCheckContributionsRule();
         stubForCalculateContributions(objectMapper.writeValueAsString(TestModelDataBuilder.getApiMaatCalculateContributionResponse()));
         stubForGetContributionsSummary(objectMapper.writeValueAsString(List.of(TestModelDataBuilder.getApiContributionSummary())));
@@ -221,7 +235,9 @@ class HardshipIntegrationTest {
                                 .withBody(objectMapper.writeValueAsString(TestModelDataBuilder.getApiFindHardshipResponse()))
                 )
         );
-        stubForInvokeStoredProcedure(objectMapper.writeValueAsString(TestModelDataBuilder.getApplicationDTO()));
+        String applicationDto = objectMapper.writeValueAsString(TestModelDataBuilder.getApplicationDTO())
+                .replace("10:15:30", "10:15:30.423+00:00");
+        stubForInvokeStoredProcedure(applicationDto);
         stubForCheckContributionsRule();
         stubForCalculateContributions(objectMapper.writeValueAsString(TestModelDataBuilder.getApiMaatCalculateContributionResponse()));
         stubForGetContributionsSummary(objectMapper.writeValueAsString(List.of(TestModelDataBuilder.getApiContributionSummary())));

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/integration/MeansAssessmentIntegrationTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/integration/MeansAssessmentIntegrationTest.java
@@ -129,8 +129,10 @@ class MeansAssessmentIntegrationTest {
         String ccpResponse = objectMapper.writeValueAsString(MeansAssessmentDataBuilder.getApiUpdateApplicationResponse());
         String cccCalculateResponse = objectMapper.writeValueAsString(TestModelDataBuilder.getApiMaatCalculateContributionResponse());
         String cccSummariesResponse = objectMapper.writeValueAsString(List.of(TestModelDataBuilder.getApiContributionSummary()));
-        String maatApiResponse = objectMapper.writeValueAsString(TestModelDataBuilder.getApplicationDTO(CourtType.CROWN_COURT));
-        String requestBody = objectMapper.writeValueAsString(MeansAssessmentDataBuilder.buildWorkFlowRequest());
+        String maatApiResponse = objectMapper.writeValueAsString(TestModelDataBuilder.getApplicationDTO(CourtType.CROWN_COURT))
+                .replace("10:15:30", "10:15:30.423+00:00");
+        String requestBody = objectMapper.writeValueAsString(MeansAssessmentDataBuilder.buildWorkFlowRequest())
+                .replace("10:15:30", "10:15:30.423+00:00");
 
         stubForOAuth();
         wiremock.stubFor(post(urlMatching(CMA_URL))
@@ -176,7 +178,8 @@ class MeansAssessmentIntegrationTest {
 
     @Test
     void givenErrorCallingMaatApi_whenCreateIsInvoked_thenServerErrorIsReturned() throws Exception {
-        String requestBody = objectMapper.writeValueAsString(MeansAssessmentDataBuilder.buildWorkFlowRequest());
+        String requestBody = objectMapper.writeValueAsString(MeansAssessmentDataBuilder.buildWorkFlowRequest())
+                .replace("10:15:30", "10:15:30.423+00:00");
         String cmaRollbackResponse = objectMapper.writeValueAsString(new ApiRollbackMeansAssessmentResponse());
 
         stubForOAuth();
@@ -194,8 +197,10 @@ class MeansAssessmentIntegrationTest {
         String ccpResponse = objectMapper.writeValueAsString(MeansAssessmentDataBuilder.getApiUpdateApplicationResponse());
         String cccCalculateResponse = objectMapper.writeValueAsString(TestModelDataBuilder.getApiMaatCalculateContributionResponse());
         String cccSummariesResponse = objectMapper.writeValueAsString(List.of(TestModelDataBuilder.getApiContributionSummary()));
-        String maatApiResponse = objectMapper.writeValueAsString(TestModelDataBuilder.getApplicationDTO(CourtType.CROWN_COURT));
-        String requestBody = objectMapper.writeValueAsString(MeansAssessmentDataBuilder.buildWorkFlowRequest());
+        String maatApiResponse = objectMapper.writeValueAsString(TestModelDataBuilder.getApplicationDTO(CourtType.CROWN_COURT))
+                .replace("10:15:30", "10:15:30.423+00:00");
+        String requestBody = objectMapper.writeValueAsString(MeansAssessmentDataBuilder.buildWorkFlowRequest())
+                .replace("10:15:30", "10:15:30.423+00:00");
 
         stubForOAuth();
         wiremock.stubFor(put(urlMatching(CMA_URL))
@@ -249,7 +254,7 @@ class MeansAssessmentIntegrationTest {
                 .willReturn(WireMock.serverError()));
         stubForRollbackMeansAssessment(cmaRollbackResponse);
 
-        mvc.perform(buildRequestGivenContent(HttpMethod.PUT, requestBody, ENDPOINT_URL))
+        mvc.perform(buildRequestGivenContent(HttpMethod.PUT, requestBody.replace("10:15:30", "10:15:30.423+00:00"), ENDPOINT_URL))
                 .andExpect(status().is5xxServerError());
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/jackson/LocalDateTimeDeserializerTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/jackson/LocalDateTimeDeserializerTest.java
@@ -17,7 +17,9 @@ class LocalDateTimeDeserializerTest {
     private final ObjectMapper mapper = new ObjectMapper();
     private final LocalDateTimeDeserializer deserializer = new LocalDateTimeDeserializer();
 
-    private static final String ISO_DATE = "2024-01-27T10:15:30";
+    private static final String ISO_DATE = "2024-01-27T10:15:30.342+00:00";
+    private static final String TIME_STAMP = "2024-04-08T10:57:27.604182";
+    private static final String LOCAL_DATE_TIME = "2024-04-08T10:57:27";
 
     @Test
     void givenValidDate_whenDeserializeIsInvoked_thenLocalDateTimeIsDeserialized() throws IOException {
@@ -27,6 +29,30 @@ class LocalDateTimeDeserializerTest {
         parser.nextToken();
 
         LocalDateTime expected = LocalDateTime.of(2024, 1, 27, 10, 15, 30);
+        LocalDateTime result = deserializer.deserialize(parser, mapper.getDeserializationContext());
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void givenValidDateWithNanoSeconds_whenDeserializeIsInvoked_thenLocalDateTimeIsDeserialized() throws IOException {
+        String content = String.format("\"%s\"", TIME_STAMP);
+        JsonParser parser = factory.createParser(content);
+        parser.setCodec(mapper);
+        parser.nextToken();
+
+        LocalDateTime expected = LocalDateTime.of(2024, 4, 8, 10, 57, 27);
+        LocalDateTime result = deserializer.deserialize(parser, mapper.getDeserializationContext());
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void givenValidLocalDateTime_whenDeserializeIsInvoked_thenLocalDateTimeIsDeserialized() throws IOException {
+        String content = String.format("\"%s\"", LOCAL_DATE_TIME);
+        JsonParser parser = factory.createParser(content);
+        parser.setCodec(mapper);
+        parser.nextToken();
+
+        LocalDateTime expected = LocalDateTime.of(2024, 4, 8, 10, 57, 27);
         LocalDateTime result = deserializer.deserialize(parser, mapper.getDeserializationContext());
         assertThat(result).isEqualTo(expected);
     }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1305)

As an interim solution, using custom deserialisers for handling the different timestamp formats.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
