### PR TITLE
LCAM 1540 Solicitors Costs Not Record on Database When Creating Hardship

### DIFF
--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/HardshipMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/HardshipMapper.java
@@ -106,7 +106,7 @@ public class HardshipMapper {
     }
 
     private SolicitorCosts hrSolicitorCostsDtoToSolicitorCosts(HRSolicitorsCostsDTO solicitorsCosts) {
-        if (solicitorsCosts.getSolicitorEstimatedTotalCost() != null) {
+        if (solicitorsCosts.getSolicitorRate() != null && solicitorsCosts.getSolicitorHours() != null) {
             return new SolicitorCosts()
                     .withVat(solicitorsCosts.getSolicitorVat())
                     .withRate(solicitorsCosts.getSolicitorRate())

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/HardshipOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/HardshipOrchestrationService.java
@@ -48,11 +48,6 @@ public class HardshipOrchestrationService implements AssessmentOrchestrator<Hard
         validate(request, action, getRepOrderDTO(request));
         ApplicationDTO application = request.getApplicationDTO();
 
-        if (courtType == CourtType.MAGISTRATE) {
-            log.info("Before create hardship via hardship service for: {}",
-                    request.getApplicationDTO().getAssessmentDTO().getFinancialAssessmentDTO().getHardship().getMagCourtHardship().getSolictorsCosts());
-        }
-
         ApiPerformHardshipResponse performHardshipResponse = hardshipService.create(request);
         try {
             // Need to refresh from DB as HardshipDetail ids may have changed

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/HardshipOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/HardshipOrchestrationService.java
@@ -48,8 +48,11 @@ public class HardshipOrchestrationService implements AssessmentOrchestrator<Hard
         validate(request, action, getRepOrderDTO(request));
         ApplicationDTO application = request.getApplicationDTO();
 
-        log.info("Before create hardship via hardship service for: {}",
-                request.getApplicationDTO().getAssessmentDTO().getFinancialAssessmentDTO().getHardship().getMagCourtHardship().getSolictorsCosts());
+        if (courtType == CourtType.MAGISTRATE) {
+            log.info("Before create hardship via hardship service for: {}",
+                    request.getApplicationDTO().getAssessmentDTO().getFinancialAssessmentDTO().getHardship().getMagCourtHardship().getSolictorsCosts());
+        }
+
         ApiPerformHardshipResponse performHardshipResponse = hardshipService.create(request);
         try {
             // Need to refresh from DB as HardshipDetail ids may have changed

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/HardshipOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/HardshipOrchestrationService.java
@@ -48,6 +48,8 @@ public class HardshipOrchestrationService implements AssessmentOrchestrator<Hard
         validate(request, action, getRepOrderDTO(request));
         ApplicationDTO application = request.getApplicationDTO();
 
+        log.info("Before create hardship via hardship service for: {}",
+                request.getApplicationDTO().getAssessmentDTO().getFinancialAssessmentDTO().getHardship().getMagCourtHardship().getSolictorsCosts());
         ApiPerformHardshipResponse performHardshipResponse = hardshipService.create(request);
         try {
             // Need to refresh from DB as HardshipDetail ids may have changed

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/HardshipReviewMapperTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/HardshipReviewMapperTest.java
@@ -47,6 +47,7 @@ class HardshipReviewMapperTest {
                 .isEqualTo(CourtType.CROWN_COURT);
         softly.assertThat(actualHardship.getTotalAnnualDisposableIncome().doubleValue())
                 .isEqualTo(workflowRequest.getApplicationDTO().getAssessmentDTO().getFinancialAssessmentDTO().getFull().getTotalAnnualDisposableIncome());
+        softly.assertThat(actualHardship.getSolicitorCosts()).isNull();
     }
 
     @Test


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/projects/LCAM/boards/881?selectedIssue=LCAM-1540)

- Null check on solicitors costs estimated total value was causing null solicitor costs data to be sent through to the hardship service, as at this point the estimated total hasn't been calculated. Instead I've altered the check to confirm both rate and hours are not null (these should both be entered for any valid solicitors costs entry).

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
