### PR TITLE
LASB-3671

### DIFF
--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/MeansAssessmentMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/MeansAssessmentMapper.java
@@ -518,6 +518,13 @@ public class MeansAssessmentMapper {
         } else {
             mapInitialAssessmentDTO(financialAssessmentDTO.getInitial(), apiResponse);
             financialAssessmentDTO.setFullAvailable(apiResponse.getFullAssessmentAvailable());
+
+            // Temp fix, wipe the income evidence before progressing until we can populate from means assessment response
+            IncomeEvidenceSummaryDTO incomeEvidence =
+                    applicationDTO.getAssessmentDTO().getFinancialAssessmentDTO().getIncomeEvidence();
+            incomeEvidence.getExtraEvidenceList().clear();
+            incomeEvidence.getApplicantIncomeEvidenceList().clear();
+            incomeEvidence.getPartnerIncomeEvidenceList().clear();
         }
     }
 

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/MeansAssessmentOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/MeansAssessmentOrchestrationService.java
@@ -85,6 +85,9 @@ public class MeansAssessmentOrchestrationService {
     }
 
     private ApplicationDTO processCrownCourtProceedings(WorkflowRequest request) {
+
+        request.getApplicationDTO().setAlertMessage("");
+
         if (featureDecisionService.isC3Enabled(request)) {
             // call post_processing_part_1_c3 and map the application
             request.setApplicationDTO(maatCourtDataService.invokeStoredProcedure(

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/TestModelDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/TestModelDataBuilder.java
@@ -1112,6 +1112,7 @@ public class TestModelDataBuilder {
         AssessmentDTO assessmentDTO = new AssessmentDTO();
         FinancialAssessmentDTO financialAssessmentDTO = getFinancialAssessmentDTOForMeansAssessmentMapper(isFullAssessmentAvailable);
         assessmentDTO.setFinancialAssessmentDTO(financialAssessmentDTO);
+        assessmentDTO.getFinancialAssessmentDTO().setIncomeEvidence(new IncomeEvidenceSummaryDTO());
         applicationDTO.setAssessmentDTO(assessmentDTO);
         return applicationDTO;
     }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/MeansAssessmentMapperTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/MeansAssessmentMapperTest.java
@@ -315,6 +315,10 @@ class MeansAssessmentMapperTest {
         ApiAssessmentChildWeighting apiAssessmentChildWeighting =
                 apiMeansAssessmentResponse.getChildWeightings().get(0);
 
+        IncomeEvidenceSummaryDTO incomeEvidence =
+                applicationDTO.getAssessmentDTO().getFinancialAssessmentDTO().getIncomeEvidence();
+        incomeEvidence.getApplicantIncomeEvidenceList().add(new EvidenceDTO());
+
         meansAssessmentMapper.meansAssessmentResponseToApplicationDto(
                 apiMeansAssessmentResponse,
                 applicationDTO
@@ -360,6 +364,11 @@ class MeansAssessmentMapperTest {
                 .isEqualTo(apiAssessmentDetail.getId().longValue());
         softly.assertThat(childWeightingDTO.getId())
                 .isEqualTo(apiAssessmentChildWeighting.getId().intValue());
+
+        // Check that income evidence records are cleared - this will be populated during post-processing
+        softly.assertThat(incomeEvidence.getExtraEvidenceList()).isEmpty();
+        softly.assertThat(incomeEvidence.getPartnerIncomeEvidenceList()).isEmpty();
+        softly.assertThat(incomeEvidence.getApplicantIncomeEvidenceList()).isEmpty();
     }
 
     @Test

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/MeansAssessmentOrchestrationServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/MeansAssessmentOrchestrationServiceTest.java
@@ -67,7 +67,7 @@ class MeansAssessmentOrchestrationServiceTest {
         when(contributionService.calculate(workflowRequest))
                 .thenReturn(applicationDTO);
         when(maatCourtDataService.invokeStoredProcedure(any(ApplicationDTO.class), any(UserDTO.class),
-                any(StoredProcedure.class)
+                                                        any(StoredProcedure.class)
         ))
                 .thenReturn(applicationDTO);
         when(featureDecisionService.isC3Enabled(workflowRequest)).thenReturn(true);
@@ -79,12 +79,12 @@ class MeansAssessmentOrchestrationServiceTest {
 
         verify(meansAssessmentService).create(workflowRequest);
         verify(maatCourtDataService).invokeStoredProcedure(applicationDTO, workflowRequest.getUserDTO(),
-                StoredProcedure.PRE_UPDATE_CC_APPLICATION
+                                                           StoredProcedure.PRE_UPDATE_CC_APPLICATION
         );
 
         verify(proceedingsService).updateApplication(workflowRequest);
         verify(maatCourtDataService).invokeStoredProcedure(applicationDTO, workflowRequest.getUserDTO(),
-                StoredProcedure.ASSESSMENT_POST_PROCESSING_PART_2
+                                                           StoredProcedure.ASSESSMENT_POST_PROCESSING_PART_2
         );
         verify(assessmentSummaryService, times(1)).getSummary(any(FinancialAssessmentDTO.class));
     }
@@ -95,7 +95,7 @@ class MeansAssessmentOrchestrationServiceTest {
         WorkflowRequest workflowRequest = MeansAssessmentDataBuilder.buildWorkFlowRequest();
 
         when(maatCourtDataService.invokeStoredProcedure(any(ApplicationDTO.class), any(UserDTO.class),
-                any(StoredProcedure.class)
+                                                        any(StoredProcedure.class)
         )).thenReturn(workflowRequest.getApplicationDTO());
 
         when(featureDecisionService.isC3Enabled(workflowRequest)).thenReturn(false);
@@ -104,14 +104,14 @@ class MeansAssessmentOrchestrationServiceTest {
         verify(meansAssessmentService).create(workflowRequest);
         verify(contributionService, times(0)).calculate(workflowRequest);
         verify(maatCourtDataService).invokeStoredProcedure(workflowRequest.getApplicationDTO(),
-                workflowRequest.getUserDTO(),
-                StoredProcedure.ASSESSMENT_POST_PROCESSING_PART_1
+                                                           workflowRequest.getUserDTO(),
+                                                           StoredProcedure.ASSESSMENT_POST_PROCESSING_PART_1
         );
 
         verify(proceedingsService, times(1)).updateApplication(workflowRequest);
         verify(maatCourtDataService).invokeStoredProcedure(workflowRequest.getApplicationDTO(),
-                workflowRequest.getUserDTO(),
-                StoredProcedure.ASSESSMENT_POST_PROCESSING_PART_2
+                                                           workflowRequest.getUserDTO(),
+                                                           StoredProcedure.ASSESSMENT_POST_PROCESSING_PART_2
         );
         verify(assessmentSummaryService, times(1)).getSummary(any());
     }
@@ -126,7 +126,7 @@ class MeansAssessmentOrchestrationServiceTest {
         when(contributionService.calculate(workflowRequest))
                 .thenReturn(applicationDTO);
         when(maatCourtDataService.invokeStoredProcedure(any(ApplicationDTO.class), any(UserDTO.class),
-                any(StoredProcedure.class)
+                                                        any(StoredProcedure.class)
         ))
                 .thenReturn(applicationDTO);
         when(featureDecisionService.isC3Enabled(workflowRequest)).thenReturn(true);
@@ -138,14 +138,14 @@ class MeansAssessmentOrchestrationServiceTest {
 
         verify(meansAssessmentService).update(workflowRequest);
         verify(maatCourtDataService).invokeStoredProcedure(workflowRequest.getApplicationDTO(),
-                workflowRequest.getUserDTO(),
-                StoredProcedure.PRE_UPDATE_CC_APPLICATION
+                                                           workflowRequest.getUserDTO(),
+                                                           StoredProcedure.PRE_UPDATE_CC_APPLICATION
         );
 
         verify(proceedingsService).updateApplication(workflowRequest);
         verify(maatCourtDataService).invokeStoredProcedure(workflowRequest.getApplicationDTO(),
-                workflowRequest.getUserDTO(),
-                StoredProcedure.ASSESSMENT_POST_PROCESSING_PART_2
+                                                           workflowRequest.getUserDTO(),
+                                                           StoredProcedure.ASSESSMENT_POST_PROCESSING_PART_2
         );
         verify(assessmentSummaryService, times(1)).getSummary(any());
     }
@@ -156,23 +156,23 @@ class MeansAssessmentOrchestrationServiceTest {
         WorkflowRequest workflowRequest = MeansAssessmentDataBuilder.buildWorkFlowRequest();
 
         when(maatCourtDataService.invokeStoredProcedure(any(ApplicationDTO.class), any(UserDTO.class),
-                any(StoredProcedure.class)
+                                                        any(StoredProcedure.class)
         ))
-            .thenReturn(workflowRequest.getApplicationDTO());
+                .thenReturn(workflowRequest.getApplicationDTO());
         when(featureDecisionService.isC3Enabled(workflowRequest)).thenReturn(false);
 
         orchestrationService.update(workflowRequest);
         verify(meansAssessmentService).update(workflowRequest);
         verify(contributionService, times(0)).calculate(workflowRequest);
         verify(maatCourtDataService).invokeStoredProcedure(workflowRequest.getApplicationDTO(),
-                workflowRequest.getUserDTO(),
-                StoredProcedure.ASSESSMENT_POST_PROCESSING_PART_1
+                                                           workflowRequest.getUserDTO(),
+                                                           StoredProcedure.ASSESSMENT_POST_PROCESSING_PART_1
         );
 
         verify(proceedingsService, times(1)).updateApplication(workflowRequest);
         verify(maatCourtDataService).invokeStoredProcedure(workflowRequest.getApplicationDTO(),
-                workflowRequest.getUserDTO(),
-                StoredProcedure.ASSESSMENT_POST_PROCESSING_PART_2
+                                                           workflowRequest.getUserDTO(),
+                                                           StoredProcedure.ASSESSMENT_POST_PROCESSING_PART_2
         );
         verify(assessmentSummaryService, times(1)).getSummary(any());
     }
@@ -216,13 +216,24 @@ class MeansAssessmentOrchestrationServiceTest {
     @Test
     void givenValidationFailureAtPostAssessmentProcessing_whenUpdateIsInvoked_thenRollbackIsInvoked() {
         WorkflowRequest workflowRequest = MeansAssessmentDataBuilder.buildWorkFlowRequest();
-        workflowRequest.getApplicationDTO().setAlertMessage(WRN_MSG_REASSESSMENT);
+        ApplicationDTO applicationSpy = spy(workflowRequest.getApplicationDTO());
+        workflowRequest.setApplicationDTO(applicationSpy);
+
         when(maatCourtDataService.invokeStoredProcedure(any(ApplicationDTO.class), any(UserDTO.class),
-                any(StoredProcedure.class)
-        )).thenReturn(workflowRequest.getApplicationDTO());
+                                                        any(StoredProcedure.class)
+        )).thenAnswer(invocation -> {
+            StoredProcedure procedure = invocation.getArgument(2);
+            if (procedure == StoredProcedure.ASSESSMENT_POST_PROCESSING_PART_1 ||
+                    procedure == StoredProcedure.ASSESSMENT_POST_PROCESSING_PART_1_C3) {
+                workflowRequest.getApplicationDTO().setAlertMessage(WRN_MSG_REASSESSMENT);
+            }
+            return workflowRequest.getApplicationDTO();
+        });
 
         assertThatThrownBy(() -> orchestrationService.update(workflowRequest))
                 .isInstanceOf(ValidationException.class).hasMessage(WRN_MSG_REASSESSMENT);
+
+        verify(applicationSpy, times(1)).setAlertMessage("");
         verify(proceedingsService, times(0)).updateApplication(workflowRequest);
         verify(meansAssessmentService, times(1)).rollback(any());
     }
@@ -230,13 +241,23 @@ class MeansAssessmentOrchestrationServiceTest {
     @Test
     void givenValidationFailureAtPostAssessmentProcessing_whenCreateIsInvoked_thenRollbackIsInvoked() {
         WorkflowRequest workflowRequest = MeansAssessmentDataBuilder.buildWorkFlowRequest();
-        workflowRequest.getApplicationDTO().setAlertMessage(WRN_MSG_INCOMPLETE_ASSESSMENT);
+        ApplicationDTO applicationSpy = spy(workflowRequest.getApplicationDTO());
+        workflowRequest.setApplicationDTO(applicationSpy);
+
         when(maatCourtDataService.invokeStoredProcedure(any(ApplicationDTO.class), any(UserDTO.class),
-                any(StoredProcedure.class)
-        )).thenReturn(workflowRequest.getApplicationDTO());
+                                                        any(StoredProcedure.class)
+        )).thenAnswer(invocation -> {
+            StoredProcedure procedure = invocation.getArgument(2);
+            if (procedure == StoredProcedure.ASSESSMENT_POST_PROCESSING_PART_1 ||
+                    procedure == StoredProcedure.ASSESSMENT_POST_PROCESSING_PART_1_C3) {
+                workflowRequest.getApplicationDTO().setAlertMessage(WRN_MSG_INCOMPLETE_ASSESSMENT);
+            }
+            return workflowRequest.getApplicationDTO();
+        });
 
         assertThatThrownBy(() -> orchestrationService.create(workflowRequest))
                 .isInstanceOf(ValidationException.class).hasMessage(WRN_MSG_INCOMPLETE_ASSESSMENT);
+        verify(applicationSpy, times(1)).setAlertMessage("");
         verify(proceedingsService, times(0)).updateApplication(workflowRequest);
         verify(meansAssessmentService, times(1)).rollback(any());
     }
@@ -246,7 +267,7 @@ class MeansAssessmentOrchestrationServiceTest {
         WorkflowRequest workflowRequest = MeansAssessmentDataBuilder.buildWorkFlowRequest();
         workflowRequest.getApplicationDTO().setAlertMessage(MOCK_ALERT);
         when(maatCourtDataService.invokeStoredProcedure(any(ApplicationDTO.class), any(UserDTO.class),
-                any(StoredProcedure.class)
+                                                        any(StoredProcedure.class)
         )).thenReturn(workflowRequest.getApplicationDTO());
 
         orchestrationService.create(workflowRequest);


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-3671)

- Clear income evidence records in ApplicationDTO following initial means assessment
  - This is a temporary fix that will be removed when we update the means assessment service to include the income evidence records in its response on create/update. Currently, the income evidence is generated during post-processing via stored procedure calls.
- Reset alert message field in ApplicationDTO before invoking stored procedures in post-processing
  - Previously, the alert message was not being reset, so if the application details were updated and this generated a warning message, then any subsequent assessments would fail until the user had reloaded the application.
- Enhanced existing test scenarios to support the above changes.