### PR TITLE
LCAM-1476

### DIFF
--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/ContributionService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/ContributionService.java
@@ -46,17 +46,13 @@ public class ContributionService {
                 if (Boolean.TRUE.equals(calculateContributionResponse.getProcessActivity())) {
                     // invoke MATRIX stored procedure
                     application = maatCourtDataService.invokeStoredProcedure(
-                            application, request.getUserDTO(), StoredProcedure.PROCESS_ACTIVITY
+                            application, request.getUserDTO(), StoredProcedure.PROCESS_ACTIVITY_AND_GET_CORRESPONDENCE
                     );
                 }
                 List<ApiContributionSummary> contributionSummaries =
                         contributionApiService.getContributionSummary(application.getRepId());
                 application.getCrownCourtOverviewDTO().setContributionSummary(
                         contributionMapper.contributionSummaryToDto(contributionSummaries)
-                );
-                // correspondence_pkg.get_application_correspondence
-                application = maatCourtDataService.invokeStoredProcedure(
-                        application, request.getUserDTO(), StoredProcedure.GET_APPLICATION_CORRESPONDENCE
                 );
             }
         }

--- a/maat-orchestration/src/main/resources/application.yaml
+++ b/maat-orchestration/src/main/resources/application.yaml
@@ -85,7 +85,7 @@ services:
       request-transfer-url: ${services.contribution-api.base-url}/api/internal/v1/contribution/request-transfer
       calculate-contribution-url: ${services.contribution-api.base-url}/api/internal/v1/contribution/calculate-contribution
       check-contribution-rule-url: ${services.contribution-api.base-url}/api/internal/v1/contribution/check-contribution-rule
-      contribution-summaries-url: ${services.contribution-api.base-url}/api/internal/v1/contribution/summaries
+      contribution-summaries-url: ${services.contribution-api.base-url}/api/internal/v1/contribution/summaries/{repId}
 
   crown-court-api:
     base-url: ${CCP_API_BASE_URL}


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1476)

- Consolidate stored procedure calls in the `ContributionService`.
  - The call to `process_activity` wasn't working because the Court Data API is only able to invoke stored procedures and not functions. However, there was an existing stored procedure that wraps calls to both `process_activity` and `get_application_correspondence` which is now being used.
- Fixed incorrect URL configuration used for retrieving contribution summaries.