### PR TITLE
LCAM-1654|Update feature toggle to use IS_Enabled flag

### DIFF
--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/FeatureDecisionService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/FeatureDecisionService.java
@@ -48,7 +48,8 @@ public class FeatureDecisionService {
             workflowRequest.getUserDTO().getUserName());
 
         return userSummaryDTO.getFeatureToggle() != null && userSummaryDTO.getFeatureToggle().stream().anyMatch(
-            t -> featureToggle.getName().equals(t.getFeatureName())
-                && featureToggleAction.getName().equals(t.getAction()));
+            featureToggleDTO -> featureToggle.getName().equals(featureToggleDTO.getFeatureName())
+                && featureToggleAction.getName().equals(featureToggleDTO.getAction())
+                && "Y".equals(featureToggleDTO.getIsEnabled()));
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/MeansAssessmentDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/MeansAssessmentDataBuilder.java
@@ -348,6 +348,7 @@ public class MeansAssessmentDataBuilder {
                 FeatureToggleDTO.builder()
                     .featureName(FeatureToggle.CALCULATE_CONTRIBUTION.getName())
                     .action(FeatureToggleAction.CREATE.getName())
+                    .isEnabled("Y")
                     .build()
             ))
             .build();

--- a/maat-orchestration/src/test/resources/application.yaml
+++ b/maat-orchestration/src/test/resources/application.yaml
@@ -1,5 +1,5 @@
 server:
-  port: 8089
+  port: 8289
 
 spring:
   main:


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1654)

As part of this change the logic in FeatureDecisionService is updated to use the newly added IS_ENABLED column on the FEATURE_TOGGLE table. This allows feature toggles that apply to all users to be disabled on a user-specific basis.
