### PR TITLE
Update timestamp validation in ValidationService

### DIFF
--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/ValidationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/ValidationService.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.laa.crime.orchestration.service;
 
+import java.time.temporal.ChronoUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -46,11 +47,17 @@ public class ValidationService {
     }
 
     private void validateApplicationTimestamp(WorkflowRequest request, RepOrderDTO repOrderDTO) {
+        ZonedDateTime applicationTimestamp = request.getApplicationDTO().getTimestamp();
+
+        if (applicationTimestamp == null) {
+            return;
+        }
+
         LocalDateTime repOrderCreatedDate = DateUtil.convertDateToDateTime(repOrderDTO.getDateCreated());
         LocalDateTime repOrderUpdatedDate = repOrderDTO.getDateModified();
         LocalDateTime repOrderTimestamp = (null != repOrderUpdatedDate) ? repOrderUpdatedDate : repOrderCreatedDate;
-        ZonedDateTime applicationTimestamp = request.getApplicationDTO().getTimestamp();
-        if (applicationTimestamp != null && !applicationTimestamp.toLocalDateTime().isEqual(repOrderTimestamp)) {
+
+        if (!applicationTimestamp.toLocalDateTime().truncatedTo(ChronoUnit.SECONDS).isEqual(repOrderTimestamp.truncatedTo(ChronoUnit.SECONDS))) {
             throw new ValidationException(CANNOT_MODIFY_APPLICATION_ERROR);
         }
     }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/TestModelDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/TestModelDataBuilder.java
@@ -446,14 +446,20 @@ public class TestModelDataBuilder {
                 .build();
     }
 
-    public static WorkflowRequest buildWorkFlowRequestForApplicationTimestampValidation() {
+    public static WorkflowRequest buildWorkflowRequestForApplicationTimestampValidation(Optional<String> timestamp) {
+        ZonedDateTime timestampToUse = timestamp.isPresent() ? toZonedDateTime(LocalDateTime.parse(timestamp.get())) : APPLICATION_TIMESTAMP;
+
         return WorkflowRequest
                 .builder()
                 .applicationDTO(
                         ApplicationDTO
                                 .builder()
                                 .repId(123L)
-                                .timestamp(APPLICATION_TIMESTAMP)
+                                .timestamp(timestampToUse)
+                                .statusDTO(RepStatusDTO
+                                    .builder()
+                                    .updateAllowed(true)
+                                    .build())
                                 .build()).build();
     }
 
@@ -1080,6 +1086,12 @@ public class TestModelDataBuilder {
 
     public static RepOrderDTO buildRepOrderDTOWithModifiedDate() {
         return RepOrderDTO.builder().dateModified(REP_ORDER_MODIFIED_TIMESTAMP).build();
+    }
+
+    public static RepOrderDTO buildRepOrderDTOWithModifiedDateOf(String dateModifiedTimestamp) {
+        LocalDateTime dateModified = LocalDateTime.parse(dateModifiedTimestamp);
+
+        return RepOrderDTO.builder().dateModified(dateModified).rorsStatus(RepOrderStatus.CURR.getCode()).build();
     }
 
     public static RepOrderDTO buildRepOrderDTOWithCreatedDateAndNoModifiedDate() {

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/integration/HardshipIntegrationTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/integration/HardshipIntegrationTest.java
@@ -122,6 +122,18 @@ class HardshipIntegrationTest {
     }
 
     @Test
+    void givenMismatchingApplicationAndRepoOrderDates_whenCreateIsInvoked_thenRollbackIsNotInvoked() throws Exception {
+        stubForOAuth();
+        stubForGetUserSummary(objectMapper.writeValueAsString(TestModelDataBuilder.getUserSummaryDTO(UPDATE_ROLE_ACTIONS, NewWorkReason.NEW)));
+        stubForGetRepOrders(objectMapper.writeValueAsString(TestModelDataBuilder.buildRepOrderDTOWithModifiedDateOf("2023-06-27T10:15:30")));
+        String requestBody = objectMapper.writeValueAsString(TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.MAGISTRATE));
+        mvc.perform(buildRequestGivenContent(HttpMethod.POST, requestBody, ENDPOINT_URL))
+            .andExpect(status().is4xxClientError());
+        verify(exactly(0), getRequestedFor(urlPathMatching("/api/internal/v1/users/summary/.*")));
+        verify(exactly(0), patchRequestedFor(urlPathMatching("/api/internal/v1/hardship/.*")));
+    }
+
+    @Test
     void givenAValidContent_whenCreateIsInvoked_thenShouldCreateSuccess() throws Exception {
 
         stubForCreateHardship(CourtType.CROWN_COURT);
@@ -179,6 +191,18 @@ class HardshipIntegrationTest {
         mvc.perform(buildRequestGivenContent(HttpMethod.PUT, requestBody, ENDPOINT_URL))
                 .andExpect(status().is4xxClientError());
         verify(exactly(1), getRequestedFor(urlPathMatching("/api/internal/v1/users/summary/.*")));
+        verify(exactly(0), patchRequestedFor(urlPathMatching("/api/internal/v1/hardship/.*")));
+    }
+
+    @Test
+    void givenMismatchingApplicationAndRepoOrderDates_whenUpdateIsInvoked_thenRollbackIsNotInvoked() throws Exception {
+        stubForOAuth();
+        stubForGetUserSummary(objectMapper.writeValueAsString(TestModelDataBuilder.getUserSummaryDTO(UPDATE_ROLE_ACTIONS, NewWorkReason.NEW)));
+        stubForGetRepOrders(objectMapper.writeValueAsString(TestModelDataBuilder.buildRepOrderDTOWithModifiedDateOf("2023-06-27T10:15:30")));
+        String requestBody = objectMapper.writeValueAsString(TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.MAGISTRATE));
+        mvc.perform(buildRequestGivenContent(HttpMethod.PUT, requestBody, ENDPOINT_URL))
+            .andExpect(status().is4xxClientError());
+        verify(exactly(0), getRequestedFor(urlPathMatching("/api/internal/v1/users/summary/.*")));
         verify(exactly(0), patchRequestedFor(urlPathMatching("/api/internal/v1/hardship/.*")));
     }
 


### PR DESCRIPTION
This PR updates the timestamp validation in the _ValidationSerivce_ to exclude milliseconds as part of the check on whether the application and rep order timestamps are equal. The _ValidationService_ is also slightly refactored in this process to make it clearer that if the application timestamp is null then there isn't anything further to validate with the timestamps.

This PR also adds some new test cases which specifically cover the timestamp validation logic, as this was previously only covered for failing cases, with the passing cases covered as part of the wider tests on the _validate_ method.

Note that I have worked on this PR going directly from the description in the story (below), without further inspection of the relevant stored procedure.

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1445)
