### PR TITLE
Fix ingress YAML

### DIFF
--- a/helm_deploy/laa-maat-orchestration/templates/ingress.yaml
+++ b/helm_deploy/laa-maat-orchestration/templates/ingress.yaml
@@ -50,6 +50,5 @@ spec:
                 name: {{ $fullName }}
                 port:
                   number: {{ $.Values.actuator.port }}
-          {{- end }}
     {{- end }}
-  {{- end }}
+{{- end }}


### PR DESCRIPTION
This PR fixes the ingress YAML to remove an extra `{{- end }}` statement which caused a parse error when running `helm upgrade` in the deploy pipeline.
