### PR TITLE
LCAM-1318|Default the income evidence field to mimic MAAT application

### DIFF
--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/MeansAssessmentMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/MeansAssessmentMapper.java
@@ -218,6 +218,7 @@ public class MeansAssessmentMapper {
                 .secondReminderDate(toDate(incomeEvidenceSummary.getSecondReminderDate()))
                 .upliftAppliedDate(toDate(incomeEvidenceSummary.getUpliftAppliedDate()))
                 .upliftRemovedDate(toDate(incomeEvidenceSummary.getUpliftRemovedDate()))
+                .enabled(Boolean.FALSE)
                 .build();
 
         List<ExtraEvidenceDTO> extraEvidenceList = new ArrayList<>();

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/MeansAssessmentDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/MeansAssessmentDataBuilder.java
@@ -388,6 +388,7 @@ public class MeansAssessmentDataBuilder {
                 .evidenceDueDate(toDate(INCOME_EVIDENCE_DUE_DATE))
                 .firstReminderDate(toDate(FIRST_REMINDER_DATE))
                 .secondReminderDate(toDate(SECOND_REMINDER_DATE))
+                .enabled(Boolean.FALSE)
                 .build();
     }
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1318)

MAAT application is expecting the enabled field to be FALSE by default on IncomeEvidenceSummaryDTO.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
