### PR TITLE
LCAM-1662|Enhance the getDateReceived method in the IncomeEvidenceMapper

### DIFF
--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/dto/maat_api/EvidenceDTO.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/dto/maat_api/EvidenceDTO.java
@@ -1,0 +1,29 @@
+package uk.gov.justice.laa.crime.orchestration.dto.maat_api;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class EvidenceDTO implements Serializable {
+    private Integer id;
+    private LocalDateTime dateReceived;
+    private LocalDateTime dateCreated;
+    private String userCreated;
+    private LocalDateTime dateModified;
+    private String userModified;
+    private String active;
+    private LocalDateTime removedDate;
+    private String mandatory;
+    private String otherText;
+    private String adhoc;
+    private String incomeEvidence;
+    private ApplicantDTO applicant;
+}

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/dto/maat_api/FinAssIncomeEvidenceDTO.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/dto/maat_api/FinAssIncomeEvidenceDTO.java
@@ -1,29 +1,4 @@
 package uk.gov.justice.laa.crime.orchestration.dto.maat_api;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-import java.io.Serializable;
-import java.time.LocalDateTime;
-
-@Data
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
-public class FinAssIncomeEvidenceDTO implements Serializable {
-    private Integer id;
-    private LocalDateTime dateReceived;
-    private LocalDateTime dateCreated;
-    private String userCreated;
-    private LocalDateTime dateModified;
-    private String userModified;
-    private String active;
-    private LocalDateTime removedDate;
-    private String mandatory;
-    private String otherText;
-    private String adhoc;
-    private String incomeEvidence;
-    private ApplicantDTO applicant;
+public class FinAssIncomeEvidenceDTO extends EvidenceDTO {
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/dto/maat_api/PassportAssessmentDTO.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/dto/maat_api/PassportAssessmentDTO.java
@@ -7,6 +7,8 @@ import lombok.NoArgsConstructor;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.UserDTO;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Data
 @Builder
@@ -60,4 +62,6 @@ public class PassportAssessmentDTO {
     private String whoDWPChecked;
     private String rtCode;
     private UserDTO userCreatedEntity;
+    @Builder.Default
+    private List<PassportAssessmentEvidenceDTO> passportAssessmentEvidences = new ArrayList<>();
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/dto/maat_api/PassportAssessmentEvidenceDTO.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/dto/maat_api/PassportAssessmentEvidenceDTO.java
@@ -1,0 +1,4 @@
+package uk.gov.justice.laa.crime.orchestration.dto.maat_api;
+
+public class PassportAssessmentEvidenceDTO extends EvidenceDTO {
+}

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/TestModelDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/TestModelDataBuilder.java
@@ -131,7 +131,8 @@ public class TestModelDataBuilder {
     public static final long APPLICANT_ID = 1000L;
     public static final long PARTNER_ID = 1234L;
     public static final String EMST_CODE ="EMPLOY";
-   
+    public static final LocalDateTime INCOME_EVIDENCE_RECEIVED_DATE = LocalDateTime.of(2023, 11, 11, 0, 0, 0);
+
 
     public static ApiFindHardshipResponse getApiFindHardshipResponse() {
         return new ApiFindHardshipResponse()

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/TestModelDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/TestModelDataBuilder.java
@@ -25,6 +25,7 @@ import uk.gov.justice.laa.crime.enums.orchestration.Action;
 import uk.gov.justice.laa.crime.orchestration.data.Constants;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.*;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.EvidenceDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicantDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.ContributionsDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.FinancialAssessmentDTO;
@@ -133,7 +134,7 @@ public class TestModelDataBuilder {
     public static final String TEST_USER_SESSION = "sessionId_e5712593c198";
     private static final Integer TEST_RECORD_ID = 100;
     private static final LocalDateTime RESERVATION_DATE = LocalDateTime.of(2022, 12, 14, 0, 0, 0);
-    public static final LocalDateTime EVIDENCE_RECEIVED_DATE = LocalDateTime.of(2023, 11, 11, 0, 0, 0);
+    public static final LocalDateTime EVIDENCE_RECEIVED_DATE = LocalDateTime.of(2023, 11, 10, 0, 0, 0);
     public static final long APPLICANT_ID = 1000L;
     public static final long PARTNER_ID = 1234L;
     public static final String EMST_CODE ="EMPLOY";
@@ -841,6 +842,14 @@ public class TestModelDataBuilder {
                 .build();
     }
 
+    public static PassportAssessmentDTO getPassportAssessmentDTO() {
+        return PassportAssessmentDTO.builder()
+                .id(Constants.FINANCIAL_ASSESSMENT_ID)
+                .passportAssessmentEvidences(List.of(getPassportAssessmentEvidenceDTO(NumberUtils.toInteger(APPLICANT_ID)),
+                        getPassportAssessmentEvidenceDTO(NumberUtils.toInteger(PARTNER_ID))))
+                .build();
+    }
+
     public static FullAssessmentDTO getFullAssessmentDTO() {
         return FullAssessmentDTO.builder()
                 .assessmentNotes(ASSESSMENT_NOTES)
@@ -984,15 +993,25 @@ public class TestModelDataBuilder {
     }
 
     private static FinAssIncomeEvidenceDTO getFinAssIncomeEvidenceDTO(Integer applicantId) {
-        return FinAssIncomeEvidenceDTO.builder()
-                .applicant(
-                        uk.gov.justice.laa.crime.orchestration.dto.maat_api.ApplicantDTO.builder()
-                                .id(applicantId)
-                                .build()
-                )
-                .dateReceived(EVIDENCE_RECEIVED_DATE)
-                .incomeEvidence(IncomeEvidenceType.TAX_RETURN.getName())
-                .build();
+        FinAssIncomeEvidenceDTO finAssIncomeEvidenceDTO = new FinAssIncomeEvidenceDTO();
+        finAssIncomeEvidenceDTO.setApplicant(uk.gov.justice.laa.crime.orchestration.dto.maat_api.ApplicantDTO.builder()
+                .id(applicantId)
+                .build());
+        finAssIncomeEvidenceDTO.setIncomeEvidence(IncomeEvidenceType.TAX_RETURN.getName());
+        finAssIncomeEvidenceDTO.setDateReceived(INCOME_EVIDENCE_RECEIVED_DATE);
+        finAssIncomeEvidenceDTO.setDateCreated(INCOME_EVIDENCE_RECEIVED_DATE);
+        return finAssIncomeEvidenceDTO;
+    }
+
+    private static PassportAssessmentEvidenceDTO getPassportAssessmentEvidenceDTO(Integer applicantId) {
+        PassportAssessmentEvidenceDTO passportAssessmentEvidenceDTO = new PassportAssessmentEvidenceDTO();
+        passportAssessmentEvidenceDTO.setApplicant(uk.gov.justice.laa.crime.orchestration.dto.maat_api.ApplicantDTO.builder()
+                .id(applicantId)
+                .build());
+        passportAssessmentEvidenceDTO.setIncomeEvidence(IncomeEvidenceType.TAX_RETURN.getName());
+        passportAssessmentEvidenceDTO.setDateReceived(EVIDENCE_RECEIVED_DATE);
+        passportAssessmentEvidenceDTO.setDateCreated(EVIDENCE_RECEIVED_DATE);
+        return passportAssessmentEvidenceDTO;
     }
 
     private static ExtraEvidenceDTO getExtraEvidenceDTO() {
@@ -1466,7 +1485,7 @@ public class TestModelDataBuilder {
     private static FinancialAssessmentIncomeEvidence getFinAssIncomeEvidence(Integer evidenceId, Integer applicantId) {
         return new FinancialAssessmentIncomeEvidence()
                 .withId(evidenceId)
-                .withDateReceived(EVIDENCE_RECEIVED_DATE)
+                .withDateReceived(INCOME_EVIDENCE_RECEIVED_DATE)
                 .withActive("Y")
                 .withIncomeEvidence(IncomeEvidenceType.TAX_RETURN.getName())
                 .withMandatory("Y")


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1662)

Enhanced the getDateReceived method in the IncomeEvidenceMapper.

When determining the Evidence Received Date, we need to check if the evidence was already provided as part of a previous passported assessment or means assessment. The DATE_RECEIVED from the latest evidence record is picked and saved to the new evidence record.