### PR TITLE
Run Hardship and Means Assessment validations via WorkflowPreProcessorService

### DIFF
--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/enums/FeatureToggle.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/enums/FeatureToggle.java
@@ -5,8 +5,9 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public enum CurrentFeatureToggles {
-    CALCULATE_CONTRIBUTION("CalculateContribution");
+public enum FeatureToggle {
+    CALCULATE_CONTRIBUTION("CalculateContribution"),
+    MAAT_POST_ASSESSMENT_PROCESSING("MaatPostAssessmentProcessing");
 
     private final String name;
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/HardshipMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/HardshipMapper.java
@@ -298,13 +298,9 @@ public class HardshipMapper {
     }
 
     public UserActionDTO getUserActionDTO(WorkflowRequest request, Action action) {
-        UserDTO userDTO = request.getUserDTO();
         HardshipReviewDTO hardshipReviewDTO = getHardshipReviewDTO(request.getApplicationDTO(), request.getCourtType());
-        return UserActionDTO.builder()
-                .username(userDTO.getUserName())
-                .sessionId(userDTO.getUserSession())
-                .newWorkReason(NewWorkReason.getFrom(hardshipReviewDTO.getNewWorkReason().getCode()))
-                .action(action)
-                .build();
+        NewWorkReason newWorkReason = NewWorkReason.getFrom(hardshipReviewDTO.getNewWorkReason().getCode());
+
+        return userMapper.getUserActionDTO(request, action, newWorkReason);
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/MeansAssessmentMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/MeansAssessmentMapper.java
@@ -8,8 +8,10 @@ import org.springframework.stereotype.Component;
 import uk.gov.justice.laa.crime.common.model.meansassessment.*;
 import uk.gov.justice.laa.crime.enums.*;
 import uk.gov.justice.laa.crime.enums.evidence.IncomeEvidenceType;
+import uk.gov.justice.laa.crime.enums.orchestration.Action;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.*;
+import uk.gov.justice.laa.crime.orchestration.dto.validation.UserActionDTO;
 import uk.gov.justice.laa.crime.util.DateUtil;
 import uk.gov.justice.laa.crime.util.NumberUtils;
 
@@ -280,6 +282,18 @@ public class MeansAssessmentMapper {
                 .incomeEvidence(incomeEvidenceSummaryToDto(apiResponse.getIncomeEvidenceSummary(), applicantId))
                 .build();
 
+    }
+
+    public UserActionDTO getUserActionDto(WorkflowRequest request, Action action) {
+        ApplicationDTO application = request.getApplicationDTO();
+        FinancialAssessmentDTO financialAssessmentDTO = application.getAssessmentDTO().getFinancialAssessmentDTO();
+        InitialAssessmentDTO initialAssessment = financialAssessmentDTO.getInitial();
+        AssessmentType assessmentType = Boolean.TRUE.equals(financialAssessmentDTO.getFullAvailable())
+            ? AssessmentType.FULL : AssessmentType.INIT;
+        NewWorkReason newWorkReason = assessmentType == AssessmentType.INIT ?
+            NewWorkReason.getFrom(initialAssessment.getNewWorkReason().getCode()) : null;
+
+        return userMapper.getUserActionDTO(request, action, newWorkReason);
     }
 
     private IncomeEvidenceSummaryDTO incomeEvidenceSummaryToDto(ApiIncomeEvidenceSummary incomeEvidenceSummary,

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/UserMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/UserMapper.java
@@ -2,7 +2,11 @@ package uk.gov.justice.laa.crime.orchestration.mapper;
 
 import org.springframework.stereotype.Component;
 import uk.gov.justice.laa.crime.common.model.common.ApiUserSession;
+import uk.gov.justice.laa.crime.enums.NewWorkReason;
+import uk.gov.justice.laa.crime.enums.orchestration.Action;
+import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.UserDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.validation.UserActionDTO;
 
 @Component
 public class UserMapper {
@@ -10,5 +14,19 @@ public class UserMapper {
         return new ApiUserSession()
                 .withUserName(user.getUserName())
                 .withSessionId(user.getUserSession());
+    }
+
+    public UserActionDTO getUserActionDTO(
+        WorkflowRequest request,
+        Action action,
+        NewWorkReason newWorkReason) {
+        UserDTO userDTO = request.getUserDTO();
+
+        return UserActionDTO.builder()
+            .username(userDTO.getUserName())
+            .sessionId(userDTO.getUserSession())
+            .newWorkReason(newWorkReason)
+            .action(action)
+            .build();
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/FeatureDecisionService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/FeatureDecisionService.java
@@ -4,7 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
 import uk.gov.justice.laa.crime.orchestration.dto.validation.UserSummaryDTO;
-import uk.gov.justice.laa.crime.orchestration.enums.CurrentFeatureToggles;
+import uk.gov.justice.laa.crime.orchestration.enums.FeatureToggle;
 import uk.gov.justice.laa.crime.orchestration.enums.FeatureToggleAction;
 
 @Slf4j
@@ -25,11 +25,30 @@ public class FeatureDecisionService {
      * @return A boolean describing whether C3 should be invoked for the user's request.
      */
     public boolean isC3Enabled(WorkflowRequest workflowRequest) {
+        return isFeatureEnabled(workflowRequest, FeatureToggle.CALCULATE_CONTRIBUTION, FeatureToggleAction.CREATE);
+    }
+
+    /**
+     * Returns whether the MAAT post-assessment processing flow is enabled based on whether the user
+     * has the requisite feature flag (CurrentFeatureToggles.MAAT_POST_ASSESSMENT_PROCESSING) and action
+     * (Read) in their user summary information.
+     * @param workflowRequest The workflow request to check against.
+     * @return A boolean describing whether the MAAT post-assessment processing flow should be
+     * invoked for the user's request.
+     */
+    public boolean isMaatPostAssessmentProcessingEnabled(WorkflowRequest workflowRequest) {
+        return isFeatureEnabled(workflowRequest, FeatureToggle.MAAT_POST_ASSESSMENT_PROCESSING, FeatureToggleAction.READ);
+    }
+
+    private boolean isFeatureEnabled(
+        WorkflowRequest workflowRequest,
+        FeatureToggle featureToggle,
+        FeatureToggleAction featureToggleAction) {
         UserSummaryDTO userSummaryDTO = maatCourtDataService.getUserSummary(
             workflowRequest.getUserDTO().getUserName());
 
         return userSummaryDTO.getFeatureToggle() != null && userSummaryDTO.getFeatureToggle().stream().anyMatch(
-            t -> CurrentFeatureToggles.CALCULATE_CONTRIBUTION.getName().equals(t.getFeatureName())
-                && FeatureToggleAction.CREATE.getName().equals(t.getAction()));
+            t -> featureToggle.getName().equals(t.getFeatureName())
+                && featureToggleAction.getName().equals(t.getAction()));
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/RepOrderService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/RepOrderService.java
@@ -1,0 +1,19 @@
+package uk.gov.justice.laa.crime.orchestration.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
+import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RepOrderService {
+    private final MaatCourtDataService maatCourtDataService;
+
+    public RepOrderDTO getRepOrder(WorkflowRequest workflowRequest) {
+        int repId = workflowRequest.getApplicationDTO().getRepId().intValue();
+        return maatCourtDataService.findRepOrder(repId);
+    }
+}

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/ValidationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/ValidationService.java
@@ -47,7 +47,7 @@ public class ValidationService {
         }
     }
 
-    public Boolean isUserActionValid(UserActionDTO request, UserSummaryDTO userSummaryDTO) {
+    public boolean isUserActionValid(UserActionDTO request, UserSummaryDTO userSummaryDTO) {
         List<String> crimeValidationExceptionList = new ArrayList<>();
 
         if (request.getAction() == null && request.getNewWorkReason() == null && request.getSessionId() == null) {

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/WorkflowPreProcessorService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/WorkflowPreProcessorService.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.laa.crime.orchestration.service;
 
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -9,30 +10,40 @@ import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.CaseDetailDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.RepStatusDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.validation.UserActionDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.validation.UserSummaryDTO;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class WorkflowPreProcessorService {
-
     private final ContributionService contributionService;
+    private final MaatCourtDataService maatCourtDataService;
+    private final ValidationService validationService;
 
-    public WorkflowRequest  preProcessRequest(WorkflowRequest workflowRequest, RepOrderDTO repOrderDTO) {
+    public WorkflowRequest preProcessRequest(WorkflowRequest workflowRequest, RepOrderDTO repOrderDTO, UserActionDTO userActionDTO) {
         ApplicationDTO applicationDTO = workflowRequest.getApplicationDTO();
         CaseDetailDTO caseDetailsDTO = applicationDTO.getCaseDetailsDTO();
         RepStatusDTO statusDTO = applicationDTO.getStatusDTO();
-        String caseType = caseDetailsDTO != null ? caseDetailsDTO.getCaseType() : null;
-        String status = statusDTO != null ? statusDTO.getStatus() : null;
-        if(hasApplicationStatusChanged(repOrderDTO, caseType, status)) {
+
+        validationService.validate(workflowRequest, repOrderDTO);
+
+        UserSummaryDTO userSummaryDTO = Optional.ofNullable(userActionDTO.getUsername()).map(maatCourtDataService::getUserSummary).orElse(null);
+        validationService.isUserActionValid(userActionDTO, userSummaryDTO);
+
+        if (hasApplicationStatusChanged(repOrderDTO, caseDetailsDTO, statusDTO)) {
             workflowRequest.setApplicationDTO(contributionService.calculate(workflowRequest));
         }
+
         return workflowRequest;
     }
 
-    private boolean hasApplicationStatusChanged(RepOrderDTO repOrderDTO, String caseType, String status) {
+    private boolean hasApplicationStatusChanged(RepOrderDTO repOrderDTO, CaseDetailDTO caseDetailsDTO, RepStatusDTO repStatusDTO) {
+        String caseType = Optional.ofNullable(caseDetailsDTO).map(CaseDetailDTO::getCaseType).orElse(null);
+        String status = Optional.ofNullable(repStatusDTO).map(RepStatusDTO::getStatus).orElse(null);
+
         return CaseType.INDICTABLE.getCaseType().equals(caseType) && repOrderDTO != null
                 && repOrderDTO.getRorsStatus() != null
                 && !repOrderDTO.getRorsStatus().equalsIgnoreCase(status);
     }
-
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/MeansAssessmentOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/MeansAssessmentOrchestrationService.java
@@ -6,20 +6,26 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 import uk.gov.justice.laa.crime.commons.exception.MAATServerException;
+import uk.gov.justice.laa.crime.enums.orchestration.Action;
 import uk.gov.justice.laa.crime.enums.orchestration.StoredProcedure;
 import uk.gov.justice.laa.crime.exception.ValidationException;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.AssessmentSummaryDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.FinancialAssessmentDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.validation.UserActionDTO;
 import uk.gov.justice.laa.crime.orchestration.exception.CrimeValidationException;
 import uk.gov.justice.laa.crime.orchestration.exception.MaatOrchestrationException;
+import uk.gov.justice.laa.crime.orchestration.mapper.MeansAssessmentMapper;
 import uk.gov.justice.laa.crime.orchestration.service.AssessmentSummaryService;
 import uk.gov.justice.laa.crime.orchestration.service.ContributionService;
 import uk.gov.justice.laa.crime.orchestration.service.FeatureDecisionService;
 import uk.gov.justice.laa.crime.orchestration.service.MaatCourtDataService;
 import uk.gov.justice.laa.crime.orchestration.service.MeansAssessmentService;
 import uk.gov.justice.laa.crime.orchestration.service.ProceedingsService;
+import uk.gov.justice.laa.crime.orchestration.service.RepOrderService;
+import uk.gov.justice.laa.crime.orchestration.service.WorkflowPreProcessorService;
 
 import static uk.gov.justice.laa.crime.orchestration.common.Constants.WRN_MSG_INCOMPLETE_ASSESSMENT;
 import static uk.gov.justice.laa.crime.orchestration.common.Constants.WRN_MSG_REASSESSMENT;
@@ -28,24 +34,27 @@ import static uk.gov.justice.laa.crime.orchestration.common.Constants.WRN_MSG_RE
 @Service
 @RequiredArgsConstructor
 public class MeansAssessmentOrchestrationService {
-
     private final ContributionService contributionService;
     private final ProceedingsService proceedingsService;
     private final MeansAssessmentService meansAssessmentService;
     private final MaatCourtDataService maatCourtDataService;
     private final AssessmentSummaryService assessmentSummaryService;
     private final FeatureDecisionService featureDecisionService;
+    private final RepOrderService repOrderService;
+    private final WorkflowPreProcessorService workflowPreProcessorService;
+    private final MeansAssessmentMapper meansAssessmentMapper;
 
     public FinancialAssessmentDTO find(int assessmentId, int applicantId) {
         return meansAssessmentService.find(assessmentId, applicantId);
     }
 
     public ApplicationDTO create(WorkflowRequest request) {
-
         ApplicationDTO application = request.getApplicationDTO();
         try {
             Long repId = application.getRepId();
             log.debug("Creating Means assessment for applicationId = " + repId);
+
+            preProcessRequest(request, Action.CREATE_ASSESSMENT);
             meansAssessmentService.create(request);
             application = processCrownCourtProceedings(request);
             log.debug("Created Means assessment for applicationId = " + repId);
@@ -64,11 +73,12 @@ public class MeansAssessmentOrchestrationService {
     }
 
     public ApplicationDTO update(WorkflowRequest request) {
-
         ApplicationDTO application = request.getApplicationDTO();
         try {
             Long repId = application.getRepId();
             log.debug("Updating Means assessment for applicationId = " + repId);
+
+            preProcessRequest(request, Action.UPDATE_ASSESSMENT);
             meansAssessmentService.update(request);
             application = processCrownCourtProceedings(request);
             log.debug("Updated Means assessment for applicationId = " + repId);
@@ -86,30 +96,39 @@ public class MeansAssessmentOrchestrationService {
         return application;
     }
 
-    private ApplicationDTO processCrownCourtProceedings(WorkflowRequest request) {
+    private void preProcessRequest(WorkflowRequest request, Action action) {
+        if (featureDecisionService.isMaatPostAssessmentProcessingEnabled(request)) {
+            RepOrderDTO repOrderDTO = repOrderService.getRepOrder(request);
+            UserActionDTO userActionDTO = meansAssessmentMapper.getUserActionDto(request, action);
 
+            workflowPreProcessorService.preProcessRequest(request, repOrderDTO, userActionDTO);
+        }
+    }
+
+    private ApplicationDTO processCrownCourtProceedings(WorkflowRequest request) {
         request.getApplicationDTO().setAlertMessage("");
 
         if (featureDecisionService.isC3Enabled(request)) {
             // call post_processing_part_1_c3 and map the application
             request.setApplicationDTO(maatCourtDataService.invokeStoredProcedure(
-                    request.getApplicationDTO(),
-                    request.getUserDTO(),
-                    StoredProcedure.ASSESSMENT_POST_PROCESSING_PART_1_C3)
+                request.getApplicationDTO(),
+                request.getUserDTO(),
+                StoredProcedure.ASSESSMENT_POST_PROCESSING_PART_1_C3)
             );
 
-            // call pre_update_cc_application with the calculated contribution and map the application
-            request.setApplicationDTO(maatCourtDataService.invokeStoredProcedure(
+            if (!featureDecisionService.isMaatPostAssessmentProcessingEnabled(request)) {
+                // check feature flag here - only need to do this for the new workflow, not for the old way of doing things
+                request.setApplicationDTO(maatCourtDataService.invokeStoredProcedure(
                     contributionService.calculate(request),
                     request.getUserDTO(),
-                    StoredProcedure.PRE_UPDATE_CC_APPLICATION)
-            );
+                    StoredProcedure.PRE_UPDATE_CC_APPLICATION));
+            }
         } else {
             // call post_processing_part1 and map the application
             request.setApplicationDTO(maatCourtDataService.invokeStoredProcedure(
-                    request.getApplicationDTO(),
-                    request.getUserDTO(),
-                    StoredProcedure.ASSESSMENT_POST_PROCESSING_PART_1)
+                request.getApplicationDTO(),
+                request.getUserDTO(),
+                StoredProcedure.ASSESSMENT_POST_PROCESSING_PART_1)
             );
         }
 
@@ -136,5 +155,4 @@ public class MeansAssessmentOrchestrationService {
         application.setTransactionId(null);
         return application;
     }
-
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/MeansAssessmentDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/MeansAssessmentDataBuilder.java
@@ -14,7 +14,7 @@ import java.time.*;
 import java.util.*;
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.FeatureToggleDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.validation.UserSummaryDTO;
-import uk.gov.justice.laa.crime.orchestration.enums.CurrentFeatureToggles;
+import uk.gov.justice.laa.crime.orchestration.enums.FeatureToggle;
 import uk.gov.justice.laa.crime.orchestration.enums.FeatureToggleAction;
 
 import static uk.gov.justice.laa.crime.orchestration.data.Constants.FINANCIAL_ASSESSMENT_ID;
@@ -346,7 +346,7 @@ public class MeansAssessmentDataBuilder {
         return UserSummaryDTO.builder()
             .featureToggle(List.of(
                 FeatureToggleDTO.builder()
-                    .featureName(CurrentFeatureToggles.CALCULATE_CONTRIBUTION.getName())
+                    .featureName(FeatureToggle.CALCULATE_CONTRIBUTION.getName())
                     .action(FeatureToggleAction.CREATE.getName())
                     .build()
             ))

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/HardshipMapperTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/HardshipMapperTest.java
@@ -22,7 +22,7 @@ import uk.gov.justice.laa.crime.orchestration.dto.maat.HardshipReviewDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.validation.UserActionDTO;
 
 @ExtendWith(SoftAssertionsExtension.class)
-class HardshipReviewMapperTest {
+class HardshipMapperTest {
 
     UserMapper userMapper = new UserMapper();
     HardshipMapper hardshipMapper = new HardshipMapper(userMapper);

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/MeansAssessmentMapperTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/MeansAssessmentMapperTest.java
@@ -14,6 +14,7 @@ import uk.gov.justice.laa.crime.orchestration.data.builder.MeansAssessmentDataBu
 import uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.*;
+import uk.gov.justice.laa.crime.orchestration.dto.validation.UserActionDTO;
 import uk.gov.justice.laa.crime.util.DateUtil;
 import uk.gov.justice.laa.crime.util.NumberUtils;
 
@@ -48,6 +49,19 @@ class MeansAssessmentMapperTest {
                 .usingRecursiveComparison()
                 .ignoringCollectionOrder()
                 .isEqualTo(expected);
+    }
+
+    @Test
+    void givenWorkflowRequestAndAction_whenGetUserActionDtoIsInvokedDtoIsInvoked_thenMappingIsCorrect() {
+        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
+        UserActionDTO actual =
+            meansAssessmentMapper.getUserActionDto(workflowRequest, TestModelDataBuilder.TEST_ACTION);
+        UserActionDTO expected = TestModelDataBuilder.getUserActionDTO();
+
+        softly.assertThat(actual)
+            .usingRecursiveComparison()
+            .ignoringCollectionOrder()
+            .isEqualTo(expected);
     }
 
     @Test

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/FeatureDecisionServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/FeatureDecisionServiceTest.java
@@ -2,10 +2,15 @@ package uk.gov.justice.laa.crime.orchestration.service;
 
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Method;
 import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.crime.orchestration.data.Constants;
@@ -13,7 +18,7 @@ import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.UserDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.FeatureToggleDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.validation.UserSummaryDTO;
-import uk.gov.justice.laa.crime.orchestration.enums.CurrentFeatureToggles;
+import uk.gov.justice.laa.crime.orchestration.enums.FeatureToggle;
 import uk.gov.justice.laa.crime.orchestration.enums.FeatureToggleAction;
 
 @ExtendWith({MockitoExtension.class})
@@ -22,8 +27,13 @@ class FeatureDecisionServiceTest {
     @Mock
     private MaatCourtDataService maatCourtDataService;
 
-    @Test
-    void givenUserDoesNotHaveFeatureToggle_whenIsC3EnabledIsInvoked_thenReturnFalse() {
+    private static final String IS_C3_ENABLED_METHOD_NAME = "isC3Enabled";
+    private static final String IS_MAAT_POST_ASSESSMENT_PROCESSING_ENABLED_METHOD_NAME
+        = "isMaatPostAssessmentProcessingEnabled";
+
+    @ParameterizedTest
+    @ValueSource(strings = {IS_C3_ENABLED_METHOD_NAME, IS_MAAT_POST_ASSESSMENT_PROCESSING_ENABLED_METHOD_NAME})
+    void givenUserDoesNotHaveFeatureToggle_whenFeatureToggleMethodIsInvoked_thenReturnFalse(String methodName) throws Exception {
         when(maatCourtDataService.getUserSummary(Constants.USERNAME))
             .thenReturn(new UserSummaryDTO());
 
@@ -36,18 +46,24 @@ class FeatureDecisionServiceTest {
             .build();
 
         FeatureDecisionService featureDecisionService = new FeatureDecisionService(maatCourtDataService);
-        boolean result = featureDecisionService.isC3Enabled(request);
+        Method method = FeatureDecisionService.class.getMethod(methodName, WorkflowRequest.class);
+        boolean result = (boolean) method.invoke(featureDecisionService, request);
 
         Assertions.assertFalse(result);
     }
 
-    @Test
-    void givenUserHasFeatureToggleButWithoutTheCorrectAction_whenIsC3EnabledIsInvoked_thenReturnFalse() {
+    @ParameterizedTest
+    @MethodSource("userHasFeatureToggleButWithoutRequiredAction")
+    void givenUserHasFeatureToggleButWithoutTheCorrectAction_whenFeatureToggleMethodIsInvoked_thenReturnFalse(
+        String methodName,
+        FeatureToggle featureToggle,
+        FeatureToggleAction featureToggleAction
+    ) throws Exception {
         UserSummaryDTO userSummaryDTO = UserSummaryDTO.builder()
             .featureToggle(List.of(
                 FeatureToggleDTO.builder()
-                    .featureName(CurrentFeatureToggles.CALCULATE_CONTRIBUTION.getName())
-                    .action(FeatureToggleAction.READ.getName())
+                    .featureName(featureToggle.getName())
+                    .action(featureToggleAction.getName())
                     .build()))
             .build();
 
@@ -63,18 +79,24 @@ class FeatureDecisionServiceTest {
             .build();
 
         FeatureDecisionService featureDecisionService = new FeatureDecisionService(maatCourtDataService);
-        boolean result = featureDecisionService.isC3Enabled(request);
+        Method method = FeatureDecisionService.class.getMethod(methodName, WorkflowRequest.class);
+        boolean result = (boolean) method.invoke(featureDecisionService, request);
 
         Assertions.assertFalse(result);
     }
 
-    @Test
-    void givenUserHasFeatureToggleWithTheCorrectAction_whenIsC3EnabledIsInvoked_thenReturnTrue() {
+    @ParameterizedTest
+    @MethodSource("userHasFeatureToggleWithRequiredAction")
+    void givenUserHasFeatureToggleWithTheCorrectAction_whenFeatureToggleMethodIsInvoked_thenReturnTrue(
+        String methodName,
+        FeatureToggle featureToggle,
+        FeatureToggleAction featureToggleAction
+    ) throws Exception {
         UserSummaryDTO userSummaryDTO = UserSummaryDTO.builder()
             .featureToggle(List.of(
                 FeatureToggleDTO.builder()
-                    .featureName(CurrentFeatureToggles.CALCULATE_CONTRIBUTION.getName())
-                    .action(FeatureToggleAction.CREATE.getName())
+                    .featureName(featureToggle.getName())
+                    .action(featureToggleAction.getName())
                     .build()))
             .build();
 
@@ -90,8 +112,35 @@ class FeatureDecisionServiceTest {
             .build();
 
         FeatureDecisionService featureDecisionService = new FeatureDecisionService(maatCourtDataService);
-        boolean result = featureDecisionService.isC3Enabled(request);
+        Method method = FeatureDecisionService.class.getMethod(methodName, WorkflowRequest.class);
+        boolean result = (boolean) method.invoke(featureDecisionService, request);
 
         Assertions.assertTrue(result);
+    }
+
+    private static Stream<Arguments> userHasFeatureToggleButWithoutRequiredAction() {
+        return Stream.of(
+            Arguments.of(
+                IS_C3_ENABLED_METHOD_NAME,
+                FeatureToggle.CALCULATE_CONTRIBUTION,
+                FeatureToggleAction.READ),
+            Arguments.of(
+                IS_MAAT_POST_ASSESSMENT_PROCESSING_ENABLED_METHOD_NAME,
+                FeatureToggle.MAAT_POST_ASSESSMENT_PROCESSING,
+                FeatureToggleAction.CREATE)
+        );
+    }
+
+    private static Stream<Arguments> userHasFeatureToggleWithRequiredAction() {
+        return Stream.of(
+            Arguments.of(
+                IS_C3_ENABLED_METHOD_NAME,
+                FeatureToggle.CALCULATE_CONTRIBUTION,
+                FeatureToggleAction.CREATE),
+            Arguments.of(
+                IS_MAAT_POST_ASSESSMENT_PROCESSING_ENABLED_METHOD_NAME,
+                FeatureToggle.MAAT_POST_ASSESSMENT_PROCESSING,
+                FeatureToggleAction.READ)
+        );
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/RepOrderServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/RepOrderServiceTest.java
@@ -1,0 +1,48 @@
+package uk.gov.justice.laa.crime.orchestration.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder;
+import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
+import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
+
+@ExtendWith(MockitoExtension.class)
+class RepOrderServiceTest {
+    @Mock
+    private MaatCourtDataService maatCourtDataService;
+
+    @InjectMocks
+    private RepOrderService repOrderService;
+
+    @Test
+    void givenUnknownRepOrder_whenGetRepOrderIsInvoked_thenNoRepOrderIsReturned() {
+        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
+        when(maatCourtDataService.findRepOrder(any())).thenReturn(null);
+
+        RepOrderDTO actualRepOrder = repOrderService.getRepOrder(workflowRequest);
+
+        assertThat(actualRepOrder).isNull();
+    }
+
+    @Test
+    void givenExistingRepOrder_whenGetRepOrderIsInvoked_thenRepOrderIsReturned() {
+        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
+        int repOrderId = workflowRequest.getApplicationDTO().getRepId().intValue();
+        RepOrderDTO expectedRepOrder = RepOrderDTO.builder()
+            .id(repOrderId)
+            .build();
+
+        when(maatCourtDataService.findRepOrder(repOrderId)).thenReturn(expectedRepOrder);
+
+        RepOrderDTO actualRepOrder = repOrderService.getRepOrder(workflowRequest);
+
+        assertThat(actualRepOrder).isEqualTo(expectedRepOrder);
+    }
+}

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/WorkflowPreProcessorServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/WorkflowPreProcessorServiceTest.java
@@ -1,6 +1,6 @@
 package uk.gov.justice.laa.crime.orchestration.service;
 
-import org.jetbrains.annotations.NotNull;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -10,80 +10,125 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.crime.enums.RepOrderStatus;
+import uk.gov.justice.laa.crime.exception.ValidationException;
 import uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
 
 import java.util.stream.Stream;
+import uk.gov.justice.laa.crime.orchestration.dto.validation.UserActionDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.validation.UserSummaryDTO;
+import uk.gov.justice.laa.crime.orchestration.exception.CrimeValidationException;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static uk.gov.justice.laa.crime.enums.CaseType.INDICTABLE;
-import static uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder.getApplicationDTO;
 
 @ExtendWith({MockitoExtension.class})
 class WorkflowPreProcessorServiceTest {
     @Mock
     private ContributionService contributionService;
 
+    @Mock
+    private MaatCourtDataService maatCourtDataService;
+
+    @Mock
+    private ValidationService validationService;
+
     @InjectMocks
     private WorkflowPreProcessorService workflowPreProcessorService;
+
+    @Test
+    void givenRequestValidationFails_whenWorkflowPreProcessorServiceIsInvoked_thenExceptionIsThrown() {
+        WorkflowRequest request = getWorkflowRequestWithCaseType(INDICTABLE.getCaseType());
+        RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTO(RepOrderStatus.CURR.getCode());
+        UserActionDTO userActionDTO = TestModelDataBuilder.getUserActionDTO();
+
+        doThrow(new ValidationException(ValidationService.CANNOT_MODIFY_APPLICATION_ERROR))
+            .when(validationService).validate(request, repOrderDTO);
+
+        assertThatThrownBy(() -> workflowPreProcessorService.preProcessRequest(request, repOrderDTO, userActionDTO))
+            .isInstanceOf(ValidationException.class);
+    }
+
+    @Test
+    void givenUserIsNotAuthorisedToPerformRequestedAction_whenWorkflowPreProcessorServiceIsInvoked_thenExceptionIsThrown() {
+        WorkflowRequest request = getWorkflowRequestWithCaseType(INDICTABLE.getCaseType());
+        RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTO(RepOrderStatus.CURR.getCode());
+        UserActionDTO userActionDTO = TestModelDataBuilder.getUserActionDTO();
+        UserSummaryDTO userSummaryDTO = TestModelDataBuilder.getUserSummaryDTO();
+        List<String> validationErrors = List.of(
+            ValidationService.USER_DOES_NOT_HAVE_A_VALID_NEW_WORK_REASON_CODE);
+
+        when(maatCourtDataService.getUserSummary(userActionDTO.getUsername())).thenReturn(userSummaryDTO);
+        doThrow(new CrimeValidationException(validationErrors)).when(validationService).isUserActionValid(userActionDTO, userSummaryDTO);
+
+        assertThatThrownBy(() -> workflowPreProcessorService.preProcessRequest(request, repOrderDTO, userActionDTO))
+            .isInstanceOf(CrimeValidationException.class);
+    }
 
     @Test
     void givenApplicationStatusHasChanged_whenWorkflowPreProcessorServiceIsInvoked_thenUpdatedWorkflowRequestWithContributionIsReturned() {
         WorkflowRequest request = getWorkflowRequestWithCaseType(INDICTABLE.getCaseType());
         RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTO(RepOrderStatus.CURR.getCode());
-        when(contributionService.calculate(any()))
-                .thenReturn(getApplicationDTO());
-        workflowPreProcessorService.preProcessRequest(request, repOrderDTO);
+        UserActionDTO userActionDTO = TestModelDataBuilder.getUserActionDTO();
+        UserSummaryDTO userSummaryDTO = TestModelDataBuilder.getUserSummaryDTO();
+
+        when(contributionService.calculate(any())).thenReturn(TestModelDataBuilder.getApplicationDTO());
+        when(maatCourtDataService.getUserSummary(userActionDTO.getUsername())).thenReturn(userSummaryDTO);
+        when(validationService.isUserActionValid(userActionDTO, userSummaryDTO)).thenReturn(true);
+
+        workflowPreProcessorService.preProcessRequest(request, repOrderDTO, userActionDTO);
+
         verify(contributionService).calculate(any());
     }
 
     @ParameterizedTest
     @MethodSource("workflowRequestWithNoApplicationStatusChange")
     void givenApplicationStatusHasNotChanged_whenWorkflowPreProcessorServiceIsInvoked_thenWorkflowRequestIsReturned(WorkflowRequest request, RepOrderDTO repOrderDTO) {
-        workflowPreProcessorService.preProcessRequest(request, repOrderDTO);
+        UserActionDTO userActionDTO = TestModelDataBuilder.getUserActionDTO();
+        UserSummaryDTO userSummaryDTO = TestModelDataBuilder.getUserSummaryDTO();
+
+        when(maatCourtDataService.getUserSummary(userActionDTO.getUsername())).thenReturn(userSummaryDTO);
+        when(validationService.isUserActionValid(userActionDTO, userSummaryDTO)).thenReturn(true);
+
+        workflowPreProcessorService.preProcessRequest(request, repOrderDTO, userActionDTO);
+
         verify(contributionService, times(0)).calculate(any());
     }
 
     private static Stream<Arguments> workflowRequestWithNoApplicationStatusChange() {
         return Stream.of(
-                Arguments.of(
-                        TestModelDataBuilder
-                                .buildWorkFlowRequest(),
-                        TestModelDataBuilder
-                                .buildRepOrderDTO(RepOrderStatus.CURR.getCode())),
-                Arguments.of(
-                        TestModelDataBuilder
-                                .buildWorkFlowRequest(),
-                        TestModelDataBuilder
-                                .buildRepOrderDTO(null)),
-                Arguments.of(
-                        TestModelDataBuilder
-                                .buildWorkFlowRequest(),
-                        TestModelDataBuilder
-                                .buildRepOrderDTO("RepStatus")),
-                Arguments.of(
-                        WorkflowRequest.builder()
-                                .applicationDTO(ApplicationDTO.builder()
-                                        .statusDTO(null)
-                                        .caseDetailsDTO(null)
-                                        .build())
-                                .build(),
-                        TestModelDataBuilder
-                                .buildRepOrderDTO("RepStatus")),
-                Arguments.of(
-                        getWorkflowRequestWithCaseType(INDICTABLE.getCaseType()),
-                        null),
-                Arguments.of(
-                        getWorkflowRequestWithCaseType(INDICTABLE.getCaseType()),
-                        TestModelDataBuilder
-                                .buildRepOrderDTO(null)),
-                Arguments.of(
-                        getWorkflowRequestWithCaseType(INDICTABLE.getCaseType()),
-                        TestModelDataBuilder
-                                .buildRepOrderDTO("RepStatus"))
+            Arguments.of(
+                TestModelDataBuilder.buildWorkFlowRequest(),
+                TestModelDataBuilder.buildRepOrderDTO(RepOrderStatus.CURR.getCode())),
+            Arguments.of(
+                TestModelDataBuilder.buildWorkFlowRequest(),
+                TestModelDataBuilder.buildRepOrderDTO(null)),
+            Arguments.of(
+                TestModelDataBuilder.buildWorkFlowRequest(),
+                TestModelDataBuilder.buildRepOrderDTO("RepStatus")),
+            Arguments.of(
+                WorkflowRequest.builder()
+                    .applicationDTO(ApplicationDTO.builder()
+                        .statusDTO(null)
+                        .caseDetailsDTO(null)
+                        .build())
+                    .build(),
+                TestModelDataBuilder.buildRepOrderDTO("RepStatus")),
+            Arguments.of(
+                getWorkflowRequestWithCaseType(INDICTABLE.getCaseType()),
+                null),
+            Arguments.of(
+                getWorkflowRequestWithCaseType(INDICTABLE.getCaseType()),
+                TestModelDataBuilder
+                    .buildRepOrderDTO(null)),
+            Arguments.of(
+                getWorkflowRequestWithCaseType(INDICTABLE.getCaseType()),
+                TestModelDataBuilder
+                    .buildRepOrderDTO("RepStatus"))
         );
     }
 
@@ -92,5 +137,4 @@ class WorkflowPreProcessorServiceTest {
         request.getApplicationDTO().getCaseDetailsDTO().setCaseType(caseType);
         return request;
     }
-
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/MeansAssessmentOrchestrationServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/MeansAssessmentOrchestrationServiceTest.java
@@ -16,6 +16,7 @@ import uk.gov.justice.laa.crime.orchestration.dto.maat.ContributionsDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.FinancialAssessmentDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.UserDTO;
 import uk.gov.justice.laa.crime.orchestration.exception.CrimeValidationException;
+import uk.gov.justice.laa.crime.orchestration.mapper.MeansAssessmentMapper;
 import uk.gov.justice.laa.crime.orchestration.service.AssessmentSummaryService;
 import uk.gov.justice.laa.crime.orchestration.service.ContributionService;
 import uk.gov.justice.laa.crime.orchestration.service.FeatureDecisionService;
@@ -24,6 +25,8 @@ import uk.gov.justice.laa.crime.orchestration.service.MeansAssessmentService;
 import uk.gov.justice.laa.crime.orchestration.service.ProceedingsService;
 
 import java.util.List;
+import uk.gov.justice.laa.crime.orchestration.service.RepOrderService;
+import uk.gov.justice.laa.crime.orchestration.service.WorkflowPreProcessorService;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
@@ -57,6 +60,16 @@ class MeansAssessmentOrchestrationServiceTest {
 
     @Mock
     private AssessmentSummaryService assessmentSummaryService;
+
+    @Mock
+    private MeansAssessmentMapper meansAssessmentMapper;
+
+    @Mock
+    private RepOrderService repOrderService;
+
+    @Mock
+    private WorkflowPreProcessorService workflowPreProcessorService;
+
     @InjectMocks
     private MeansAssessmentOrchestrationService orchestrationService;
 
@@ -68,7 +81,6 @@ class MeansAssessmentOrchestrationServiceTest {
 
     @Test
     void givenARequestWithC3Enabled_whenCreateIsInvoked_thenApplicationDTOIsUpdatedWithContribution() {
-
         WorkflowRequest workflowRequest = MeansAssessmentDataBuilder.buildWorkFlowRequest();
         ContributionsDTO contributionsDTO = MeansAssessmentDataBuilder.getContributionsDTO();
         ApplicationDTO applicationDTO = MeansAssessmentDataBuilder.getApplicationDTO();
@@ -127,7 +139,6 @@ class MeansAssessmentOrchestrationServiceTest {
 
     @Test
     void givenARequestWithC3Enabled_whenUpdateIsInvoked_thenApplicationDTOIsUpdatedWithContribution() {
-
         WorkflowRequest workflowRequest = MeansAssessmentDataBuilder.buildWorkFlowRequest();
         ContributionsDTO contributionsDTO = MeansAssessmentDataBuilder.getContributionsDTO();
         ApplicationDTO applicationDTO = MeansAssessmentDataBuilder.getApplicationDTO();
@@ -161,7 +172,6 @@ class MeansAssessmentOrchestrationServiceTest {
 
     @Test
     void givenARequestWithC3NotEnabled_whenUpdateIsInvoked_thenCalculationContributionIsNotCalled() {
-
         WorkflowRequest workflowRequest = MeansAssessmentDataBuilder.buildWorkFlowRequest();
 
         when(maatCourtDataService.invokeStoredProcedure(any(ApplicationDTO.class), any(UserDTO.class),
@@ -184,6 +194,49 @@ class MeansAssessmentOrchestrationServiceTest {
                                                            StoredProcedure.ASSESSMENT_POST_PROCESSING_PART_2
         );
         verify(assessmentSummaryService, times(1)).getSummary(any());
+    }
+
+    @Test
+    void givenARequestWithC3EnabledAndPostProcessingNotEnabled_whenUpdateIsInvoked_thenWorkflowPreProcessorServiceIsNotCalled() {
+        WorkflowRequest workflowRequest = MeansAssessmentDataBuilder.buildWorkFlowRequest();
+        ApplicationDTO applicationDTO = MeansAssessmentDataBuilder.getApplicationDTO();
+
+        when(contributionService.calculate(workflowRequest)).thenReturn(applicationDTO);
+        when(maatCourtDataService.invokeStoredProcedure(any(ApplicationDTO.class), any(UserDTO.class),
+            any(StoredProcedure.class)
+        ))
+            .thenReturn(applicationDTO);
+        when(featureDecisionService.isC3Enabled(workflowRequest)).thenReturn(true);
+        when(featureDecisionService.isMaatPostAssessmentProcessingEnabled(workflowRequest)).thenReturn(false);
+
+        orchestrationService.update(workflowRequest);
+
+        verify(maatCourtDataService).invokeStoredProcedure(
+            applicationDTO,
+            workflowRequest.getUserDTO(),
+            StoredProcedure.PRE_UPDATE_CC_APPLICATION
+        );
+        verify(workflowPreProcessorService, times(0)).preProcessRequest(any(), any(), any());
+    }
+
+    @Test
+    void givenARequestWithC3EnabledAndPostProcessingEnabled_whenUpdateIsInvoked_thenWorkflowPreProcessorServiceIsCalled() {
+        WorkflowRequest workflowRequest = MeansAssessmentDataBuilder.buildWorkFlowRequest();
+
+        when(maatCourtDataService.invokeStoredProcedure(any(ApplicationDTO.class), any(UserDTO.class),
+            any(StoredProcedure.class)
+        ))
+            .thenReturn(workflowRequest.getApplicationDTO());
+        when(featureDecisionService.isC3Enabled(workflowRequest)).thenReturn(true);
+        when(featureDecisionService.isMaatPostAssessmentProcessingEnabled(workflowRequest)).thenReturn(true);
+
+        orchestrationService.update(workflowRequest);
+        verify(maatCourtDataService, times(0)).invokeStoredProcedure(
+            workflowRequest.getApplicationDTO(),
+            workflowRequest.getUserDTO(),
+            StoredProcedure.PRE_UPDATE_CC_APPLICATION
+        );
+        verify(workflowPreProcessorService).preProcessRequest(any(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
This PR updates the Hardship and Means Assessment workflows to use the _WorkflowPreProcessorService_ for validating incoming requests, specifically to ensure that the application status and timestamp are valid, as well as to ensure that the user is authorised for the action that they're attempting to perform.

This validation is only triggered from the Hardship and Means Assessment workflows when the `MaatPostAssessmentProcessing` feature flag has been enabled and additionally, in the case of Means Assessment workflows, only when the Crown Court Contribution Service has been enabled.

The _FeatureDecisionService_ has been refactored as part of this PR to consolidate common logic and the tests have been parameterised to try and ensure that duplication does not become an issue as the number of methods for checking various features increase.

This PR has _not_ refactored the _WorkflowPreProcessorService_ to consolidate Rep Order retrieval into a single method, as described in the story. The reason for this is that currently, only two services (hardship orchestration and means assessment orchestration) are calling the preprocessor; between them, one of the services is using the retrieved Rep Order elsewhere in, so a call to refactor retrieval of it in the preprocessor wouldn't remove the call to retrieve it elsewhere. The Rep Order is also used to calculate the appropriate _UserActionDTO_ (in the respective calling services), which we would otherwise need to refactor for in the preprocessor. Overall, it feels like slight premature optimisation to refactor at this stage but I'm happy to hear the thoughts of others.

Note: will fix-up commits once folks are happy with the substantive changes.

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1255)
