### PR TITLE
Migrate Uplift Data Item Validation Logic to Orchestration Service

### DIFF
--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/ValidationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/ValidationService.java
@@ -39,6 +39,14 @@ public class ValidationService {
     public static final String USER_DOES_NOT_HAVE_A_VALID_NEW_WORK_REASON_CODE =
             "User does not have a valid New Work Reason Code";
 
+    public void checkUpliftFieldPermissions(final UserSummaryDTO userSummaryDTO) {
+        boolean userCanEditUpliftApplied = this.isUserAuthorisedToEditField(userSummaryDTO, RestrictedField.UPLIFT_APPLIED);
+
+        if (!userCanEditUpliftApplied || !this.isUserAuthorisedToEditField(userSummaryDTO, RestrictedField.UPLIFT_REMOVED)) {
+            throw new ValidationException(USER_DOES_NOT_HAVE_A_ROLE_CAPABLE_OF_PERFORMING_THIS_ACTION);
+        }
+    }
+
     public Boolean isUserActionValid(UserActionDTO request, UserSummaryDTO userSummaryDTO) {
         List<String> crimeValidationExceptionList = new ArrayList<>();
 
@@ -92,7 +100,7 @@ public class ValidationService {
             throw new ValidationException(String.format(CANNOT_UPDATE_APPLICATION_STATUS, statusDTO.getDescription()));
         }
     }
-    
+
     private void validateApplicationTimestamp(WorkflowRequest request, RepOrderDTO repOrderDTO) {
         ZonedDateTime applicationTimestamp = request.getApplicationDTO().getTimestamp();
 
@@ -110,7 +118,3 @@ public class ValidationService {
     }
 
 }
-
-
-
-

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/ValidationServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/ValidationServiceTest.java
@@ -407,4 +407,35 @@ class ValidationServiceTest {
 
         assertTrue(result);
     }
+
+    @Test
+    void givenUserHasNoUpliftPermissions_whenCheckUpliftFieldPermissionsInInvoked_thenExceptionIsThrown() {
+        UserSummaryDTO userSummaryDTO = TestModelDataBuilder.getUserSummaryDTO();
+
+        ValidationException validationException = assertThrows(ValidationException.class, () -> validationService.checkUpliftFieldPermissions(userSummaryDTO));
+        assertThat(validationException.getMessage()).isEqualTo(USER_DOES_NOT_HAVE_A_ROLE_CAPABLE_OF_PERFORMING_THIS_ACTION);
+    }
+
+    @Test
+    void givenUserHasPartialPermissions_whenCheckUpliftFieldPermissionsInInvoked_thenExceptionIsThrown() {
+        List<RoleDataItemDTO> roleDataItems = List.of(
+            new RoleDataItemDTO("CCMT CASEWORKER", RestrictedField.UPLIFT_APPLIED.getField(), "Y", "Y", "Y"),
+            new RoleDataItemDTO("CCMT CASEWORKER", RestrictedField.UPLIFT_REMOVED.getField(), "N", "Y", "Y")
+        );
+        UserSummaryDTO userSummaryDTO = TestModelDataBuilder.getUserSummaryDTO(roleDataItems);
+
+        ValidationException validationException = assertThrows(ValidationException.class, () -> validationService.checkUpliftFieldPermissions(userSummaryDTO));
+        assertThat(validationException.getMessage()).isEqualTo(USER_DOES_NOT_HAVE_A_ROLE_CAPABLE_OF_PERFORMING_THIS_ACTION);
+    }
+
+    @Test
+    void givenUserHasUpliftPermissions_whenCheckUpliftFieldPermissionsIsInvoked_thenNoExceptionIsThrown() {
+        List<RoleDataItemDTO> roleDataItems = List.of(
+            new RoleDataItemDTO("CCMT CASEWORKER", RestrictedField.UPLIFT_APPLIED.getField(), "Y", "Y", "Y"),
+            new RoleDataItemDTO("CCMT CASEWORKER", RestrictedField.UPLIFT_REMOVED.getField(), "Y", "Y", "Y")
+        );
+        UserSummaryDTO userSummaryDTO = TestModelDataBuilder.getUserSummaryDTO(roleDataItems);
+
+        assertDoesNotThrow(() -> validationService.checkUpliftFieldPermissions(userSummaryDTO));
+    }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/ValidationServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/ValidationServiceTest.java
@@ -393,7 +393,7 @@ class ValidationServiceTest {
 
     @ParameterizedTest
     @MethodSource("restrictedFieldsEditableByUser")
-    void givenUserHasPermission_whenIsUserAuthorisedToEditField_thenReturnsTrue(final RestrictedField restrictedField) {
+    void givenUserHasPermission_whenIsUserAuthorisedToEditFieldIsInvoked_thenReturnsTrue(final RestrictedField restrictedField) {
         List<RoleDataItemDTO> roleDataItems = List.of(
             new RoleDataItemDTO("CCMT CASEWORKER", RestrictedField.APPEAL_CC_OUTCOME.getField(), "N", null, null),
             new RoleDataItemDTO("CCMT CASEWORKER", RestrictedField.APPEAL_RECEIVED_DATE.getField(), "Y", "Y", "N"),


### PR DESCRIPTION
This PR creates a method for checking a user's permission to edit the uplift fields of a legal aid application. It makes the assumption that a user has permission to change uplift fields only if the user can edit both the uplift applied and removed fields; if only one of these roles exists or is enabled against the user, a _ValidationException_ will be thrown.

It should also be noted that this PR is not checking the existing uplift applied and/or removed dates as the story could be taken to imply; after discussion of the story, it was confirmed that the method in this PR is solely about checking permissions of a user to edit these fields.

This PR also performs some other housekeeping, re-ordering the methods within the _ValidationService_ to list them
alphabetically and grouped by method visibility, as well as fixing one of the existing test names to ensure consistency within the test suite.

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1400)
