### PR TITLE
Add basic PR checks for Orchestration Service repo

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,37 @@
+name: PR Checks
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, edited, ready_for_review]
+
+jobs:
+  run-pr-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR description check
+        env:
+          DESCRIPTION: ${{ github.event.pull_request.body }}
+        run: |
+          if [[ $DESCRIPTION == *"Describe what you did and why"* ]]; then
+            echo "Please add a meaningful description to your PR."
+            exit 1
+          fi
+      - name: PR commit count check
+        env:
+          COMMIT_COUNT: ${{ github.event.pull_request.commits }}
+        run: |
+          commit_limit=40
+
+          if (( $COMMIT_COUNT > $commit_limit )); then
+            echo "You have exceeded the recommended limit of $commit_limit commits in this PR. Please fix-up your commits to make them more individually meaningful."
+            exit 1
+          fi
+      - name: Jira link check
+        env:
+          DESCRIPTION: ${{ github.event.pull_request.body }}
+        run: |
+          if [[ $DESCRIPTION =~ https://dsdmoj.atlassian.net/browse/[A-Za-z]+-[xX]+ ]]; then
+            echo "Please update the Jira link to point to the corresponding work item(s)."
+            exit 1
+          fi


### PR DESCRIPTION
This commit adds basic PR checks for the Orchestration Service repo, which check to make sure that there is a non-default description, that the number of commits is no greater than 40 and that a link exists to a Jira work item.

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1631)