### PR TITLE
LCAM 1621 Persist Income Evidence

### DIFF
--- a/helm_deploy/laa-maat-orchestration/templates/_environment.tpl
+++ b/helm_deploy/laa-maat-orchestration/templates/_environment.tpl
@@ -45,6 +45,10 @@ env:
     value: {{ .Values.catApi.baseUrl }}
   - name: CAT_API_OAUTH_URL
     value: {{ .Values.catApi.oauthUrl }}
+  - name: EVIDENCE_API_BASE_URL
+    value: {{ .Values.evidenceApi.baseUrl }}
+  - name: EVIDENCE_API_OAUTH_URL
+    value: {{ .Values.evidenceApi.oauthUrl }}
   - name: JWT_ISSUER_URI
     value: {{ .Values.jwt.issuerUri }}
   - name: HARDSHIP_API_OAUTH_CLIENT_ID

--- a/helm_deploy/laa-maat-orchestration/templates/_environment.tpl
+++ b/helm_deploy/laa-maat-orchestration/templates/_environment.tpl
@@ -120,11 +120,11 @@ env:
   - name: EVIDENCE_API_OAUTH_CLIENT_ID
     valueFrom:
         secretKeyRef:
-            name: evidence-oauth-client-id
+            name: evidence-api-oauth-client-id
             key: EVIDENCE_API_OAUTH_CLIENT_ID
   - name: EVIDENCE_API_OAUTH_CLIENT_SECRET
     valueFrom:
         secretKeyRef:
-            name: evidence-oauth-client-secret
+            name: evidence-api-oauth-client-secret
             key: EVIDENCE_API_OAUTH_CLIENT_SECRET
 {{- end -}}

--- a/helm_deploy/laa-maat-orchestration/templates/_environment.tpl
+++ b/helm_deploy/laa-maat-orchestration/templates/_environment.tpl
@@ -117,4 +117,14 @@ env:
         secretKeyRef:
             name: cat-api-oauth-client-secret
             key: CAT_API_OAUTH_CLIENT_SECRET
+  - name: EVIDENCE_API_OAUTH_CLIENT_ID
+    valueFrom:
+        secretKeyRef:
+            name: evidence-oauth-client-id
+            key: EVIDENCE_API_OAUTH_CLIENT_ID
+  - name: EVIDENCE_API_OAUTH_CLIENT_SECRET
+    valueFrom:
+        secretKeyRef:
+            name: evidence-oauth-client-secret
+            key: EVIDENCE_API_OAUTH_CLIENT_SECRET
 {{- end -}}

--- a/helm_deploy/laa-maat-orchestration/values-dev.yaml
+++ b/helm_deploy/laa-maat-orchestration/values-dev.yaml
@@ -49,6 +49,10 @@ catApi:
   baseUrl: http://laa-crime-application-tracking-service.laa-crime-application-tracking-service-dev.svc.cluster.local/
   oauthUrl: https://laa-crime-auth-ats.auth.eu-west-2.amazoncognito.com/oauth2/token
 
+evidenceApi:
+  baseUrl: http://laa-crime-evidence.laa-crime-evidence-dev.svc.cluster.local
+  oauthUrl: https://laa-crime-auth-evidence.auth.eu-west-2.amazoncognito.com/oauth2/token
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: false

--- a/helm_deploy/laa-maat-orchestration/values-prod.yaml
+++ b/helm_deploy/laa-maat-orchestration/values-prod.yaml
@@ -49,6 +49,9 @@ catApi:
   baseUrl: http://laa-crime-application-tracking-service.laa-crime-application-tracking-service-prod.svc.cluster.local
   oauthUrl: https://laa-crime-auth-ats.auth.eu-west-2.amazoncognito.com/oauth2/token
 
+evidenceApi:
+  baseUrl: http://laa-crime-evidence.laa-crime-evidence-prod.svc.cluster.local
+  oauthUrl: https://laa-crime-auth-evidence.auth.eu-west-2.amazoncognito.com/oauth2/token
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/helm_deploy/laa-maat-orchestration/values-test.yaml
+++ b/helm_deploy/laa-maat-orchestration/values-test.yaml
@@ -49,6 +49,10 @@ catApi:
   baseUrl: http://laa-crime-application-tracking-service.laa-crime-application-tracking-service-test.svc.cluster.local
   oauthUrl: https://laa-crime-auth-ats.auth.eu-west-2.amazoncognito.com/oauth2/token
 
+evidenceApi:
+  baseUrl: http://laa-crime-evidence.laa-crime-evidence-test.svc.cluster.local
+  oauthUrl: https://laa-crime-auth-evidence.auth.eu-west-2.amazoncognito.com/oauth2/token
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: false

--- a/helm_deploy/laa-maat-orchestration/values-uat.yaml
+++ b/helm_deploy/laa-maat-orchestration/values-uat.yaml
@@ -49,6 +49,10 @@ catApi:
   baseUrl: http://laa-crime-application-tracking-service.laa-crime-application-tracking-service-uat.svc.cluster.local
   oauthUrl: https://laa-crime-auth-ats.auth.eu-west-2.amazoncognito.com/oauth2/token
 
+evidenceApi:
+  baseUrl: http://laa-crime-evidence.laa-crime-evidence-uat.svc.cluster.local
+  oauthUrl: https://laa-crime-auth-evidence.auth.eu-west-2.amazoncognito.com/oauth2/token
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: false

--- a/maat-orchestration/build.gradle
+++ b/maat-orchestration/build.gradle
@@ -18,7 +18,7 @@ java {
 def versions = [
 		pitest                  : "1.16.1",
 		springdocVersion        : "2.5.0",
-		commonsModSchemas       : "1.20.0",
+		commonsModSchemas       : "1.19.0-SNAPSHOT",
 		crimeCommonsClasses     : "3.29.0",
 		commonsRestClient       : "3.18.0",
 		okhttpVersion           : "4.12.0",
@@ -33,6 +33,9 @@ configurations {
 
 repositories {
 	mavenCentral()
+	maven {
+		url 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
+	}
 }
 
 dependencies {

--- a/maat-orchestration/build.gradle
+++ b/maat-orchestration/build.gradle
@@ -18,7 +18,7 @@ java {
 def versions = [
 		pitest                  : "1.16.1",
 		springdocVersion        : "2.5.0",
-		commonsModSchemas       : "1.19.0-SNAPSHOT",
+		commonsModSchemas       : "1.20.1",
 		crimeCommonsClasses     : "3.29.0",
 		commonsRestClient       : "3.18.0",
 		okhttpVersion           : "4.12.0",

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/config/ServicesConfiguration.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/config/ServicesConfiguration.java
@@ -30,6 +30,9 @@ public class ServicesConfiguration {
     @NotNull
     private CATApi catApi;
 
+    @NotNull
+    private EvidenceApi evidenceApi;
+
     @Data
     @AllArgsConstructor
     @NoArgsConstructor
@@ -191,6 +194,27 @@ public class ServicesConfiguration {
             @NotNull
             private String handleEformUrl;
 
+        }
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class EvidenceApi {
+
+        @NotNull
+        private String baseUrl;
+
+        @NotNull
+        private Endpoints endpoints;
+
+        @Data
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class Endpoints {
+
+            @NotNull
+            private String incomeEvidenceUrl;
         }
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/config/ServicesConfiguration.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/config/ServicesConfiguration.java
@@ -163,7 +163,7 @@ public class ServicesConfiguration {
             @NotNull
             private String updateSendToCCLFUrl;
             @NotNull
-            private String getAssessmentUrl;
+            private String financialAssessmentUrl;
         }
 
         @Data

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/dto/maat/FinancialAssessmentDTO.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/dto/maat/FinancialAssessmentDTO.java
@@ -5,6 +5,8 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import java.time.LocalDateTime;
+
 @Data
 @SuperBuilder
 @NoArgsConstructor
@@ -18,5 +20,6 @@ public class FinancialAssessmentDTO extends GenericDTO {
     private IncomeEvidenceSummaryDTO incomeEvidence;
     private Boolean fullAvailable;
     private Long usn;
+    private LocalDateTime dateCompleted;
 
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/IncomeEvidenceMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/IncomeEvidenceMapper.java
@@ -86,8 +86,7 @@ public class IncomeEvidenceMapper {
                 .withInitApplicationEmploymentStatus(application.getApplicantDTO().getEmploymentStatusDTO().getCode())
                 .withAssessmentDetails(meansAssessmentMapper.assessmentDetailsBuilder(assessmentDetails))
                 .withChildWeightings(meansAssessmentMapper.childWeightingsBuilder(initialAssessment.getChildWeightings()))
-                // TODO: Amend CMA to return the date completed and update schemas so it is available here
-                .withDateCompleted();
+                .withDateCompleted(application.getAssessmentDTO().getFinancialAssessmentDTO().getDateCompleted());
 
         if ( assessmentType.equals("FULL")) {
             updateAssessment.setFassFullStatus(fullAssessment.getAssessmnentStatusDTO().getStatus());

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/IncomeEvidenceMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/IncomeEvidenceMapper.java
@@ -116,8 +116,8 @@ public class IncomeEvidenceMapper {
         List<EvidenceDTO> applicantEvidence = new ArrayList<>();
         List<EvidenceDTO> partnerEvidence = new ArrayList<>();
 
+        Integer applicantId = NumberUtils.toInteger(application.getApplicantDTO().getId());
         for (uk.gov.justice.laa.crime.common.model.meansassessment.ApiIncomeEvidence evidence : assessmentResponse.getIncomeEvidence()) {
-            Integer applicantId = NumberUtils.toInteger(application.getApplicantDTO().getId());
 
             if (evidence.getApplicantId().equals(applicantId)) {
                 applicantEvidence.add(meansAssessmentMapper.getEvidenceDTO(evidence));

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/IncomeEvidenceMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/IncomeEvidenceMapper.java
@@ -20,11 +20,10 @@ import uk.gov.justice.laa.crime.util.NumberUtils;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Stream;
+
+import static java.util.Optional.ofNullable;
 
 @Component
 @RequiredArgsConstructor
@@ -71,8 +70,10 @@ public class IncomeEvidenceMapper {
                 .withInitialAssessmentDate(DateUtil.toLocalDateTime(initialAssessment.getAssessmentDate()))
                 .withInitOtherBenefitNote(initialAssessment.getOtherBenefitNote())
                 .withInitOtherIncomeNote(initialAssessment.getOtherIncomeNote())
-                .withInitTotAggregatedIncome(BigDecimal.valueOf(initialAssessment.getTotalAggregatedIncome()))
-                .withInitAdjustedIncomeValue(BigDecimal.valueOf(initialAssessment.getAdjustedIncomeValue()))
+                .withInitTotAggregatedIncome(
+                        BigDecimal.valueOf(ofNullable(initialAssessment.getTotalAggregatedIncome()).orElse(0.0)))
+                .withInitAdjustedIncomeValue(
+                        BigDecimal.valueOf(ofNullable(initialAssessment.getAdjustedIncomeValue()).orElse(0.0)))
                 .withInitNotes(initialAssessment.getNotes())
                 .withInitResult(initialAssessment.getResult())
                 .withInitResultReason(initialAssessment.getResultReason())
@@ -88,10 +89,13 @@ public class IncomeEvidenceMapper {
             updateAssessment.setFullResult(fullAssessment.getResult());
             updateAssessment.setFullResultReason(fullAssessment.getResultReason());
             updateAssessment.setFullAssessmentNotes(fullAssessment.getAssessmentNotes());
-            updateAssessment.setFullAdjustedLivingAllowance(BigDecimal.valueOf(fullAssessment.getAdjustedLivingAllowance()));
-            updateAssessment.setFullTotalAnnualDisposableIncome(BigDecimal.valueOf(fullAssessment.getTotalAnnualDisposableIncome()));
+            updateAssessment.setFullAdjustedLivingAllowance(
+                    BigDecimal.valueOf(ofNullable(fullAssessment.getAdjustedLivingAllowance()).orElse(0.0)));
+            updateAssessment.setFullTotalAnnualDisposableIncome(
+                    BigDecimal.valueOf(ofNullable(fullAssessment.getTotalAnnualDisposableIncome()).orElse(0.0)));
             updateAssessment.setFullOtherHousingNote(fullAssessment.getOtherHousingNote());
-            updateAssessment.setFullTotalAggregatedExpenses(BigDecimal.valueOf(fullAssessment.getTotalAggregatedExpense()));
+            updateAssessment.setFullTotalAggregatedExpenses(
+                    BigDecimal.valueOf(ofNullable(fullAssessment.getTotalAggregatedExpense()).orElse(0.0)));
             updateAssessment.setFullAscrId(NumberUtils.toInteger(fullAssessment.getCriteriaId()));
         }
 

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/IncomeEvidenceMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/IncomeEvidenceMapper.java
@@ -51,7 +51,7 @@ public class IncomeEvidenceMapper {
                                                                 RepOrderDTO repOrder,
                                                                 ApiCreateIncomeEvidenceResponse evidenceResponse) {
         ApplicationDTO application = workflowRequest.getApplicationDTO();
-        String assessmentType = application.getAssessmentDTO().getFinancialAssessmentDTO().getFullAvailable() ? "FULL" : "INIT";
+        String assessmentType = Boolean.TRUE.equals(application.getAssessmentDTO().getFinancialAssessmentDTO().getFullAvailable()) ? "FULL" : "INIT";
         InitialAssessmentDTO initialAssessment = application.getAssessmentDTO().getFinancialAssessmentDTO().getInitial();
         FullAssessmentDTO fullAssessment = application.getAssessmentDTO().getFinancialAssessmentDTO().getFull();
         Collection<AssessmentDetailDTO> assessmentDetails  = assessmentType.equals("FULL")
@@ -220,7 +220,7 @@ public class IncomeEvidenceMapper {
                         .withDateReceived(getDateReceived(applicantId, evidence, existingFinancialAssessment))
                         .withActive("Y")
                         .withIncomeEvidence(evidence.getEvidenceType().getName())
-                        .withMandatory(evidence.getMandatory() ? "Y" : "N")
+                        .withMandatory(Boolean.TRUE.equals(evidence.getMandatory()) ? "Y" : "N")
                         .withApplicant(applicantId)
                         .withOtherText(evidence.getDescription())
                         .withUserCreated(user.getUserName()))

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/IncomeEvidenceMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/IncomeEvidenceMapper.java
@@ -1,0 +1,109 @@
+package uk.gov.justice.laa.crime.orchestration.mapper;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiApplicantDetails;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceRequest;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiIncomeEvidenceMetadata;
+import uk.gov.justice.laa.crime.enums.EmploymentStatus;
+import uk.gov.justice.laa.crime.enums.MagCourtOutcome;
+import uk.gov.justice.laa.crime.exception.ValidationException;
+import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.*;
+import uk.gov.justice.laa.crime.util.NumberUtils;
+
+import java.math.BigDecimal;
+import java.time.ZoneId;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Stream;
+
+@Component
+@RequiredArgsConstructor
+public class IncomeEvidenceMapper {
+
+    UserMapper userMapper;
+
+    public ApiCreateIncomeEvidenceRequest workflowRequestToApiCreateIncomeEvidenceRequest(WorkflowRequest workflowRequest) {
+        ApplicationDTO applicationDTO = workflowRequest.getApplicationDTO();
+        ApiApplicantDetails partnerDetails = getPartnerDetails(applicationDTO.getApplicantLinks());
+        Collection<AssessmentSectionSummaryDTO> sectionSummaries = applicationDTO.getAssessmentDTO()
+                .getFinancialAssessmentDTO().getInitial().getSectionSummaries();
+
+        return new ApiCreateIncomeEvidenceRequest()
+                .withMagCourtOutcome(MagCourtOutcome.getFrom(applicationDTO.getMagsOutcomeDTO().getOutcome()))
+                .withApplicantDetails(getApplicantDetails(applicationDTO.getApplicantDTO()))
+                .withPartnerDetails(partnerDetails)
+                .withApplicantPensionAmount(getPensionAmount(sectionSummaries, false))
+                .withPartnerPensionAmount(partnerDetails == null ? null : getPensionAmount(sectionSummaries, true))
+                .withMetadata(getMetadata(workflowRequest));
+    }
+
+    private ApiApplicantDetails getPartnerDetails(Collection<ApplicantLinkDTO> applicantLinks) {
+        if (applicantLinks == null) return null;
+
+        List<ApiApplicantDetails> partnerDTOs = applicantLinks
+                .stream()
+                .filter(link -> link.getUnlinked() == null)
+                .map(link -> getApplicantDetails(link.getPartnerDTO()))
+                .toList();
+
+        if (partnerDTOs.size() > 1) {
+            throw new ValidationException("The applicant has more than one partner linked.");
+        }
+
+        return partnerDTOs.get(0);
+    }
+
+    private ApiApplicantDetails getApplicantDetails(ApplicantDTO applicantDTO) {
+        return new ApiApplicantDetails()
+                .withId(NumberUtils.toInteger(applicantDTO.getId()))
+                .withEmploymentStatus(EmploymentStatus.getFrom(applicantDTO.getEmploymentStatusDTO().getCode()));
+    }
+
+    private BigDecimal getPensionAmount(Collection<AssessmentSectionSummaryDTO> sectionSummaries, boolean isPartner) {
+        AssessmentDetailDTO pensionDetails = sectionSummaries
+                .stream()
+                .flatMap(section -> section.getAssessmentDetail().stream())
+                .filter(detail -> detail.getDescription().equals("Income from Private Pension(s)"))
+                .findFirst()
+                .orElse(null);
+
+        if (pensionDetails == null) return BigDecimal.ZERO;
+
+        if (isPartner) {
+            return calculatePensionAmount(pensionDetails.getPartnerAmount(),
+                    pensionDetails.getPartnerFrequency().getAnnualWeighting());
+        } else {
+            return calculatePensionAmount(pensionDetails.getApplicantAmount(),
+                    pensionDetails.getApplicantFrequency().getAnnualWeighting());
+        }
+    }
+
+    private BigDecimal calculatePensionAmount(Double amount, Long weighting) {
+        return weighting == null ? BigDecimal.ZERO : BigDecimal.valueOf(amount * weighting);
+    }
+
+    private ApiIncomeEvidenceMetadata getMetadata(WorkflowRequest workflowRequest) {
+        ApplicationDTO applicationDTO = workflowRequest.getApplicationDTO();
+
+
+        return new ApiIncomeEvidenceMetadata()
+                .withApplicationReceivedDate(applicationDTO.getDateReceived().toInstant().atZone(ZoneId.systemDefault())
+                        .toLocalDate())
+                .withEvidencePending(isEvidencePending(applicationDTO.getAssessmentDTO().getFinancialAssessmentDTO()
+                        .getIncomeEvidence()))
+                .withNotes(applicationDTO.getAssessmentDTO().getFinancialAssessmentDTO().getIncomeEvidence()
+                        .getIncomeEvidenceNotes())
+                .withUserSession(userMapper.userDtoToUserSession(workflowRequest.getUserDTO()));
+    }
+
+    private Boolean isEvidencePending(IncomeEvidenceSummaryDTO incomeEvidence) {
+        return !Stream.of(incomeEvidence.getApplicantIncomeEvidenceList(), incomeEvidence.getPartnerIncomeEvidenceList(),
+                        incomeEvidence.getExtraEvidenceList())
+                .flatMap(Collection::stream)
+                .filter(evidence -> evidence.getDateReceived() == null)
+                .toList()
+                .isEmpty();
+    }
+}

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/MeansAssessmentMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/MeansAssessmentMapper.java
@@ -180,7 +180,7 @@ public class MeansAssessmentMapper {
                 .withOtherText(evidenceItem.getOtherText());
     }
 
-    private List<ApiAssessmentChildWeighting> childWeightingsBuilder(Collection<ChildWeightingDTO> childWeightings) {
+    public List<ApiAssessmentChildWeighting> childWeightingsBuilder(Collection<ChildWeightingDTO> childWeightings) {
         List<ApiAssessmentChildWeighting> childWeightingList = new ArrayList<>();
         if (childWeightings != null) {
             for (ChildWeightingDTO childWeightingDTO : childWeightings) {
@@ -250,7 +250,7 @@ public class MeansAssessmentMapper {
         return apiAssessmentSectionSummaries;
     }
 
-    private List<ApiAssessmentDetail> assessmentDetailsBuilder(Collection<AssessmentDetailDTO> assessmentDetails) {
+    public List<ApiAssessmentDetail> assessmentDetailsBuilder(Collection<AssessmentDetailDTO> assessmentDetails) {
         List<ApiAssessmentDetail> apiAssessmentDetails = new ArrayList<>();
         if (assessmentDetails != null) {
             for (AssessmentDetailDTO assessmentDetailDTO : assessmentDetails) {
@@ -525,6 +525,7 @@ public class MeansAssessmentMapper {
         FinancialAssessmentDTO financialAssessmentDTO = applicationDTO.getAssessmentDTO().getFinancialAssessmentDTO();
         financialAssessmentDTO.setId(ofNullable(apiResponse.getAssessmentId()).map(Integer::longValue).orElse(0L));
         financialAssessmentDTO.setTimestamp(toZonedDateTime(apiResponse.getUpdated()));
+        // TODO: add date completed to finassDTO and then map it from api response
 
 
         if (Boolean.TRUE.equals(applicationDTO.getAssessmentDTO().getFinancialAssessmentDTO().getFullAvailable())) {

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/MeansAssessmentMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/MeansAssessmentMapper.java
@@ -525,8 +525,7 @@ public class MeansAssessmentMapper {
         FinancialAssessmentDTO financialAssessmentDTO = applicationDTO.getAssessmentDTO().getFinancialAssessmentDTO();
         financialAssessmentDTO.setId(ofNullable(apiResponse.getAssessmentId()).map(Integer::longValue).orElse(0L));
         financialAssessmentDTO.setTimestamp(toZonedDateTime(apiResponse.getUpdated()));
-        // TODO: add date completed to finassDTO and then map it from api response
-
+        financialAssessmentDTO.setDateCompleted(apiResponse.getDateCompleted());
 
         if (Boolean.TRUE.equals(applicationDTO.getAssessmentDTO().getFinancialAssessmentDTO().getFullAvailable())) {
             mapFullAssessmentDTO(financialAssessmentDTO.getFull(), apiResponse);

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/MeansAssessmentMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/MeansAssessmentMapper.java
@@ -332,7 +332,7 @@ public class MeansAssessmentMapper {
         return incomeEvidenceSummaryDTO;
     }
 
-    private EvidenceDTO getEvidenceDTO(ApiIncomeEvidence apiIncomeEvidence) {
+    public EvidenceDTO getEvidenceDTO(ApiIncomeEvidence apiIncomeEvidence) {
         EvidenceDTO evidenceDTO = new EvidenceDTO();
         evidenceDTO.setEvidenceTypeDTO(getEvidenceTypeDTO(apiIncomeEvidence.getApiEvidenceType()));
         evidenceDTO.setId(ofNullable(apiIncomeEvidence.getId()).map(Integer::longValue).orElse(0L));

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/MeansAssessmentMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/MeansAssessmentMapper.java
@@ -411,7 +411,7 @@ public class MeansAssessmentMapper {
         return ReviewTypeDTO.builder().build();
     }
 
-    private static List<ChildWeightingDTO> mapChildWeightings(List<ApiAssessmentChildWeighting> childWeightings) {
+    public static List<ChildWeightingDTO> mapChildWeightings(List<ApiAssessmentChildWeighting> childWeightings) {
         List<ChildWeightingDTO> childWeightingDTOList = new ArrayList<>();
         for (ApiAssessmentChildWeighting apiAssessmentChildWeighting : childWeightings) {
             ChildWeightingDTO childWeightingDTO = new ChildWeightingDTO();

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/IncomeEvidenceService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/IncomeEvidenceService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceRequest;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceResponse;
 import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.MaatApiAssessmentResponse;
+import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.MaatApiUpdateAssessment;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
 import uk.gov.justice.laa.crime.orchestration.mapper.IncomeEvidenceMapper;
@@ -18,17 +19,11 @@ public class IncomeEvidenceService {
     private final EvidenceApiService evidenceApiService;
     private final MaatCourtDataApiService maatCourtDataApiService;
     private final IncomeEvidenceMapper incomeEvidenceMapper;
-    
-    public ??? createEvidence(WorkflowRequest request, RepOrderDTO repOrderDTO) {
+
+    public ??? createEvidence(WorkflowRequest request, RepOrderDTO repOrder) {
         ApiCreateIncomeEvidenceRequest evidenceRequest = incomeEvidenceMapper.workflowRequestToApiCreateIncomeEvidenceRequest(request);
         ApiCreateIncomeEvidenceResponse evidenceResponse = evidenceApiService.createEvidence(evidenceRequest);
-        // TODO: Map MaatApiUpdateAssessment for call to maat api
-        MaatApiAssessmentResponse bla2 = maatCourtDataApiService.updateFinancialAssessment();
-    }
-
-    // TODO: Complete private method to get date received if evidence received in rep order otherwise set to null
-    // Use RepOrderDTO here
-    private ??? getDateReceived() {
-
+        MaatApiUpdateAssessment maatApiRequest = incomeEvidenceMapper.mapToMaatApiUpdateAssessment(request, repOrder, evidenceResponse);
+        MaatApiAssessmentResponse maatApiResponse = maatCourtDataApiService.updateFinancialAssessment(maatApiRequest);
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/IncomeEvidenceService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/IncomeEvidenceService.java
@@ -2,9 +2,12 @@ package uk.gov.justice.laa.crime.orchestration.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceRequest;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceResponse;
 import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.MaatApiAssessmentResponse;
-import uk.gov.justice.laa.crime.orchestration.dto.maat_api.FinancialAssessmentDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
+import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
+import uk.gov.justice.laa.crime.orchestration.mapper.IncomeEvidenceMapper;
 import uk.gov.justice.laa.crime.orchestration.service.api.EvidenceApiService;
 import uk.gov.justice.laa.crime.orchestration.service.api.MaatCourtDataApiService;
 
@@ -14,14 +17,17 @@ public class IncomeEvidenceService {
 
     private final EvidenceApiService evidenceApiService;
     private final MaatCourtDataApiService maatCourtDataApiService;
-
-    // TODO: Complete method to call evidence service, map data and then call maat api to perist evidence
-    public ??? createEvidence() {
-        ApiCreateIncomeEvidenceResponse bla = evidenceApiService.createEvidence();
+    private final IncomeEvidenceMapper incomeEvidenceMapper;
+    
+    public ??? createEvidence(WorkflowRequest request, RepOrderDTO repOrderDTO) {
+        ApiCreateIncomeEvidenceRequest evidenceRequest = incomeEvidenceMapper.workflowRequestToApiCreateIncomeEvidenceRequest(request);
+        ApiCreateIncomeEvidenceResponse evidenceResponse = evidenceApiService.createEvidence(evidenceRequest);
+        // TODO: Map MaatApiUpdateAssessment for call to maat api
         MaatApiAssessmentResponse bla2 = maatCourtDataApiService.updateFinancialAssessment();
     }
 
     // TODO: Complete private method to get date received if evidence received in rep order otherwise set to null
+    // Use RepOrderDTO here
     private ??? getDateReceived() {
 
     }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/IncomeEvidenceService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/IncomeEvidenceService.java
@@ -1,0 +1,26 @@
+package uk.gov.justice.laa.crime.orchestration.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceResponse;
+import uk.gov.justice.laa.crime.orchestration.service.api.EvidenceApiService;
+import uk.gov.justice.laa.crime.orchestration.service.api.MaatCourtDataApiService;
+
+@Service
+@RequiredArgsConstructor
+public class IncomeEvidenceService {
+
+    private final EvidenceApiService evidenceApiService;
+    private final MaatCourtDataApiService maatCourtDataApiService;
+
+    // TODO: Complete method to call evidence service, map data and then call maat api to perist evidence
+    public ??? createEvidence() {
+        ApiCreateIncomeEvidenceResponse bla = evidenceApiService.createEvidence();
+        ??? bla2 = maatCourtDataApiService.updateFinancialAssessment();
+    }
+
+    // TODO: Complete private method to get date received if evidence received in rep order otherwise set to null
+    private ??? getDateReceived() {
+
+    }
+}

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/IncomeEvidenceService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/IncomeEvidenceService.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.laa.crime.orchestration.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceRequest;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceResponse;
@@ -12,6 +13,7 @@ import uk.gov.justice.laa.crime.orchestration.mapper.IncomeEvidenceMapper;
 import uk.gov.justice.laa.crime.orchestration.service.api.EvidenceApiService;
 import uk.gov.justice.laa.crime.orchestration.service.api.MaatCourtDataApiService;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class IncomeEvidenceService {
@@ -20,10 +22,18 @@ public class IncomeEvidenceService {
     private final MaatCourtDataApiService maatCourtDataApiService;
     private final IncomeEvidenceMapper incomeEvidenceMapper;
 
-    public ??? createEvidence(WorkflowRequest request, RepOrderDTO repOrder) {
-        ApiCreateIncomeEvidenceRequest evidenceRequest = incomeEvidenceMapper.workflowRequestToApiCreateIncomeEvidenceRequest(request);
-        ApiCreateIncomeEvidenceResponse evidenceResponse = evidenceApiService.createEvidence(evidenceRequest);
-        MaatApiUpdateAssessment maatApiRequest = incomeEvidenceMapper.mapToMaatApiUpdateAssessment(request, repOrder, evidenceResponse);
+    public void createEvidence(WorkflowRequest request, RepOrderDTO repOrder) {
+        log.debug("Creating evidence items for financialAssessmentId: {}",
+                request.getApplicationDTO().getAssessmentDTO().getFinancialAssessmentDTO().getId());
+
+        ApiCreateIncomeEvidenceRequest evidenceRequest =
+                incomeEvidenceMapper.workflowRequestToApiCreateIncomeEvidenceRequest(request);
+        ApiCreateIncomeEvidenceResponse evidenceResponse =
+                evidenceApiService.createEvidence(evidenceRequest);
+
+        MaatApiUpdateAssessment maatApiRequest =
+                incomeEvidenceMapper.mapToMaatApiUpdateAssessment(request, repOrder, evidenceResponse);
         MaatApiAssessmentResponse maatApiResponse = maatCourtDataApiService.updateFinancialAssessment(maatApiRequest);
+        incomeEvidenceMapper.maatApiAssessmentResponseToApplicationDTO(maatApiResponse, request.getApplicationDTO());
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/IncomeEvidenceService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/IncomeEvidenceService.java
@@ -3,6 +3,7 @@ package uk.gov.justice.laa.crime.orchestration.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceResponse;
+import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.MaatApiAssessmentResponse;
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.FinancialAssessmentDTO;
 import uk.gov.justice.laa.crime.orchestration.service.api.EvidenceApiService;
 import uk.gov.justice.laa.crime.orchestration.service.api.MaatCourtDataApiService;
@@ -17,7 +18,7 @@ public class IncomeEvidenceService {
     // TODO: Complete method to call evidence service, map data and then call maat api to perist evidence
     public ??? createEvidence() {
         ApiCreateIncomeEvidenceResponse bla = evidenceApiService.createEvidence();
-        FinancialAssessmentDTO bla2 = maatCourtDataApiService.updateFinancialAssessment();
+        MaatApiAssessmentResponse bla2 = maatCourtDataApiService.updateFinancialAssessment();
     }
 
     // TODO: Complete private method to get date received if evidence received in rep order otherwise set to null

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/IncomeEvidenceService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/IncomeEvidenceService.java
@@ -3,6 +3,7 @@ package uk.gov.justice.laa.crime.orchestration.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceResponse;
+import uk.gov.justice.laa.crime.orchestration.dto.maat_api.FinancialAssessmentDTO;
 import uk.gov.justice.laa.crime.orchestration.service.api.EvidenceApiService;
 import uk.gov.justice.laa.crime.orchestration.service.api.MaatCourtDataApiService;
 
@@ -16,7 +17,7 @@ public class IncomeEvidenceService {
     // TODO: Complete method to call evidence service, map data and then call maat api to perist evidence
     public ??? createEvidence() {
         ApiCreateIncomeEvidenceResponse bla = evidenceApiService.createEvidence();
-        ??? bla2 = maatCourtDataApiService.updateFinancialAssessment();
+        FinancialAssessmentDTO bla2 = maatCourtDataApiService.updateFinancialAssessment();
     }
 
     // TODO: Complete private method to get date received if evidence received in rep order otherwise set to null

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/api/EvidenceApiService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/api/EvidenceApiService.java
@@ -24,7 +24,7 @@ public class EvidenceApiService {
     private final ServicesConfiguration configuration;
 
     public ApiCreateIncomeEvidenceResponse createEvidence(ApiCreateIncomeEvidenceRequest apiCreateIncomeEvidenceRequest) {
-        log.info(REQUEST_STRING, apiCreateIncomeEvidenceRequest);
+        log.debug(REQUEST_STRING, apiCreateIncomeEvidenceRequest);
         ApiCreateIncomeEvidenceResponse apiCreateIncomeEvidenceResponse = evidenceApiClient.post(
                 apiCreateIncomeEvidenceRequest,
                 new ParameterizedTypeReference<>() {},

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/api/EvidenceApiService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/api/EvidenceApiService.java
@@ -1,0 +1,37 @@
+package uk.gov.justice.laa.crime.orchestration.service.api;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.stereotype.Service;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceRequest;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceResponse;
+import uk.gov.justice.laa.crime.commons.client.RestAPIClient;
+import uk.gov.justice.laa.crime.orchestration.config.ServicesConfiguration;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EvidenceApiService {
+
+    private static final String REQUEST_STRING = "Request to evidence service: {}";
+    private static final String RESPONSE_STRING = "Response from evidence service: {}";
+    @Qualifier("evidenceApiClient")
+    private final RestAPIClient evidenceApiClient;
+    private final ServicesConfiguration configuration;
+
+    public ApiCreateIncomeEvidenceResponse createEvidence(ApiCreateIncomeEvidenceRequest request) {
+        log.info(REQUEST_STRING, request);
+        ApiCreateIncomeEvidenceResponse response = evidenceApiClient.post(
+                request,
+                new ParameterizedTypeReference<>() {},
+                configuration.getEvidenceApi().getEndpoints().getIncomeEvidenceUrl(),
+                Map.of()
+        );
+        log.debug(RESPONSE_STRING, response);
+        return response;
+    }
+}

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/api/EvidenceApiService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/api/EvidenceApiService.java
@@ -23,15 +23,15 @@ public class EvidenceApiService {
     private final RestAPIClient evidenceApiClient;
     private final ServicesConfiguration configuration;
 
-    public ApiCreateIncomeEvidenceResponse createEvidence(ApiCreateIncomeEvidenceRequest request) {
-        log.info(REQUEST_STRING, request);
-        ApiCreateIncomeEvidenceResponse response = evidenceApiClient.post(
-                request,
+    public ApiCreateIncomeEvidenceResponse createEvidence(ApiCreateIncomeEvidenceRequest apiCreateIncomeEvidenceRequest) {
+        log.info(REQUEST_STRING, apiCreateIncomeEvidenceRequest);
+        ApiCreateIncomeEvidenceResponse apiCreateIncomeEvidenceResponse = evidenceApiClient.post(
+                apiCreateIncomeEvidenceRequest,
                 new ParameterizedTypeReference<>() {},
                 configuration.getEvidenceApi().getEndpoints().getIncomeEvidenceUrl(),
                 Map.of()
         );
-        log.debug(RESPONSE_STRING, response);
-        return response;
+        log.debug(RESPONSE_STRING, apiCreateIncomeEvidenceResponse);
+        return apiCreateIncomeEvidenceResponse;
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/api/MaatCourtDataApiService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/api/MaatCourtDataApiService.java
@@ -93,7 +93,7 @@ public class MaatCourtDataApiService {
     }
 
     public MaatApiAssessmentResponse updateFinancialAssessment(MaatApiUpdateAssessment maatApiUpdateAssessment) {
-        log.info(REQUEST_STRING, maatApiUpdateAssessment);
+        log.debug(REQUEST_STRING, maatApiUpdateAssessment);
         MaatApiAssessmentResponse financialAssessmentDTO = maatApiClient.put(
                 maatApiUpdateAssessment,
                 new ParameterizedTypeReference<>() {},

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/api/MaatCourtDataApiService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/api/MaatCourtDataApiService.java
@@ -90,4 +90,9 @@ public class MaatCourtDataApiService {
         return financialAssessmentDTO;
     }
 
+    // TODO: Complete the update financial assessment via maat api method
+    public ??? updateFinancialAssessment() {
+
+    }
+
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/api/MaatCourtDataApiService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/api/MaatCourtDataApiService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Service;
+import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.MaatApiUpdateAssessment;
 import uk.gov.justice.laa.crime.commons.client.RestAPIClient;
 import uk.gov.justice.laa.crime.orchestration.config.ServicesConfiguration;
 import uk.gov.justice.laa.crime.orchestration.dto.StoredProcedureRequest;
@@ -83,16 +84,23 @@ public class MaatCourtDataApiService {
         FinancialAssessmentDTO financialAssessmentDTO = maatApiClient.get(
                 new ParameterizedTypeReference<>() {
                 },
-                configuration.getMaatApi().getEndpoints().getGetAssessmentUrl(),
+                configuration.getMaatApi().getEndpoints().getFinancialAssessmentUrl(),
                 financialAssessmentId
         );
         log.debug(RESPONSE_STRING, financialAssessmentDTO);
         return financialAssessmentDTO;
     }
 
-    // TODO: Complete the update financial assessment via maat api method
-    public ??? updateFinancialAssessment() {
-
+    public FinancialAssessmentDTO updateFinancialAssessment(MaatApiUpdateAssessment maatApiUpdateAssessment) {
+        log.info(REQUEST_STRING, maatApiUpdateAssessment);
+        FinancialAssessmentDTO financialAssessmentDTO = maatApiClient.put(
+                maatApiUpdateAssessment,
+                new ParameterizedTypeReference<>() {},
+                configuration.getMaatApi().getEndpoints().getFinancialAssessmentUrl(),
+                Map.of()
+        );
+        log.debug(RESPONSE_STRING, financialAssessmentDTO);
+        return financialAssessmentDTO;
     }
 
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/api/MaatCourtDataApiService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/api/MaatCourtDataApiService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Service;
+import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.MaatApiAssessmentResponse;
 import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.MaatApiUpdateAssessment;
 import uk.gov.justice.laa.crime.commons.client.RestAPIClient;
 import uk.gov.justice.laa.crime.orchestration.config.ServicesConfiguration;
@@ -91,9 +92,9 @@ public class MaatCourtDataApiService {
         return financialAssessmentDTO;
     }
 
-    public FinancialAssessmentDTO updateFinancialAssessment(MaatApiUpdateAssessment maatApiUpdateAssessment) {
+    public MaatApiAssessmentResponse updateFinancialAssessment(MaatApiUpdateAssessment maatApiUpdateAssessment) {
         log.info(REQUEST_STRING, maatApiUpdateAssessment);
-        FinancialAssessmentDTO financialAssessmentDTO = maatApiClient.put(
+        MaatApiAssessmentResponse financialAssessmentDTO = maatApiClient.put(
                 maatApiUpdateAssessment,
                 new ParameterizedTypeReference<>() {},
                 configuration.getMaatApi().getEndpoints().getFinancialAssessmentUrl(),

--- a/maat-orchestration/src/main/resources/application.yaml
+++ b/maat-orchestration/src/main/resources/application.yaml
@@ -112,6 +112,7 @@ services:
       call-stored-proc-url: ${services.maat-api.base-url}/api/internal/v1/assessment/execute-stored-procedure
       rep-order-url: ${services.maat-api.base-url}/api/internal/v1/assessment/rep-orders/{repId}
       update-send-to-cclf-url: ${services.maat-api.base-url}/api/internal/v1/application/applicant/update-cclf
+      financial-assessment-url: ${services.maat-api.base-url}/api/internal/v1/assessment/financial-assessments
     user-domain: ${services.maat-api.base-url}/api/internal/v1/users
     application-domain: ${services.maat-api.base-url}/api/internal/v1/application
     user-endpoints:

--- a/maat-orchestration/src/main/resources/application.yaml
+++ b/maat-orchestration/src/main/resources/application.yaml
@@ -37,6 +37,8 @@ spring:
             token-uri: ${MAAT_API_OAUTH_URL}
           cat:
             token-uri: ${CAT_API_OAUTH_URL}
+          evidence:
+            token-uri: ${EVIDENCE_API_OAUTH_URL}
         registration:
           hardship:
             client-id: ${HARDSHIP_API_OAUTH_CLIENT_ID}
@@ -66,6 +68,10 @@ spring:
             client-id: ${CAT_API_OAUTH_CLIENT_ID}
             client-secret: ${CAT_API_OAUTH_CLIENT_SECRET}
             authorization-grant-type: client_credentials
+          evidence:
+            client-id: ${EVIDENCE_API_OAUTH_CLIENT_ID}
+            client-secret: ${EVIDENCE_API_OAUTH_CLIENT_SECRET}
+            authorization-grant-type: client-credentials
       resource-server:
         jwt:
           issuer-uri: ${JWT_ISSUER_URI}
@@ -114,6 +120,11 @@ services:
     base-url: ${CAT_API_BASE_URL}
     endpoints:
       handle-eform-url: ${services.cat-api.base-url}/api/internal/v1/application-tracking-output-result
+  evidence-api:
+    base-url: ${EVIDENCE_API_BASE_URL}
+    endpoints:
+      income-evidence-url: ${services.evidence-api.base-url}/api/internal/v1/evidence
+
 retry-config:
   max-retries: 3
   min-back-off-period: 5

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/config/MockServicesConfiguration.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/config/MockServicesConfiguration.java
@@ -13,6 +13,7 @@ public class MockServicesConfiguration {
         ServicesConfiguration.CmaApi cmaApi = new ServicesConfiguration.CmaApi();
         ServicesConfiguration.MaatApi maatApi = new ServicesConfiguration.MaatApi();
         ServicesConfiguration.CATApi catApi = new ServicesConfiguration.CATApi();
+        ServicesConfiguration.EvidenceApi evidenceApi = new ServicesConfiguration.EvidenceApi();
 
         ServicesConfiguration.HardshipApi.Endpoints hardshipEndpoints =
                 new ServicesConfiguration.HardshipApi.Endpoints(
@@ -60,6 +61,10 @@ public class MockServicesConfiguration {
                 "/api/internal/v1/application-tracking-output-result"
         );
 
+        ServicesConfiguration.EvidenceApi.Endpoints evidenceEndpoints = new ServicesConfiguration.EvidenceApi.Endpoints(
+                "/api/internal/v1/evidence"
+        );
+
         hardshipApi.setBaseUrl(host);
         hardshipApi.setEndpoints(hardshipEndpoints);
 
@@ -75,7 +80,11 @@ public class MockServicesConfiguration {
         maatApi.setBaseUrl(host);
         maatApi.setEndpoints(maatEndpoints);
         maatApi.setUserEndpoints(userEndpoints);
+
         catApi.setEndpoints(catEndpoints);
+
+        evidenceApi.setBaseUrl(host);
+        evidenceApi.setEndpoints(evidenceEndpoints);
 
         servicesConfiguration.setHardshipApi(hardshipApi);
         servicesConfiguration.setContributionApi(contributionApi);
@@ -83,6 +92,7 @@ public class MockServicesConfiguration {
         servicesConfiguration.setCmaApi(cmaApi);
         servicesConfiguration.setMaatApi(maatApi);
         servicesConfiguration.setCatApi(catApi);
+        servicesConfiguration.setEvidenceApi(evidenceApi);
 
         return servicesConfiguration;
     }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/Constants.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/Constants.java
@@ -10,7 +10,7 @@ import java.util.Date;
 
 public class Constants {
 
-    public static final BigDecimal DISPOSABLE_INCOME = BigDecimal.valueOf(12000);
+    public static final BigDecimal DISPOSABLE_INCOME = BigDecimal.valueOf(12000.0);
     public static final BigDecimal POST_HARDSHIP_DISPOSABLE_INCOME = BigDecimal.valueOf(5000);
     public static final Integer FINANCIAL_ASSESSMENT_ID = 321;
     public static final Integer HARDSHIP_REVIEW_ID = 1000;

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/MeansAssessmentDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/MeansAssessmentDataBuilder.java
@@ -3,6 +3,7 @@ package uk.gov.justice.laa.crime.orchestration.data.builder;
 import org.springframework.stereotype.Component;
 import uk.gov.justice.laa.crime.common.model.common.ApiUserSession;
 import uk.gov.justice.laa.crime.common.model.meansassessment.*;
+import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.MaatApiAssessmentResponse;
 import uk.gov.justice.laa.crime.enums.*;
 import uk.gov.justice.laa.crime.orchestration.data.Constants;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
@@ -97,7 +98,7 @@ public class MeansAssessmentDataBuilder {
     public static final BigDecimal ADJUSTED_LIVING_ALLOWANCE = BigDecimal.valueOf(15600.00);
     public static final String RESULT_REASON = "FullAssessmentResult.PASS.getReason()";
     public static final String CRITERIA_DETAIL_CODE = "Mock assessment detail code";
-    public static final String ASSESSMENT_DESCRIPTION = "Mock assessment description";
+    public static final String ASSESSMENT_DESCRIPTION = "Income from Private Pension(s)";
     public static final BigDecimal PARTNER_AMOUNT = BigDecimal.valueOf(2000);
     private static final LocalDateTime DATE_MODIFIED = LocalDateTime.of(2023, 10, 13, 10, 15, 30);
     private static final ZonedDateTime TIME_STAMP =  toZonedDateTime(DATE_MODIFIED);
@@ -414,7 +415,7 @@ public class MeansAssessmentDataBuilder {
                 .build();
     }
 
-    private static EvidenceDTO getApplicantEvidenceDTO() {
+    public static EvidenceDTO getApplicantEvidenceDTO() {
         return EvidenceDTO.builder()
                 .id(APPLICANT_EVIDENCE_ID.longValue())
                 .evidenceTypeDTO(getEvidenceTypeDTO())
@@ -423,7 +424,7 @@ public class MeansAssessmentDataBuilder {
                 .build();
     }
 
-    private static EvidenceDTO getPartnerEvidenceDTO() {
+   public static EvidenceDTO getPartnerEvidenceDTO() {
         return EvidenceDTO.builder()
                 .id(PARTNER_EVIDENCE_ID.longValue())
                 .evidenceTypeDTO(getEvidenceTypeDTO())
@@ -580,32 +581,37 @@ public class MeansAssessmentDataBuilder {
                 .withFirstReminderDate(FIRST_REMINDER_DATE)
                 .withSecondReminderDate(SECOND_REMINDER_DATE)
                 .withUpliftRemovedDate(INCOME_UPLIFT_REMOVE_DATE)
-                .withIncomeEvidence(getIncomeEvidence());
+                .withIncomeEvidence(getIncomeEvidence(true));
     }
 
-    private static List<ApiIncomeEvidence> getIncomeEvidence() {
-        return List.of(
-                new ApiIncomeEvidence()
-                        .withId(APPLICANT_EVIDENCE_ID)
-                        .withApplicantId(Constants.APPLICANT_ID)
-                        .withDateReceived(APPLICANT_EVIDENCE_RECEIVED_DATE)
-                        .withDateModified(DATE_MODIFIED)
-                        .withApiEvidenceType(getApiEvidenceType()),
-                new ApiIncomeEvidence()
-                        .withId(PARTNER_EVIDENCE_ID)
-                        .withApplicantId(PARTNER_ID)
-                        .withDateReceived(PARTNER_EVIDENCE_RECEIVED_DATE)
-                        .withDateModified(DATE_MODIFIED)
-                        .withApiEvidenceType(getApiEvidenceType()),
-                new ApiIncomeEvidence()
-                        .withAdhoc("Y")
-                        .withId(EXTRA_EVIDENCE_ID)
-                        .withApiEvidenceType(getApiEvidenceType())
-                        .withDateReceived(DATETIME_RECEIVED)
-                        .withOtherText(OTHER_DESCRIPTION)
-                        .withMandatory("true")
-                        .withDateModified(DATE_MODIFIED)
-        );
+    public static List<ApiIncomeEvidence> getIncomeEvidence(boolean withExtra) {
+        List<ApiIncomeEvidence> incomeEvidences = new ArrayList<>();
+
+        incomeEvidences.add(new ApiIncomeEvidence()
+                .withId(APPLICANT_EVIDENCE_ID)
+                .withApplicantId(Constants.APPLICANT_ID)
+                .withDateReceived(APPLICANT_EVIDENCE_RECEIVED_DATE)
+                .withDateModified(DATE_MODIFIED)
+                .withApiEvidenceType(getApiEvidenceType()));
+        incomeEvidences.add(new ApiIncomeEvidence()
+                .withId(PARTNER_EVIDENCE_ID)
+                .withApplicantId(PARTNER_ID)
+                .withDateReceived(PARTNER_EVIDENCE_RECEIVED_DATE)
+                .withDateModified(DATE_MODIFIED)
+                .withApiEvidenceType(getApiEvidenceType()));
+
+        if (withExtra) {
+            incomeEvidences.add(new ApiIncomeEvidence()
+                    .withAdhoc("Y")
+                    .withId(EXTRA_EVIDENCE_ID)
+                    .withApiEvidenceType(getApiEvidenceType())
+                    .withDateReceived(DATETIME_RECEIVED)
+                    .withOtherText(OTHER_DESCRIPTION)
+                    .withMandatory("true")
+                    .withDateModified(DATE_MODIFIED));
+        }
+
+        return incomeEvidences;
     }
 
     private static ApiEvidenceType getApiEvidenceType() {

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/MeansAssessmentDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/MeansAssessmentDataBuilder.java
@@ -3,7 +3,6 @@ package uk.gov.justice.laa.crime.orchestration.data.builder;
 import org.springframework.stereotype.Component;
 import uk.gov.justice.laa.crime.common.model.common.ApiUserSession;
 import uk.gov.justice.laa.crime.common.model.meansassessment.*;
-import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.MaatApiAssessmentResponse;
 import uk.gov.justice.laa.crime.enums.*;
 import uk.gov.justice.laa.crime.orchestration.data.Constants;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/MeansAssessmentDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/MeansAssessmentDataBuilder.java
@@ -730,7 +730,8 @@ public class MeansAssessmentDataBuilder {
                 .withTotalAnnualDisposableIncome(ANNUAL_DISPOSABLE_INCOME)
                 .withTransactionDateTime(APPLICATION_TIMESTAMP)
                 .withUpdated(APPLICATION_TIMESTAMP)
-                .withUpperThreshold(UPPER_THRESHOLD);
+                .withUpperThreshold(UPPER_THRESHOLD)
+                .withDateCompleted(DATE_MODIFIED);
 
     }
 

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/MeansAssessmentDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/MeansAssessmentDataBuilder.java
@@ -293,7 +293,7 @@ public class MeansAssessmentDataBuilder {
                 .build();
     }
 
-    private static AssessmentDetailDTO getSectionDetail() {
+    public static AssessmentDetailDTO getSectionDetail() {
         return AssessmentDetailDTO.builder()
                 .id(ASSESSMENT_DETAIL_ID.longValue())
                 .applicantAmount(APPLICANT_VALUE.doubleValue())

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/TestModelDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/TestModelDataBuilder.java
@@ -136,7 +136,7 @@ public class TestModelDataBuilder {
     public static final LocalDateTime EVIDENCE_RECEIVED_DATE = LocalDateTime.of(2023, 11, 11, 0, 0, 0);
     public static final long APPLICANT_ID = 1000L;
     public static final long PARTNER_ID = 1234L;
-    public static final String EMST_CODE ="EMST_CODE";
+    public static final String EMST_CODE ="EMPLOY";
     public static final LocalDateTime INCOME_EVIDENCE_RECEIVED_DATE = LocalDateTime.of(2023, 11, 11, 0, 0, 0);
 
 

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/TestModelDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/TestModelDataBuilder.java
@@ -5,6 +5,9 @@ import org.springframework.stereotype.Component;
 import uk.gov.justice.laa.crime.common.model.common.ApiCrownCourtOutcome;
 import uk.gov.justice.laa.crime.common.model.contribution.ApiMaatCalculateContributionResponse;
 import uk.gov.justice.laa.crime.common.model.contribution.common.ApiContributionSummary;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiApplicantDetails;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceRequest;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiIncomeEvidenceMetadata;
 import uk.gov.justice.laa.crime.common.model.hardship.*;
 import uk.gov.justice.laa.crime.common.model.proceeding.common.ApiCapitalEvidence;
 import uk.gov.justice.laa.crime.common.model.proceeding.common.ApiCrownCourtSummary;
@@ -25,6 +28,7 @@ import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RoleDataItemDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.validation.ReservationsDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.validation.UserActionDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.validation.UserSummaryDTO;
+import uk.gov.justice.laa.crime.util.NumberUtils;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -63,6 +67,7 @@ public class TestModelDataBuilder {
     private static final Integer EXTRA_EVIDENCE_ID = 9552475;
     private static final String INCOME_EVIDENCE_DESCRIPTION = "Tax Return";
     private static final String INCOME_EVIDENCE = "TAX RETURN";
+    private static final String INCOME_EVIDENCE_NOTES = "Income evidence notes";
     private static final String EVIDENCE_FEE_LEVEL_1 = "LEVEL1";
     public static final Integer PASSPORTED_ID = 777;
     private static final Integer APPLICANT_HISTORY_ID = 666;
@@ -128,6 +133,7 @@ public class TestModelDataBuilder {
     private static final Integer TEST_RECORD_ID = 100;
     private static final LocalDateTime RESERVATION_DATE = LocalDateTime.of(2022, 12, 14, 0, 0, 0);
     public static final LocalDateTime EVIDENCE_RECEIVED_DATE = LocalDateTime.of(2023, 11, 11, 0, 0, 0);
+    public static final long APPLICANT_ID = 1000L;
     public static final long PARTNER_ID = 1234L;
     public static final String EMST_CODE ="EMST_CODE";
     public static final LocalDateTime INCOME_EVIDENCE_RECEIVED_DATE = LocalDateTime.of(2023, 11, 11, 0, 0, 0);
@@ -605,7 +611,7 @@ public class TestModelDataBuilder {
 
     public static ApplicantDTO getApplicantDTO() {
         return ApplicantDTO.builder()
-                .id(1000L)
+                .id(APPLICANT_ID)
                 .applicantHistoryId(APPLICANT_HISTORY_ID.longValue())
                 .employmentStatusDTO(getEmploymentStatusDTO())
                 .build();
@@ -956,7 +962,7 @@ public class TestModelDataBuilder {
         return IncomeEvidenceSummaryDTO.builder()
                 .upliftAppliedDate(toDate(LocalDateTime.of(2023, 11, 18, 0, 0, 0)))
                 .upliftRemovedDate(toDate(LocalDateTime.of(2023, 11, 18, 0, 0, 0)))
-                .incomeEvidenceNotes("Income Evidence Notes")
+                .incomeEvidenceNotes(INCOME_EVIDENCE_NOTES)
                 .extraEvidenceList(List.of(getExtraEvidenceDTO()))
                 .applicantIncomeEvidenceList(List.of(getEvidenceDTO(APPLICANT_EVIDENCE_ID)))
                 .partnerIncomeEvidenceList(List.of(getEvidenceDTO(PARTNER_EVIDENCE_ID)))
@@ -1342,5 +1348,29 @@ public class TestModelDataBuilder {
                 .result(RESULT_FAIL)
                 .reviewType(RT_CODE_ER)
                 .build();
+    }
+
+    public static ApiCreateIncomeEvidenceRequest getApiCreateEvidenceRequest(boolean isPartner) {
+        return new ApiCreateIncomeEvidenceRequest()
+                .withMagCourtOutcome(MagCourtOutcome.SENT_FOR_TRIAL)
+                .withApplicantDetails(getApplicantDetails(false))
+                .withPartnerDetails(isPartner ? getApplicantDetails(true) : null)
+                .withApplicantPensionAmount(BigDecimal.valueOf(1000.0 * Frequency.MONTHLY.getWeighting()))
+                .withPartnerPensionAmount(isPartner ? BigDecimal.valueOf(2000.0 * Frequency.TWO_WEEKLY.getWeighting()) : null)
+                .withMetadata(getMetadata());
+    }
+
+    public static ApiApplicantDetails getApplicantDetails(boolean isPartner) {
+        return new ApiApplicantDetails()
+                .withId(isPartner ? NumberUtils.toInteger(PARTNER_ID) : NumberUtils.toInteger(APPLICANT_ID))
+                .withEmploymentStatus(EmploymentStatus.EMPLOY);
+    }
+
+    public static ApiIncomeEvidenceMetadata getMetadata() {
+        return new ApiIncomeEvidenceMetadata()
+                .withApplicationReceivedDate(DATETIME_RECEIVED.toLocalDate())
+                .withEvidencePending(false)
+                .withNotes(INCOME_EVIDENCE_NOTES)
+                .withUserSession(getApiUserSession());
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/TestModelDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/TestModelDataBuilder.java
@@ -9,6 +9,8 @@ import uk.gov.justice.laa.crime.common.model.evidence.ApiApplicantDetails;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceRequest;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiIncomeEvidenceMetadata;
 import uk.gov.justice.laa.crime.common.model.hardship.*;
+import uk.gov.justice.laa.crime.common.model.meansassessment.ApiAssessmentChildWeighting;
+import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.MaatApiUpdateAssessment;
 import uk.gov.justice.laa.crime.common.model.proceeding.common.ApiCapitalEvidence;
 import uk.gov.justice.laa.crime.common.model.proceeding.common.ApiCrownCourtSummary;
 import uk.gov.justice.laa.crime.common.model.proceeding.common.ApiIOJSummary;
@@ -28,6 +30,7 @@ import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RoleDataItemDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.validation.ReservationsDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.validation.UserActionDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.validation.UserSummaryDTO;
+import uk.gov.justice.laa.crime.util.DateUtil;
 import uk.gov.justice.laa.crime.util.NumberUtils;
 
 import java.math.BigDecimal;
@@ -1360,17 +1363,65 @@ public class TestModelDataBuilder {
                 .withMetadata(getMetadata());
     }
 
-    public static ApiApplicantDetails getApplicantDetails(boolean isPartner) {
+    private static ApiApplicantDetails getApplicantDetails(boolean isPartner) {
         return new ApiApplicantDetails()
                 .withId(isPartner ? NumberUtils.toInteger(PARTNER_ID) : NumberUtils.toInteger(APPLICANT_ID))
                 .withEmploymentStatus(EmploymentStatus.EMPLOY);
     }
 
-    public static ApiIncomeEvidenceMetadata getMetadata() {
+    private static ApiIncomeEvidenceMetadata getMetadata() {
         return new ApiIncomeEvidenceMetadata()
                 .withApplicationReceivedDate(DATETIME_RECEIVED.toLocalDate())
                 .withEvidencePending(false)
                 .withNotes(INCOME_EVIDENCE_NOTES)
                 .withUserSession(getApiUserSession());
+    }
+
+    public static MaatApiUpdateAssessment getMaatApiUpdateAssessment(AssessmentType assessmentType) {
+        MaatApiUpdateAssessment maatApiUpdateAssessment = new MaatApiUpdateAssessment()
+                .withFinancialAssessmentId(Constants.FINANCIAL_ASSESSMENT_ID)
+                .withUserModified(Constants.USERNAME)
+                .withFinAssIncomeEvidences() // TODO complete this
+                .withRepId(REP_ID)
+                .withAssessmentType(assessmentType.getType())
+                .withCmuId(CMU_ID)
+                .withFassInitStatus(AssessmentStatusDTO.COMPLETE)
+                .withInitialAssessmentDate(null)
+                .withInitOtherBenefitNote(null)
+                .withInitOtherIncomeNote(null)
+                .withInitTotAggregatedIncome(TOTAL_AGGREGATED_INCOME)
+                .withInitAdjustedIncomeValue(null)
+                .withInitNotes(null)
+                .withInitResult(RESULT_FAIL)
+                .withInitResultReason(null)
+                .withInitialAscrId(null)
+                .withInitApplicationEmploymentStatus("EMPLOY")
+                .withAssessmentDetails() // TODO complete this need to build this
+                .withChildWeightings(getAssessmentChildWeightings())
+                .withDateCompleted(null);
+
+        if (AssessmentType.FULL.equals(assessmentType)) {
+            maatApiUpdateAssessment.setFassFullStatus(AssessmentStatusDTO.COMPLETE);
+            maatApiUpdateAssessment.setFullAssessmentDate(LocalDateTime.ofInstant(ASSESSMENT_DATE.toInstant(), ZoneId.systemDefault()));
+            maatApiUpdateAssessment.setFullResult(RESULT_PASS);
+            maatApiUpdateAssessment.setFullResultReason(null);
+            maatApiUpdateAssessment.setFullAssessmentNotes(ASSESSMENT_NOTES);
+            maatApiUpdateAssessment.setFullAdjustedLivingAllowance(null);
+            maatApiUpdateAssessment.setFullTotalAnnualDisposableIncome(Constants.DISPOSABLE_INCOME);
+            maatApiUpdateAssessment.setFullOtherHousingNote(OTHER_HOUSING_NOTES);
+            maatApiUpdateAssessment.setFullTotalAggregatedExpenses(null);
+            maatApiUpdateAssessment.setFullAscrId(null);
+        }
+
+        return maatApiUpdateAssessment;
+    }
+
+    private static List<ApiAssessmentChildWeighting> getAssessmentChildWeightings() {
+        return List.of(
+                new ApiAssessmentChildWeighting()
+                        .withId(1234)
+                        .withChildWeightingId(37)
+                        .withNoOfChildren(1)
+        );
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/IncomeEvidenceMapperTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/IncomeEvidenceMapperTest.java
@@ -9,18 +9,23 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceRequest;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceResponse;
 import uk.gov.justice.laa.crime.common.model.meansassessment.ApiIncomeEvidence;
 import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.MaatApiAssessmentResponse;
+import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.MaatApiUpdateAssessment;
+import uk.gov.justice.laa.crime.enums.AssessmentType;
 import uk.gov.justice.laa.crime.enums.CourtType;
 import uk.gov.justice.laa.crime.orchestration.data.builder.MeansAssessmentDataBuilder;
 import uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.UserDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
 
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -68,12 +73,42 @@ public class IncomeEvidenceMapperTest {
 
     @Test
     void givenInitialAssessment_whenMapToMaatApiUpdateAssessmentIsInvoked_thenMaatApiUpdateAssessmentIsReturned() {
+        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest(); // full not available
+        RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTO("CURR");
+        ApiCreateIncomeEvidenceResponse apiCreateIncomeEvidenceResponse = ???;
 
+        when(meansAssessmentMapper.assessmentDetailsBuilder(anyList()))
+                .thenReturn();
+        when(meansAssessmentMapper.childWeightingsBuilder(anyList()))
+                .thenReturn();
+
+        MaatApiUpdateAssessment maatApiUpdateAssessment =
+                incomeEvidenceMapper.mapToMaatApiUpdateAssessment(workflowRequest, repOrderDTO, apiCreateIncomeEvidenceResponse);
+
+        softly.assertThat(maatApiUpdateAssessment)
+                .usingRecursiveComparison()
+                .ignoringFields("laaTransactionId")
+                .isEqualTo(TestModelDataBuilder.getMaatApiUpdateAssessment(AssessmentType.INIT));
     }
 
     @Test
     void givenFullAssessment_whenMapToMaatApiUpdateAssessmentIsInvoked_thenMaatApiUpdateAssessmentIsReturned() {
+        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest(CourtType.CROWN_COURT); // full
+        RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTO("CURR"); // TODO this might not be right
+        ApiCreateIncomeEvidenceResponse apiCreateIncomeEvidenceResponse = ???;
 
+        when(meansAssessmentMapper.assessmentDetailsBuilder(anyList()))
+                .thenReturn();
+        when(meansAssessmentMapper.childWeightingsBuilder(anyList()))
+                .thenReturn();
+
+        MaatApiUpdateAssessment maatApiUpdateAssessment =
+                incomeEvidenceMapper.mapToMaatApiUpdateAssessment(workflowRequest, repOrderDTO, apiCreateIncomeEvidenceResponse);
+
+        softly.assertThat(maatApiUpdateAssessment)
+                .usingRecursiveComparison()
+                .ignoringFields("laaTransactionId")
+                .isEqualTo(TestModelDataBuilder.getMaatApiUpdateAssessment(AssessmentType.FULL));
     }
 
     @Test

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/IncomeEvidenceMapperTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/IncomeEvidenceMapperTest.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(SoftAssertionsExtension.class)
-public class IncomeEvidenceMapperTest {
+class IncomeEvidenceMapperTest {
 
     @Mock
     private UserMapper userMapper;
@@ -54,6 +54,7 @@ public class IncomeEvidenceMapperTest {
         softly.assertThat(apiCreateIncomeEvidenceRequest)
                 .usingRecursiveComparison()
                 .isEqualTo(TestModelDataBuilder.getApiCreateEvidenceRequest(false));
+        softly.assertAll();
     }
 
     @Test
@@ -69,6 +70,7 @@ public class IncomeEvidenceMapperTest {
         softly.assertThat(apiCreateIncomeEvidenceRequest)
                 .usingRecursiveComparison()
                 .isEqualTo(TestModelDataBuilder.getApiCreateEvidenceRequest(true));
+        softly.assertAll();
     }
 
     @Test
@@ -90,6 +92,7 @@ public class IncomeEvidenceMapperTest {
                 .usingRecursiveComparison()
                 .ignoringFields("laaTransactionId")
                 .isEqualTo(TestModelDataBuilder.getMaatApiUpdateAssessment(AssessmentType.INIT));
+        softly.assertAll();
     }
 
     @Test
@@ -111,6 +114,7 @@ public class IncomeEvidenceMapperTest {
                 .usingRecursiveComparison()
                 .ignoringFields("laaTransactionId")
                 .isEqualTo(TestModelDataBuilder.getMaatApiUpdateAssessment(AssessmentType.FULL));
+        softly.assertAll();
     }
 
     @Test
@@ -131,5 +135,6 @@ public class IncomeEvidenceMapperTest {
                 .isEqualTo(List.of(MeansAssessmentDataBuilder.getApplicantEvidenceDTO()));
         softly.assertThat(applicationDTO.getAssessmentDTO().getFinancialAssessmentDTO().getIncomeEvidence().getPartnerIncomeEvidenceList())
                 .isEqualTo(List.of(MeansAssessmentDataBuilder.getPartnerEvidenceDTO()));
+        softly.assertAll();
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/IncomeEvidenceMapperTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/IncomeEvidenceMapperTest.java
@@ -1,0 +1,98 @@
+package uk.gov.justice.laa.crime.orchestration.mapper;
+
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceRequest;
+import uk.gov.justice.laa.crime.common.model.meansassessment.ApiIncomeEvidence;
+import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.MaatApiAssessmentResponse;
+import uk.gov.justice.laa.crime.enums.CourtType;
+import uk.gov.justice.laa.crime.orchestration.data.builder.MeansAssessmentDataBuilder;
+import uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder;
+import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.UserDTO;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(SoftAssertionsExtension.class)
+public class IncomeEvidenceMapperTest {
+
+    @Mock
+    private UserMapper userMapper;
+    @Mock
+    private MeansAssessmentMapper meansAssessmentMapper;
+    @InjectMocks
+    private IncomeEvidenceMapper incomeEvidenceMapper;
+    @InjectSoftAssertions
+    private SoftAssertions softly;
+
+    @Test
+    void givenValidWorkflowRequest_whenWorkflowRequestToApiCreateIncomeEvidenceRequestIsInvoked_thenApiCreateIncomeEvidenceRequestIsReturned() {
+        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest(CourtType.CROWN_COURT);
+
+        when(userMapper.userDtoToUserSession(any(UserDTO.class)))
+                .thenReturn(TestModelDataBuilder.getApiUserSession());
+
+        ApiCreateIncomeEvidenceRequest apiCreateIncomeEvidenceRequest =
+                incomeEvidenceMapper.workflowRequestToApiCreateIncomeEvidenceRequest(workflowRequest);
+
+        softly.assertThat(apiCreateIncomeEvidenceRequest)
+                .usingRecursiveComparison()
+                .isEqualTo(TestModelDataBuilder.getApiCreateEvidenceRequest(false));
+    }
+
+    @Test
+    void givenWorkflowRequestWithPartner_whenWorkflowRequestToApiCreateIncomeEvidenceRequestIsInvoked_thenApiCreateIncomeEvidenceRequestIsReturned() {
+        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
+
+        when(userMapper.userDtoToUserSession(any(UserDTO.class)))
+                .thenReturn(TestModelDataBuilder.getApiUserSession());
+
+        ApiCreateIncomeEvidenceRequest apiCreateIncomeEvidenceRequest =
+                incomeEvidenceMapper.workflowRequestToApiCreateIncomeEvidenceRequest(workflowRequest);
+
+        softly.assertThat(apiCreateIncomeEvidenceRequest)
+                .usingRecursiveComparison()
+                .isEqualTo(TestModelDataBuilder.getApiCreateEvidenceRequest(true));
+    }
+
+    @Test
+    void givenInitialAssessment_whenMapToMaatApiUpdateAssessmentIsInvoked_thenMaatApiUpdateAssessmentIsReturned() {
+
+    }
+
+    @Test
+    void givenFullAssessment_whenMapToMaatApiUpdateAssessmentIsInvoked_thenMaatApiUpdateAssessmentIsReturned() {
+
+    }
+
+    @Test
+    void givenValidParams_whenMaatApiAssessmentResponseToApplicationDTOIsInvoked_thenApplicationDTOIsUpdated() {
+        List<ApiIncomeEvidence> incomeEvidences = MeansAssessmentDataBuilder.getIncomeEvidence(false);
+        MaatApiAssessmentResponse maatApiAssessmentResponse =
+                new MaatApiAssessmentResponse().withIncomeEvidence(incomeEvidences);
+        ApplicationDTO applicationDTO = MeansAssessmentDataBuilder.getApplicationDTO();
+
+        when(meansAssessmentMapper.getEvidenceDTO(incomeEvidences.get(0)))
+                .thenReturn(MeansAssessmentDataBuilder.getApplicantEvidenceDTO());
+        when(meansAssessmentMapper.getEvidenceDTO(incomeEvidences.get(1)))
+                .thenReturn(MeansAssessmentDataBuilder.getPartnerEvidenceDTO());
+
+        incomeEvidenceMapper.maatApiAssessmentResponseToApplicationDTO(maatApiAssessmentResponse, applicationDTO);
+
+        softly.assertThat(applicationDTO.getAssessmentDTO().getFinancialAssessmentDTO().getIncomeEvidence().getApplicantIncomeEvidenceList())
+                .isEqualTo(List.of(MeansAssessmentDataBuilder.getApplicantEvidenceDTO()));
+        softly.assertThat(applicationDTO.getAssessmentDTO().getFinancialAssessmentDTO().getIncomeEvidence().getPartnerIncomeEvidenceList())
+                .isEqualTo(List.of(MeansAssessmentDataBuilder.getPartnerEvidenceDTO()));
+    }
+}

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/IncomeEvidenceMapperTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/IncomeEvidenceMapperTest.java
@@ -73,14 +73,15 @@ public class IncomeEvidenceMapperTest {
 
     @Test
     void givenInitialAssessment_whenMapToMaatApiUpdateAssessmentIsInvoked_thenMaatApiUpdateAssessmentIsReturned() {
-        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest(); // full not available
+        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest(); // need to set full available to false
         RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTO("CURR");
-        ApiCreateIncomeEvidenceResponse apiCreateIncomeEvidenceResponse = ???;
+        repOrderDTO.setFinancialAssessments(List.of(TestModelDataBuilder.getMaatApiFinancialAssessmentDTO()));
+        ApiCreateIncomeEvidenceResponse apiCreateIncomeEvidenceResponse = TestModelDataBuilder.getCreateIncomeEvidenceResponse();
 
         when(meansAssessmentMapper.assessmentDetailsBuilder(anyList()))
-                .thenReturn();
+                .thenReturn(List.of(TestModelDataBuilder.getAssessmentDetail()));
         when(meansAssessmentMapper.childWeightingsBuilder(anyList()))
-                .thenReturn();
+                .thenReturn(List.of(TestModelDataBuilder.getAssessmentChildWeighting()));
 
         MaatApiUpdateAssessment maatApiUpdateAssessment =
                 incomeEvidenceMapper.mapToMaatApiUpdateAssessment(workflowRequest, repOrderDTO, apiCreateIncomeEvidenceResponse);
@@ -94,13 +95,14 @@ public class IncomeEvidenceMapperTest {
     @Test
     void givenFullAssessment_whenMapToMaatApiUpdateAssessmentIsInvoked_thenMaatApiUpdateAssessmentIsReturned() {
         WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest(CourtType.CROWN_COURT); // full
-        RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTO("CURR"); // TODO this might not be right
-        ApiCreateIncomeEvidenceResponse apiCreateIncomeEvidenceResponse = ???;
+        RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTO("CURR");
+        repOrderDTO.setFinancialAssessments(List.of(TestModelDataBuilder.getMaatApiFinancialAssessmentDTO()));
+        ApiCreateIncomeEvidenceResponse apiCreateIncomeEvidenceResponse = TestModelDataBuilder.getCreateIncomeEvidenceResponse();
 
         when(meansAssessmentMapper.assessmentDetailsBuilder(anyList()))
-                .thenReturn();
+                .thenReturn(List.of(TestModelDataBuilder.getAssessmentDetail()));
         when(meansAssessmentMapper.childWeightingsBuilder(anyList()))
-                .thenReturn();
+                .thenReturn(List.of(TestModelDataBuilder.getAssessmentChildWeighting()));
 
         MaatApiUpdateAssessment maatApiUpdateAssessment =
                 incomeEvidenceMapper.mapToMaatApiUpdateAssessment(workflowRequest, repOrderDTO, apiCreateIncomeEvidenceResponse);

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/MeansAssessmentMapperTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/MeansAssessmentMapperTest.java
@@ -295,6 +295,8 @@ class MeansAssessmentMapperTest {
                 .isEqualTo(apiMeansAssessmentResponse.getAssessmentId().intValue());
         softly.assertThat(financialAssessmentDTO.getTimestamp().toLocalDateTime())
                 .isEqualTo(apiMeansAssessmentResponse.getUpdated());
+        softly.assertThat(financialAssessmentDTO.getDateCompleted())
+                .isEqualTo(apiMeansAssessmentResponse.getDateCompleted());
         softly.assertThat(fullAssessmentDTO.getResult())
                 .isEqualTo(apiMeansAssessmentResponse.getFullResult());
         softly.assertThat(fullAssessmentDTO.getAdjustedLivingAllowance())
@@ -346,6 +348,8 @@ class MeansAssessmentMapperTest {
                 .isEqualTo(apiMeansAssessmentResponse.getAssessmentId().intValue());
         softly.assertThat(financialAssessmentDTO.getTimestamp().toLocalDateTime())
                 .isEqualTo(apiMeansAssessmentResponse.getUpdated());
+        softly.assertThat(financialAssessmentDTO.getDateCompleted())
+                .isEqualTo(apiMeansAssessmentResponse.getDateCompleted());
         softly.assertThat(financialAssessmentDTO.getFullAvailable())
                 .isEqualTo(apiMeansAssessmentResponse.getFullAssessmentAvailable());
         softly.assertThat(initialAssessmentDTO.getLowerThreshold())

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/IncomeEvidenceServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/IncomeEvidenceServiceTest.java
@@ -11,6 +11,7 @@ import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.MaatApiAsse
 import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.MaatApiUpdateAssessment;
 import uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
 import uk.gov.justice.laa.crime.orchestration.mapper.IncomeEvidenceMapper;
 import uk.gov.justice.laa.crime.orchestration.service.api.EvidenceApiService;
@@ -37,11 +38,11 @@ class IncomeEvidenceServiceTest {
         WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
         RepOrderDTO repOrder = TestModelDataBuilder.buildRepOrderDTO("CURR");
 
-        when(incomeEvidenceMapper.workflowRequestToApiCreateIncomeEvidenceRequest(workflowRequest))
+        when(incomeEvidenceMapper.workflowRequestToApiCreateIncomeEvidenceRequest(any(WorkflowRequest.class)))
                 .thenReturn(new ApiCreateIncomeEvidenceRequest());
         when(evidenceApiService.createEvidence(any(ApiCreateIncomeEvidenceRequest.class)))
                 .thenReturn(new ApiCreateIncomeEvidenceResponse());
-        when(incomeEvidenceMapper.mapToMaatApiUpdateAssessment(workflowRequest, repOrder, any(ApiCreateIncomeEvidenceResponse.class)))
+        when(incomeEvidenceMapper.mapToMaatApiUpdateAssessment(any(WorkflowRequest.class), any(RepOrderDTO.class), any(ApiCreateIncomeEvidenceResponse.class)))
                 .thenReturn(new MaatApiUpdateAssessment());
         when(maatCourtDataApiService.updateFinancialAssessment(any(MaatApiUpdateAssessment.class)))
                 .thenReturn(new MaatApiAssessmentResponse());
@@ -51,7 +52,7 @@ class IncomeEvidenceServiceTest {
         verify(evidenceApiService).createEvidence(any(ApiCreateIncomeEvidenceRequest.class));
         verify(maatCourtDataApiService).updateFinancialAssessment(any(MaatApiUpdateAssessment.class));
         verify(incomeEvidenceMapper).maatApiAssessmentResponseToApplicationDTO(any(MaatApiAssessmentResponse.class),
-                workflowRequest.getApplicationDTO());
+                any(ApplicationDTO.class));
     }
 }
 

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/IncomeEvidenceServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/IncomeEvidenceServiceTest.java
@@ -1,0 +1,57 @@
+package uk.gov.justice.laa.crime.orchestration.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceRequest;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceResponse;
+import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.MaatApiAssessmentResponse;
+import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.MaatApiUpdateAssessment;
+import uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder;
+import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
+import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
+import uk.gov.justice.laa.crime.orchestration.mapper.IncomeEvidenceMapper;
+import uk.gov.justice.laa.crime.orchestration.service.api.EvidenceApiService;
+import uk.gov.justice.laa.crime.orchestration.service.api.MaatCourtDataApiService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class IncomeEvidenceServiceTest {
+
+    @Mock
+    private EvidenceApiService evidenceApiService;
+    @Mock
+    private MaatCourtDataApiService maatCourtDataApiService;
+    @Mock
+    private IncomeEvidenceMapper incomeEvidenceMapper;
+    @InjectMocks
+    private IncomeEvidenceService incomeEvidenceService;
+
+    @Test
+    void givenValidWorkflowRequestAndRepOrder_whenCreateEvidenceIsInvoked_thenApiServicesCalledAndResponseMapped() {
+        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
+        RepOrderDTO repOrder = TestModelDataBuilder.buildRepOrderDTO("CURR");
+
+        when(incomeEvidenceMapper.workflowRequestToApiCreateIncomeEvidenceRequest(workflowRequest))
+                .thenReturn(new ApiCreateIncomeEvidenceRequest());
+        when(evidenceApiService.createEvidence(any(ApiCreateIncomeEvidenceRequest.class)))
+                .thenReturn(new ApiCreateIncomeEvidenceResponse());
+        when(incomeEvidenceMapper.mapToMaatApiUpdateAssessment(workflowRequest, repOrder, any(ApiCreateIncomeEvidenceResponse.class)))
+                .thenReturn(new MaatApiUpdateAssessment());
+        when(maatCourtDataApiService.updateFinancialAssessment(any(MaatApiUpdateAssessment.class)))
+                .thenReturn(new MaatApiAssessmentResponse());
+
+        incomeEvidenceService.createEvidence(workflowRequest, repOrder);
+
+        verify(evidenceApiService).createEvidence(any(ApiCreateIncomeEvidenceRequest.class));
+        verify(maatCourtDataApiService).updateFinancialAssessment(any(MaatApiUpdateAssessment.class));
+        verify(incomeEvidenceMapper).maatApiAssessmentResponseToApplicationDTO(any(MaatApiAssessmentResponse.class),
+                workflowRequest.getApplicationDTO());
+    }
+}
+

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/api/EvidenceApiServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/api/EvidenceApiServiceTest.java
@@ -5,9 +5,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceRequest;
 import uk.gov.justice.laa.crime.commons.client.RestAPIClient;
+import uk.gov.justice.laa.crime.orchestration.config.MockServicesConfiguration;
+import uk.gov.justice.laa.crime.orchestration.config.ServicesConfiguration;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.verify;
@@ -19,6 +22,9 @@ class EvidenceApiServiceTest {
     private RestAPIClient evidenceApiClient;
     @InjectMocks
     private EvidenceApiService evidenceApiService;
+
+    @Spy
+    private ServicesConfiguration configuration = MockServicesConfiguration.getConfiguration(1000);
 
     @Test
     void givenValidRequest_whenCreateEvidenceIsInvoked_thenApiCreateIncomeEvidenceResponseIsReturned() {

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/api/EvidenceApiServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/api/EvidenceApiServiceTest.java
@@ -1,0 +1,28 @@
+package uk.gov.justice.laa.crime.orchestration.service.api;
+
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceRequest;
+import uk.gov.justice.laa.crime.commons.client.RestAPIClient;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class EvidenceApiServiceTest {
+
+    @Mock
+    private RestAPIClient evidenceApiClient;
+    @InjectMocks
+    private EvidenceApiService evidenceApiService;
+
+    @Test
+    void givenValidRequest_whenCreateEvidenceIsInvoked_thenApiCreateIncomeEvidenceResponseIsReturned() {
+        evidenceApiService.createEvidence(new ApiCreateIncomeEvidenceRequest());
+        verify(evidenceApiClient).post(any(ApiCreateIncomeEvidenceRequest.class), any(), any(), any());
+    }
+}

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/api/MaatCourtDataApiServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/api/MaatCourtDataApiServiceTest.java
@@ -6,13 +6,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.MaatApiUpdateAssessment;
 import uk.gov.justice.laa.crime.commons.client.RestAPIClient;
 import uk.gov.justice.laa.crime.orchestration.config.MockServicesConfiguration;
 import uk.gov.justice.laa.crime.orchestration.config.ServicesConfiguration;
 import uk.gov.justice.laa.crime.orchestration.dto.StoredProcedureRequest;
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.SendToCCLFDTO;
-
-import java.util.HashMap;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.verify;
@@ -62,5 +61,11 @@ class MaatCourtDataApiServiceTest {
         maatCourtDataApiService.getFinancialAssessment(1000);
         verify(cmaApiClient)
                 .get(any(), any(), anyInt());
+    }
+
+    @Test
+    void givenValidRequest_whenUpdateFinancialAssessmentIsInvoked_thenMaatApiAssessmentResponseIsReturned() {
+        maatCourtDataApiService.updateFinancialAssessment(new MaatApiUpdateAssessment());
+        verify(cmaApiClient).put(any(MaatApiUpdateAssessment.class), any(), any(), any());
     }
 }

--- a/maat-orchestration/src/test/resources/application.yaml
+++ b/maat-orchestration/src/test/resources/application.yaml
@@ -22,6 +22,8 @@ spring:
             token-uri: http://localhost:${wiremock.server.port}/oauth2/token
           cat:
             token-uri: http://localhost:${wiremock.server.port}/oauth2/token
+          evidence:
+            token-uri: http://localhost:${wiremock.server.port}/oauth2/token
         registration:
           hardship:
             client-id: dummy-client
@@ -48,6 +50,10 @@ spring:
             client-secret: dummy-client
             authorization-grant-type: client_credentials
           cat:
+            client-id: dummy-client
+            client-secret: dummy-client
+            authorization-grant-type: client_credentials
+          evidence:
             client-id: dummy-client
             client-secret: dummy-client
             authorization-grant-type: client_credentials
@@ -100,6 +106,10 @@ services:
     base-url: http://localhost:${wiremock.server.port}
     endpoints:
       handle-eform-url: ${services.cat-api.base-url}/api/internal/v1/application-tracking-output-result
+  evidence-api:
+    base-url: http://localhost:${wiremock.server.port}
+    endpoints:
+      income-evidence-url: ${services.evidence-api.base-url}/api/internal/v1/evidence
 
 retry-config:
   max-retries: 2


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/projects/LCAM/boards/881?selectedIssue=LCAM-1621)

- Added configuration, service method and mapper to call the evidence service to create default evidence items.
- Added configuration, service method and mapper to call maat api to update the means assessment with the details of the new evidence items.
- Added method to sequence the above calls and update the workflow request with the details of the evidence items created.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.