### PR TITLE
LCAM-1450|Handle alert messages to display appropriate error on UI

### DIFF
--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/common/Constants.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/common/Constants.java
@@ -1,7 +1,7 @@
 package uk.gov.justice.laa.crime.orchestration.common;
 
 public final class Constants {
-    public static final String WRN_MSG_REASSESSMENT	= "A reassessment is required";
+    public static final String WRN_MSG_REASSESSMENT = "A reassessment is required";
     public static final String WRN_MSG_INCOMPLETE_ASSESSMENT = "Incomplete assessment has been cleared due to this change.";
 
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/common/Constants.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/common/Constants.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.laa.crime.orchestration.common;
 
 public final class Constants {
+    private Constants() {}
     public static final String WRN_MSG_REASSESSMENT = "A reassessment is required";
     public static final String WRN_MSG_INCOMPLETE_ASSESSMENT = "Incomplete assessment has been cleared due to this change.";
 

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/common/Constants.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/common/Constants.java
@@ -1,0 +1,7 @@
+package uk.gov.justice.laa.crime.orchestration.common;
+
+public final class Constants {
+    public static final String WRN_MSG_REASSESSMENT	= "A reassessment is required";
+    public static final String WRN_MSG_INCOMPLETE_ASSESSMENT = "Incomplete assessment has been cleared due to this change.";
+
+}

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/MeansAssessmentOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/MeansAssessmentOrchestrationService.java
@@ -19,6 +19,7 @@ import uk.gov.justice.laa.crime.orchestration.service.ContributionService;
 import uk.gov.justice.laa.crime.orchestration.service.MaatCourtDataService;
 import uk.gov.justice.laa.crime.orchestration.service.MeansAssessmentService;
 import uk.gov.justice.laa.crime.orchestration.service.ProceedingsService;
+import static uk.gov.justice.laa.crime.orchestration.common.Constants.*;
 
 @Slf4j
 @Service
@@ -30,7 +31,6 @@ public class MeansAssessmentOrchestrationService {
     private final MeansAssessmentService meansAssessmentService;
     private final MaatCourtDataService maatCourtDataService;
     private final AssessmentSummaryService assessmentSummaryService;
-
 
     public FinancialAssessmentDTO find(int assessmentId, int applicantId) {
         return meansAssessmentService.find(assessmentId, applicantId);
@@ -108,7 +108,8 @@ public class MeansAssessmentOrchestrationService {
 
         // Check for any validation alerts resulted as part of the pre_update_checks and raise exception
         String alertMessage = request.getApplicationDTO().getAlertMessage();
-        if (StringUtils.isNotBlank(alertMessage)) {
+        if (StringUtils.isNotBlank(alertMessage) &&
+                (alertMessage.contains(WRN_MSG_REASSESSMENT) || alertMessage.contains(WRN_MSG_INCOMPLETE_ASSESSMENT))) {
             throw new MAATServerException(alertMessage);
         }
 

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/MeansAssessmentOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/MeansAssessmentOrchestrationService.java
@@ -3,16 +3,22 @@ package uk.gov.justice.laa.crime.orchestration.service.orchestration;
 import io.sentry.Sentry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 import uk.gov.justice.laa.crime.commons.exception.MAATServerException;
-import uk.gov.justice.laa.crime.enums.orchestration.AssessmentResult;
 import uk.gov.justice.laa.crime.exception.ValidationException;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
-import uk.gov.justice.laa.crime.orchestration.dto.maat.*;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.AssessmentSummaryDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.FinancialAssessmentDTO;
 import uk.gov.justice.laa.crime.orchestration.enums.StoredProcedure;
 import uk.gov.justice.laa.crime.orchestration.exception.CrimeValidationException;
 import uk.gov.justice.laa.crime.orchestration.exception.MaatOrchestrationException;
-import uk.gov.justice.laa.crime.orchestration.service.*;
+import uk.gov.justice.laa.crime.orchestration.service.AssessmentSummaryService;
+import uk.gov.justice.laa.crime.orchestration.service.ContributionService;
+import uk.gov.justice.laa.crime.orchestration.service.MaatCourtDataService;
+import uk.gov.justice.laa.crime.orchestration.service.MeansAssessmentService;
+import uk.gov.justice.laa.crime.orchestration.service.ProceedingsService;
 
 @Slf4j
 @Service
@@ -36,11 +42,7 @@ public class MeansAssessmentOrchestrationService {
         try {
             Long repId = application.getRepId();
             log.debug("Creating Means assessment for applicationId = " + repId);
-            log.info("Creating Means assessment for applicationId = " + repId);
-            log.info("MeansAssessmentOrchestrationService.create = " + request);
-            printStatus(request.getApplicationDTO(), "Before calling processCrownCourtProceedings");
             meansAssessmentService.create(request);
-            printStatus(request.getApplicationDTO(), "after calling processCrownCourtProceedings");
             application = processCrownCourtProceedings(request);
             log.debug("Created Means assessment for applicationId = " + repId);
         } catch (ValidationException | CrimeValidationException exception) {
@@ -49,7 +51,7 @@ public class MeansAssessmentOrchestrationService {
             meansAssessmentService.rollback(request);
             throw new ValidationException(exception.getMessage());
         } catch (Exception ex) {
-            log.warn("Create Means assessment failed with the exception: {}", ex);
+            log.warn("Create Means assessment failed with the exception: {}", ex.getMessage(), ex);
             meansAssessmentService.rollback(request);
             Sentry.captureException(ex);
             throw new MaatOrchestrationException(request.getApplicationDTO());
@@ -63,8 +65,6 @@ public class MeansAssessmentOrchestrationService {
         try {
             Long repId = application.getRepId();
             log.debug("Updating Means assessment for applicationId = " + repId);
-            log.info("MeansAssessmentOrchestrationService.update = " + request);
-            printStatus(request.getApplicationDTO(), "Before calling processCrownCourtProceedings");
             meansAssessmentService.update(request);
             application = processCrownCourtProceedings(request);
             log.debug("Updated Means assessment for applicationId = " + repId);
@@ -74,7 +74,7 @@ public class MeansAssessmentOrchestrationService {
             meansAssessmentService.rollback(request);
             throw new ValidationException(exception.getMessage());
         } catch (Exception ex) {
-            log.warn("Update Means assessment failed with the exception: {}", ex);
+            log.warn("Update Means assessment failed with the exception: {}", ex.getMessage(), ex);
             meansAssessmentService.rollback(request);
             Sentry.captureException(ex);
             throw new MaatOrchestrationException(request.getApplicationDTO());
@@ -82,38 +82,21 @@ public class MeansAssessmentOrchestrationService {
         return application;
     }
 
-    private void printStatus(ApplicationDTO applicationDTO, String message) {
-        log.info(message);
-        FinancialAssessmentDTO financialAssessmentDTO = applicationDTO.getAssessmentDTO().getFinancialAssessmentDTO();
-        InitialAssessmentDTO initialAssessmentDTO = financialAssessmentDTO.getInitial();
-        FullAssessmentDTO fullAssessmentDTO = financialAssessmentDTO.getFull();
-        log.info("printStatus.initialAssessmentDTO.status-->" + initialAssessmentDTO.getAssessmnentStatusDTO().getStatus());
-        if (Boolean.TRUE.equals(financialAssessmentDTO.getFullAvailable())) {
-            log.info("printStatus.fullAssessmentDTO.status-->" + fullAssessmentDTO.getAssessmnentStatusDTO().getStatus());
-            log.info("printStatus.fullAssessmentDTO.Result-->" + AssessmentResult.getFrom(fullAssessmentDTO.getResult()));
-        }
-    }
-
     private ApplicationDTO processCrownCourtProceedings(WorkflowRequest request) {
         if (request.isC3Enabled()) {
-
-
-            log.info("Before calling ASSESSMENT_POST_PROCESSING_PART_1_C3");
-            printStatus(request.getApplicationDTO(), "Before calling ASSESSMENT_POST_PROCESSING_PART_1_C3.printStatus()");
             // call post_processing_part_1_c3 and map the application
             request.setApplicationDTO(maatCourtDataService.invokeStoredProcedure(
                     request.getApplicationDTO(),
                     request.getUserDTO(),
                     StoredProcedure.ASSESSMENT_POST_PROCESSING_PART_1_C3)
             );
-            printStatus(request.getApplicationDTO(), "after calling ASSESSMENT_POST_PROCESSING_PART_1_C3");
+
             // call pre_update_cc_application with the calculated contribution and map the application
             request.setApplicationDTO(maatCourtDataService.invokeStoredProcedure(
                     contributionService.calculate(request),
                     request.getUserDTO(),
                     StoredProcedure.PRE_UPDATE_CC_APPLICATION)
             );
-            log.info("MeansAssessmentOrchestrationService.PRE_UPDATE_CC_APPLICATION = " + request);
         } else {
             // call post_processing_part1 and map the application
             request.setApplicationDTO(maatCourtDataService.invokeStoredProcedure(
@@ -122,9 +105,15 @@ public class MeansAssessmentOrchestrationService {
                     StoredProcedure.ASSESSMENT_POST_PROCESSING_PART_1)
             );
         }
-        proceedingsService.updateApplication(request);
 
-        log.info("MeansAssessmentOrchestrationService.updateApplication = " + request);
+        // Check for any validation alerts resulted as part of the pre_update_checks and raise exception
+        String alertMessage = request.getApplicationDTO().getAlertMessage();
+        if (StringUtils.isNotBlank(alertMessage)) {
+            throw new MAATServerException(alertMessage);
+        }
+
+        // call CCP service
+        proceedingsService.updateApplication(request);
 
         // call post_processing_part_2
         ApplicationDTO application = maatCourtDataService.invokeStoredProcedure(
@@ -132,9 +121,8 @@ public class MeansAssessmentOrchestrationService {
                 request.getUserDTO(),
                 StoredProcedure.ASSESSMENT_POST_PROCESSING_PART_2);
 
-        log.info("MeansAssessmentOrchestrationService.ASSESSMENT_POST_PROCESSING_PART_2 = " + request);
-
-        AssessmentSummaryDTO assessmentSummaryDTO = assessmentSummaryService.getSummary(request.getApplicationDTO().getAssessmentDTO().getFinancialAssessmentDTO());
+        AssessmentSummaryDTO assessmentSummaryDTO = assessmentSummaryService
+                .getSummary(request.getApplicationDTO().getAssessmentDTO().getFinancialAssessmentDTO());
         assessmentSummaryService.updateApplication(application, assessmentSummaryDTO);
 
         application.setTransactionId(null);

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/MeansAssessmentOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/MeansAssessmentOrchestrationService.java
@@ -16,6 +16,7 @@ import uk.gov.justice.laa.crime.orchestration.exception.CrimeValidationException
 import uk.gov.justice.laa.crime.orchestration.exception.MaatOrchestrationException;
 import uk.gov.justice.laa.crime.orchestration.service.AssessmentSummaryService;
 import uk.gov.justice.laa.crime.orchestration.service.ContributionService;
+import uk.gov.justice.laa.crime.orchestration.service.FeatureDecisionService;
 import uk.gov.justice.laa.crime.orchestration.service.MaatCourtDataService;
 import uk.gov.justice.laa.crime.orchestration.service.MeansAssessmentService;
 import uk.gov.justice.laa.crime.orchestration.service.ProceedingsService;

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/MeansAssessmentOrchestrationServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/MeansAssessmentOrchestrationServiceTest.java
@@ -216,7 +216,6 @@ class MeansAssessmentOrchestrationServiceTest {
     @Test
     void givenValidationFailureAtPostAssessmentProcessing_whenUpdateIsInvoked_thenRollbackIsInvoked() {
         WorkflowRequest workflowRequest = MeansAssessmentDataBuilder.buildWorkFlowRequest();
-        workflowRequest.setC3Enabled(false);
         workflowRequest.getApplicationDTO().setAlertMessage(WRN_MSG_REASSESSMENT);
         when(maatCourtDataService.invokeStoredProcedure(any(ApplicationDTO.class), any(UserDTO.class),
                 any(StoredProcedure.class)
@@ -235,8 +234,6 @@ class MeansAssessmentOrchestrationServiceTest {
         when(maatCourtDataService.invokeStoredProcedure(any(ApplicationDTO.class), any(UserDTO.class),
                 any(StoredProcedure.class)
         )).thenReturn(workflowRequest.getApplicationDTO());
-        when(contributionService.calculate(workflowRequest))
-                .thenReturn(workflowRequest.getApplicationDTO());
 
         assertThatThrownBy(() -> orchestrationService.create(workflowRequest))
                 .isInstanceOf(ValidationException.class).hasMessage(WRN_MSG_INCOMPLETE_ASSESSMENT);
@@ -251,8 +248,6 @@ class MeansAssessmentOrchestrationServiceTest {
         when(maatCourtDataService.invokeStoredProcedure(any(ApplicationDTO.class), any(UserDTO.class),
                 any(StoredProcedure.class)
         )).thenReturn(workflowRequest.getApplicationDTO());
-        when(contributionService.calculate(workflowRequest))
-                .thenReturn(workflowRequest.getApplicationDTO());
 
         orchestrationService.create(workflowRequest);
         verify(proceedingsService, times(1)).updateApplication(workflowRequest);


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1450)

When user updates the caseType on the Application tab, but there is a validation error around the committal date, the caseType in the ApplicationDTO is updated but not in the DB, causing a mismatch. This triggers a validation check check_alert_message in pre_update_checks that wipes the assessment in the stored procedure and sets an alert message to say a reassessment is required.

This change is to check for the alert messages populated in the stored procedure so that these can be displayed on the UI.

We need to add some additional front-end checks around the case type and committal date so that this scenario can be avoided.
