### PR TITLE
LCAM-1430|Enhance eror handling to display the validation error on UI

### DIFF
--- a/maat-orchestration/build.gradle
+++ b/maat-orchestration/build.gradle
@@ -20,7 +20,7 @@ def versions = [
 		springdocVersion        : "2.5.0",
 		commonsModSchemas       : "1.5.0",
 		crimeCommonsClasses     : "3.22.0",
-		commonsRestClient       : "3.4.0",
+		commonsRestClient       : "3.16.0",
 		okhttpVersion           : "4.12.0",
 		wmStubRunnerVersion    	: "4.1.3"
 ]

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/controller/MeansAssessmentController.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/controller/MeansAssessmentController.java
@@ -39,7 +39,7 @@ public class MeansAssessmentController {
     public ResponseEntity<FinancialAssessmentDTO> find(
             @PathVariable int financialAssessmentId,
             @PathVariable int applicantId) {
-        log.info("Received request to find crime means assessment");
+        log.info("Received request to find crime means assessment - {}", financialAssessmentId);
         return ResponseEntity.ok(assessmentOrchestrationService.find(financialAssessmentId, applicantId));
     }
 

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/MeansAssessmentOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/MeansAssessmentOrchestrationService.java
@@ -4,6 +4,7 @@ import io.sentry.Sentry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import uk.gov.justice.laa.crime.commons.exception.MAATServerException;
 import uk.gov.justice.laa.crime.enums.orchestration.AssessmentResult;
 import uk.gov.justice.laa.crime.exception.ValidationException;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
@@ -44,6 +45,9 @@ public class MeansAssessmentOrchestrationService {
             log.debug("Created Means assessment for applicationId = " + repId);
         } catch (ValidationException | CrimeValidationException exception) {
             throw exception;
+        } catch (MAATServerException exception) {
+            meansAssessmentService.rollback(request);
+            throw new ValidationException(exception.getMessage());
         } catch (Exception ex) {
             log.warn("Create Means assessment failed with the exception: {}", ex);
             meansAssessmentService.rollback(request);
@@ -66,6 +70,9 @@ public class MeansAssessmentOrchestrationService {
             log.debug("Updated Means assessment for applicationId = " + repId);
         } catch (ValidationException | CrimeValidationException exception) {
             throw exception;
+        } catch (MAATServerException exception) {
+            meansAssessmentService.rollback(request);
+            throw new ValidationException(exception.getMessage());
         } catch (Exception ex) {
             log.warn("Update Means assessment failed with the exception: {}", ex);
             meansAssessmentService.rollback(request);


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1430)

Updated error handling to ensure we rollback the transaction in case of a MAAT Server exception. Using the latest commons-client jar to allow the error message to be passed to the MAAT Application so that the validation error message is displayed on the UI.
Also, updated logging to print the financial transaction ID.
