### PR TITLE
LCAM-1424|Obfuscate sensitive fields before logging

### DIFF
--- a/maat-orchestration/build.gradle
+++ b/maat-orchestration/build.gradle
@@ -19,7 +19,7 @@ def versions = [
 		pitest                  : "1.16.0",
 		springdocVersion        : "2.5.0",
 		commonsModSchemas       : "1.3.3",
-		crimeCommonsClasses     : "3.21.0",
+		crimeCommonsClasses     : "3.22.0",
 		commonsRestClient       : "3.4.0",
 		okhttpVersion           : "4.12.0",
 		wmStubRunnerVersion    	: "4.1.2"

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/api/MaatCourtDataApiService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/api/MaatCourtDataApiService.java
@@ -28,13 +28,15 @@ public class MaatCourtDataApiService {
     private final ServicesConfiguration configuration;
 
     public ApplicationDTO executeStoredProcedure(StoredProcedureRequest request) {
-        return maatApiClient.post(
+        ApplicationDTO response = maatApiClient.post(
                 request,
                 new ParameterizedTypeReference<>() {
                 },
                 configuration.getMaatApi().getEndpoints().getCallStoredProcUrl(),
                 Collections.emptyMap()
         );
+        log.info(RESPONSE_STRING, response);
+        return response;
     }
 
     public RepOrderDTO getRepOrderByRepId(Integer repId) {

--- a/maat-orchestration/src/main/resources/logback.xml
+++ b/maat-orchestration/src/main/resources/logback.xml
@@ -1,7 +1,45 @@
 <configuration>
     <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg[%X]%n</pattern>
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="uk.gov.justice.laa.crime.util.MaskingPatternLayout">
+                <maskPattern>caseId=(\w+)</maskPattern>
+                <maskPattern>arrestSummonsNo=(\w+)</maskPattern>
+                <maskPattern>solicitorName=(\w+)</maskPattern>
+                <maskPattern>solicitorEmail=([\w.-]+@[\w.-]+\.\w+)</maskPattern>
+                <maskPattern>solicitorAdminEmail=([\w.-]+@[\w.-]+\.\w+)</maskPattern>
+                <maskPattern>firstName=(\w+)</maskPattern>
+                <maskPattern>surname=(\w+)</maskPattern>
+                <maskPattern>password=(\w+)</maskPattern>
+                <maskPattern>userSession=(\w+)</maskPattern>
+                <maskPattern>ethnicity=([\w\s\&amp;\(\=\,]+)</maskPattern>
+                <maskPattern>foreignId=([\w\/]+)</maskPattern>
+                <maskPattern>gender=(\w+)</maskPattern>
+                <maskPattern>otherNames=(\w+)</maskPattern>
+                <maskPattern>dob=([\w\s\:]+)</maskPattern>
+                <maskPattern>NiNumber=(\w+)</maskPattern>
+                <maskPattern>disabled=(\w+)</maskPattern>
+                <maskPattern>disabilities=(\w+)</maskPattern>
+                <maskPattern>disabilityStatementDTO=(\w+)</maskPattern>
+                <maskPattern>email=([\w.-]+@[\w.-]+\.\w+)</maskPattern>
+                <maskPattern>mobileTelephone=([\w\s]+)</maskPattern>
+                <maskPattern>workTelephone=([\w\s]+)</maskPattern>
+                <maskPattern>homeTelephone=([\w\s]+)</maskPattern>
+                <maskPattern>line1=([\w\s\&amp;\()-]+)</maskPattern>
+                <maskPattern>line2=([\w\s\&amp;\()-]+)</maskPattern>
+                <maskPattern>line3=([\w\s\&amp;\()-]+)</maskPattern>
+                <maskPattern>postCode=([\w\s]+)</maskPattern>
+                <maskPattern>accountNumber=(\w+)</maskPattern>
+                <maskPattern>ownerName=(\w+)</maskPattern>
+                <maskPattern>branchSortCode=([\w.-]+)</maskPattern>
+                <maskPattern>VehicleRegistrationMark=(\w+)</maskPattern>
+                <maskPattern>nationaInsuranceNumber=(\w+)</maskPattern>
+                <maskPattern>dateOfBirth=([\w\s\:]+)</maskPattern>
+                <maskPattern>lastName=(\w+)</maskPattern>
+                <maskPattern>telephone=([\w\s]+)</maskPattern>
+                <maskPattern>defendantId=([\w+-]+)</maskPattern>
+                <maskPattern>debtRefNumber=(\w+)</maskPattern>
+                <pattern>%d{HH:mm:ss.SSS} traceId: %X{traceId:-} spanId: %X{spanId:-} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            </layout>
         </encoder>
     </appender>
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1424)

Log the MAAT API response from stored procedure call. 
Obfuscate sensitive fields before logging the response from MAAT API.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
