### PR TITLE
LCAM-1660|Create an end point to manage income evidence updates

### DIFF
--- a/maat-orchestration/build.gradle
+++ b/maat-orchestration/build.gradle
@@ -18,7 +18,7 @@ java {
 def versions = [
 		pitest                  : "1.16.1",
 		springdocVersion        : "2.5.0",
-		commonsModSchemas       : "1.22.0",
+		commonsModSchemas       : "1.23.1",
 		crimeCommonsClasses     : "4.1.0",
 		commonsRestClient       : "3.18.0",
 		okhttpVersion           : "4.12.0",

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/controller/EvidenceController.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/controller/EvidenceController.java
@@ -1,0 +1,39 @@
+package uk.gov.justice.laa.crime.orchestration.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.justice.laa.crime.annotation.DefaultHTTPErrorResponse;
+import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
+import uk.gov.justice.laa.crime.orchestration.service.orchestration.EvidenceOrchestrationService;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@Slf4j
+@RestController
+@RequestMapping("api/internal/v1/orchestration/evidence")
+@RequiredArgsConstructor
+public class EvidenceController {
+
+    private final EvidenceOrchestrationService evidenceOrchestrationService;
+
+    @PutMapping(produces = APPLICATION_JSON_VALUE)
+    @Operation(description = "Update Income Evidence for a means assessment")
+    @ApiResponse(responseCode = "200",
+            content = @Content(mediaType = APPLICATION_JSON_VALUE, schema = @Schema(implementation = ApplicationDTO.class)))
+    @DefaultHTTPErrorResponse
+    public ResponseEntity<ApplicationDTO> updateIncomeEvidence(@Valid @RequestBody WorkflowRequest workflowRequest) {
+        log.info("Received a request to update Income Evidence");
+        return ResponseEntity.ok(evidenceOrchestrationService.updateIncomeEvidence(workflowRequest));
+    }
+}

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/IncomeEvidenceService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/IncomeEvidenceService.java
@@ -5,9 +5,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceRequest;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceResponse;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiUpdateIncomeEvidenceRequest;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiUpdateIncomeEvidenceResponse;
 import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.MaatApiAssessmentResponse;
 import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.MaatApiUpdateAssessment;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
 import uk.gov.justice.laa.crime.orchestration.mapper.IncomeEvidenceMapper;
 import uk.gov.justice.laa.crime.orchestration.service.api.EvidenceApiService;
@@ -35,5 +38,22 @@ public class IncomeEvidenceService {
                 incomeEvidenceMapper.mapToMaatApiUpdateAssessment(request, repOrder, evidenceResponse);
         MaatApiAssessmentResponse maatApiResponse = maatCourtDataApiService.updateFinancialAssessment(maatApiRequest);
         incomeEvidenceMapper.maatApiAssessmentResponseToApplicationDTO(maatApiResponse, request.getApplicationDTO());
+    }
+
+    public ApplicationDTO updateEvidence(WorkflowRequest workflowRequest, RepOrderDTO repOrderDTO) {
+        ApplicationDTO applicationDTO = workflowRequest.getApplicationDTO();
+        log.debug("Updating evidence items for financialAssessmentId: {}",
+                applicationDTO.getAssessmentDTO().getFinancialAssessmentDTO().getId());
+
+        ApiUpdateIncomeEvidenceRequest evidenceRequest = incomeEvidenceMapper
+                .workflowRequestToApiUpdateIncomeEvidenceRequest(applicationDTO, workflowRequest.getUserDTO());
+
+        ApiUpdateIncomeEvidenceResponse evidenceResponse = evidenceApiService.updateEvidence(evidenceRequest);
+        MaatApiUpdateAssessment maatApiRequest =
+                incomeEvidenceMapper.mapUpdateEvidenceToMaatApiUpdateAssessment(workflowRequest, repOrderDTO, evidenceResponse);
+
+        MaatApiAssessmentResponse maatApiResponse = maatCourtDataApiService.updateFinancialAssessment(maatApiRequest);
+        incomeEvidenceMapper.maatApiAssessmentResponseToApplicationDTO(maatApiResponse, applicationDTO);
+        return applicationDTO;
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/WorkflowPreProcessorService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/WorkflowPreProcessorService.java
@@ -46,4 +46,9 @@ public class WorkflowPreProcessorService {
                 && repOrderDTO.getRorsStatus() != null
                 && !repOrderDTO.getRorsStatus().equalsIgnoreCase(status);
     }
+
+    public void preProcessEvidenceRequest(UserActionDTO userActionDTO) {
+        UserSummaryDTO userSummaryDTO = Optional.ofNullable(userActionDTO.getUsername()).map(maatCourtDataService::getUserSummary).orElse(null);
+        validationService.isUserActionValid(userActionDTO, userSummaryDTO);
+    }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/api/EvidenceApiService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/api/EvidenceApiService.java
@@ -7,6 +7,8 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Service;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceRequest;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceResponse;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiUpdateIncomeEvidenceRequest;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiUpdateIncomeEvidenceResponse;
 import uk.gov.justice.laa.crime.commons.client.RestAPIClient;
 import uk.gov.justice.laa.crime.orchestration.config.ServicesConfiguration;
 
@@ -33,5 +35,17 @@ public class EvidenceApiService {
         );
         log.debug(RESPONSE_STRING, apiCreateIncomeEvidenceResponse);
         return apiCreateIncomeEvidenceResponse;
+    }
+
+    public ApiUpdateIncomeEvidenceResponse updateEvidence(ApiUpdateIncomeEvidenceRequest apiUpdateIncomeEvidenceRequest) {
+        log.debug(REQUEST_STRING, apiUpdateIncomeEvidenceRequest);
+        ApiUpdateIncomeEvidenceResponse apiUpdateIncomeEvidenceResponse = evidenceApiClient.put(
+                apiUpdateIncomeEvidenceRequest,
+                new ParameterizedTypeReference<>() {},
+                configuration.getEvidenceApi().getEndpoints().getIncomeEvidenceUrl(),
+                Map.of()
+        );
+        log.debug(RESPONSE_STRING, apiUpdateIncomeEvidenceResponse);
+        return apiUpdateIncomeEvidenceResponse;
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/EvidenceOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/EvidenceOrchestrationService.java
@@ -1,0 +1,36 @@
+package uk.gov.justice.laa.crime.orchestration.service.orchestration;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import uk.gov.justice.laa.crime.enums.orchestration.Action;
+import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.validation.UserActionDTO;
+import uk.gov.justice.laa.crime.orchestration.mapper.UserMapper;
+import uk.gov.justice.laa.crime.orchestration.service.IncomeEvidenceService;
+import uk.gov.justice.laa.crime.orchestration.service.RepOrderService;
+import uk.gov.justice.laa.crime.orchestration.service.WorkflowPreProcessorService;
+
+@Service
+@RequiredArgsConstructor
+public class EvidenceOrchestrationService {
+
+    private final IncomeEvidenceService incomeEvidenceService;
+    private final RepOrderService repOrderService;
+    private final UserMapper userMapper;
+    private final WorkflowPreProcessorService workflowPreProcessorService;
+
+    public ApplicationDTO updateIncomeEvidence(WorkflowRequest workflowRequest) {
+
+        preProcessRequest(workflowRequest);
+
+        RepOrderDTO repOrderDTO = repOrderService.getRepOrder(workflowRequest);
+        return incomeEvidenceService.updateEvidence(workflowRequest, repOrderDTO);
+    }
+
+    private void preProcessRequest(WorkflowRequest request) {
+        UserActionDTO userActionDTO = userMapper.getUserActionDTO(request, Action.MANAGE_INCOME_EVIDENCE, null);
+        workflowPreProcessorService.preProcessEvidenceRequest(userActionDTO);
+    }
+}

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/controller/EvidenceControllerTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/controller/EvidenceControllerTest.java
@@ -1,0 +1,75 @@
+package uk.gov.justice.laa.crime.orchestration.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.justice.laa.crime.commons.exception.APIClientException;
+import uk.gov.justice.laa.crime.commons.tracing.TraceIdHandler;
+import uk.gov.justice.laa.crime.enums.CourtType;
+import uk.gov.justice.laa.crime.orchestration.config.OrchestrationTestConfiguration;
+import uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder;
+import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
+import uk.gov.justice.laa.crime.orchestration.service.orchestration.EvidenceOrchestrationService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.justice.laa.crime.util.RequestBuilderUtils.buildRequestWithTransactionIdGivenContent;
+
+@WebMvcTest(controllers = EvidenceController.class)
+@Import(OrchestrationTestConfiguration.class)
+@AutoConfigureMockMvc(addFilters = false)
+public class EvidenceControllerTest {
+    private static final String ENDPOINT_URL = "/api/internal/v1/orchestration/evidence";
+
+    @MockBean
+    private EvidenceOrchestrationService evidenceOrchestrationService;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    private TraceIdHandler traceIdHandler;
+
+    @Test
+    void givenValidRequest_whenUpdateIsInvoked_thenOkResponseIsReturned() throws Exception {
+        when(evidenceOrchestrationService.updateIncomeEvidence(any(WorkflowRequest.class)))
+                .thenReturn(new ApplicationDTO());
+        String requestBody = objectMapper
+                .writeValueAsString(TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.MAGISTRATE));
+        mockMvc.perform(buildRequestWithTransactionIdGivenContent(HttpMethod.PUT, requestBody, ENDPOINT_URL, true))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    void givenInvalidRequest_whenUpdateIsInvoked_thenBadRequestResponseIsReturned() throws Exception {
+        mockMvc.perform(buildRequestWithTransactionIdGivenContent(HttpMethod.PUT, "", ENDPOINT_URL, true))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void givenWebClientFailure_whenUpdateIsInvoked_thenInternalServerErrorResponseIsReturned() throws Exception {
+
+        when(evidenceOrchestrationService.updateIncomeEvidence(any(WorkflowRequest.class)))
+                .thenThrow(new APIClientException());
+
+        String requestBody = objectMapper
+                .writeValueAsString(TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.MAGISTRATE));
+        mockMvc.perform(buildRequestWithTransactionIdGivenContent(HttpMethod.PUT, requestBody, ENDPOINT_URL, true))
+                .andExpect(status().isInternalServerError())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+    }
+}

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/TestModelDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/TestModelDataBuilder.java
@@ -131,7 +131,9 @@ public class TestModelDataBuilder {
     public static final long APPLICANT_ID = 1000L;
     public static final long PARTNER_ID = 1234L;
     public static final String EMST_CODE ="EMPLOY";
-    public static final LocalDateTime INCOME_EVIDENCE_RECEIVED_DATE = LocalDateTime.of(2023, 11, 11, 0, 0, 0);
+    public static final LocalDateTime FINASS_INCOME_EVIDENCE_RECEIVED_DATE = LocalDateTime.of(2023, 11, 11, 0, 0, 0);
+    public static final LocalDateTime EVIDENCE_DUE_DATE = LocalDateTime.of(2023, 3, 18, 0, 0, 0);
+    public static final LocalDateTime INCOME_EVIDENCE_RECEIVED_DATE = LocalDateTime.of(2023, 2, 18, 0, 0, 0);
 
 
     public static ApiFindHardshipResponse getApiFindHardshipResponse() {
@@ -257,7 +259,7 @@ public class TestModelDataBuilder {
                 .withIojAppeal(getApiIOJSummary())
                 .withFinancialAssessment(getApiFinancialAssessment())
                 .withPassportAssessment(getApiPassportAssessment())
-                .withIncomeEvidenceReceivedDate(LocalDateTime.of(2023, 2, 18, 0, 0, 0))
+                .withIncomeEvidenceReceivedDate(INCOME_EVIDENCE_RECEIVED_DATE)
                 .withCapitalEvidenceReceivedDate(EVIDENCE_RECEIVED_DATE)
                 .withCapitalEvidence(List.of(getApiCapitalEvidence()))
                 .withEmstCode(EMST_CODE);
@@ -931,8 +933,8 @@ public class TestModelDataBuilder {
                 .extraEvidenceList(List.of(getExtraEvidenceDTO()))
                 .applicantIncomeEvidenceList(List.of(getEvidenceDTO(APPLICANT_EVIDENCE_ID)))
                 .partnerIncomeEvidenceList(List.of(getEvidenceDTO(PARTNER_EVIDENCE_ID)))
-                .evidenceReceivedDate(toDate(LocalDateTime.of(2023, 2, 18, 0, 0, 0)))
-                .evidenceDueDate(toDate(LocalDateTime.of(2023, 3, 18, 0, 0, 0)))
+                .evidenceReceivedDate(toDate(INCOME_EVIDENCE_RECEIVED_DATE))
+                .evidenceDueDate(toDate(EVIDENCE_DUE_DATE))
                 .upliftsAvailable(true)
                 .build();
     }
@@ -943,8 +945,8 @@ public class TestModelDataBuilder {
                 .id(applicantId)
                 .build());
         finAssIncomeEvidenceDTO.setIncomeEvidence(IncomeEvidenceType.TAX_RETURN.getName());
-        finAssIncomeEvidenceDTO.setDateReceived(INCOME_EVIDENCE_RECEIVED_DATE);
-        finAssIncomeEvidenceDTO.setDateCreated(INCOME_EVIDENCE_RECEIVED_DATE);
+        finAssIncomeEvidenceDTO.setDateReceived(FINASS_INCOME_EVIDENCE_RECEIVED_DATE);
+        finAssIncomeEvidenceDTO.setDateCreated(FINASS_INCOME_EVIDENCE_RECEIVED_DATE);
         return finAssIncomeEvidenceDTO;
     }
 
@@ -993,7 +995,7 @@ public class TestModelDataBuilder {
     private static AppealDTO getAppealDTO() {
         return AppealDTO.builder()
                 .available(true)
-                .appealReceivedDate(toDate(LocalDateTime.of(2023, 3, 18, 0, 0, 0)))
+                .appealReceivedDate(toDate(EVIDENCE_DUE_DATE))
                 .appealSentenceOrderDate(toDate(LocalDateTime.of(2023, 8, 3, 0, 0, 0)))
                 .appealTypeDTO(getAppealTypeDTO())
                 .build();
@@ -1347,6 +1349,39 @@ public class TestModelDataBuilder {
                 .withMetadata(getMetadata());
     }
 
+    public static ApiUpdateIncomeEvidenceRequest getApiUpdateEvidenceRequest(boolean isPartner) {
+        return new ApiUpdateIncomeEvidenceRequest()
+                .withMagCourtOutcome(MagCourtOutcome.SENT_FOR_TRIAL)
+                .withApplicantEvidenceItems(getApiIncomeEvidenceItems(false))
+                .withPartnerEvidenceItems(isPartner ? getApiIncomeEvidenceItems(true) : null)
+                .withApplicantPensionAmount(BigDecimal.valueOf(1000.0 * Frequency.MONTHLY.getWeighting()))
+                .withPartnerPensionAmount(isPartner ? BigDecimal.valueOf(2000.0 * Frequency.TWO_WEEKLY.getWeighting()) : null)
+                .withEvidenceDueDate(EVIDENCE_DUE_DATE)
+                .withEvidenceReceivedDate(INCOME_EVIDENCE_RECEIVED_DATE)
+                .withMetadata(getMetadata());
+    }
+
+    private static ApiIncomeEvidenceItems getApiIncomeEvidenceItems(boolean isPartner) {
+        List<ApiIncomeEvidence> incomeEvidenceItems = List.of(new ApiIncomeEvidence()
+                        .withId(APPLICANT_EVIDENCE_ID)
+                        .withDateReceived(EVIDENCE_RECEIVED_DATE.toLocalDate())
+                        .withEvidenceType(IncomeEvidenceType.TAX_RETURN)
+                        .withMandatory(true),
+                new ApiIncomeEvidence()
+                        .withId(EXTRA_EVIDENCE_ID)
+                        .withDateReceived(EVIDENCE_RECEIVED_DATE.toLocalDate())
+                        .withEvidenceType(IncomeEvidenceType.TAX_RETURN)
+                        .withMandatory(true));
+        List<ApiIncomeEvidence> partnerIncomeEvidenceItems = List.of(new ApiIncomeEvidence()
+                        .withId(PARTNER_EVIDENCE_ID)
+                        .withDateReceived(EVIDENCE_RECEIVED_DATE.toLocalDate())
+                        .withEvidenceType(IncomeEvidenceType.TAX_RETURN)
+                        .withMandatory(true));
+        return new ApiIncomeEvidenceItems()
+                .withIncomeEvidenceItems(isPartner ? partnerIncomeEvidenceItems : incomeEvidenceItems)
+                .withApplicantDetails(getApplicantDetails(isPartner));
+    }
+
     private static ApiApplicantDetails getApplicantDetails(boolean isPartner) {
         return new ApiApplicantDetails()
                 .withId(isPartner ? NumberUtils.toInteger(PARTNER_ID) : NumberUtils.toInteger(APPLICANT_ID))
@@ -1430,7 +1465,7 @@ public class TestModelDataBuilder {
     private static FinancialAssessmentIncomeEvidence getFinAssIncomeEvidence(Integer evidenceId, Integer applicantId) {
         return new FinancialAssessmentIncomeEvidence()
                 .withId(evidenceId)
-                .withDateReceived(INCOME_EVIDENCE_RECEIVED_DATE)
+                .withDateReceived(FINASS_INCOME_EVIDENCE_RECEIVED_DATE)
                 .withActive("Y")
                 .withIncomeEvidence(IncomeEvidenceType.TAX_RETURN.getName())
                 .withMandatory("Y")

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/IncomeEvidenceMapperTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/IncomeEvidenceMapperTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceRequest;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceResponse;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiUpdateIncomeEvidenceRequest;
 import uk.gov.justice.laa.crime.common.model.meansassessment.ApiIncomeEvidence;
 import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.MaatApiAssessmentResponse;
 import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.MaatApiUpdateAssessment;
@@ -28,6 +29,7 @@ import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.when;
@@ -194,4 +196,31 @@ class IncomeEvidenceMapperTest {
                 Arguments.of(existingBothEvidencesRepOrderDTO, existingFinEvidencesAssessment)
         );
     }
+
+    @ParameterizedTest
+    @MethodSource("updateIncomeEvidences")
+    void givenValidWorkflowRequest_whenWorkflowRequestToApiUpdateIncomeEvidenceRequestIsInvoked_thenApiUpdateIncomeEvidenceRequestIsReturned(
+            WorkflowRequest workflowRequest,
+            ApiUpdateIncomeEvidenceRequest expectedRequest) {
+        ApplicationDTO applicationDTO = workflowRequest.getApplicationDTO();
+        UserDTO userDTO = workflowRequest.getUserDTO();
+
+        when(userMapper.userDtoToUserSession(userDTO))
+                .thenReturn(TestModelDataBuilder.getApiUserSession());
+
+        ApiUpdateIncomeEvidenceRequest actualRequest =
+                incomeEvidenceMapper.workflowRequestToApiUpdateIncomeEvidenceRequest(applicationDTO, userDTO);
+
+        assertThat(actualRequest).usingRecursiveComparison().isEqualTo(expectedRequest);
+    }
+
+    private static Stream<Arguments> updateIncomeEvidences() {
+        return Stream.of(
+                Arguments.of(TestModelDataBuilder.buildWorkFlowRequest(CourtType.CROWN_COURT),
+                        TestModelDataBuilder.getApiUpdateEvidenceRequest(false)),
+                Arguments.of(TestModelDataBuilder.buildWorkFlowRequest(),
+                        TestModelDataBuilder.getApiUpdateEvidenceRequest(true))
+        );
+    }
+
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/IncomeEvidenceServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/IncomeEvidenceServiceTest.java
@@ -7,11 +7,14 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceRequest;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceResponse;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiUpdateIncomeEvidenceRequest;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiUpdateIncomeEvidenceResponse;
 import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.MaatApiAssessmentResponse;
 import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.MaatApiUpdateAssessment;
 import uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.UserDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
 import uk.gov.justice.laa.crime.orchestration.mapper.IncomeEvidenceMapper;
 import uk.gov.justice.laa.crime.orchestration.service.api.EvidenceApiService;
@@ -54,5 +57,26 @@ class IncomeEvidenceServiceTest {
         verify(incomeEvidenceMapper).maatApiAssessmentResponseToApplicationDTO(any(MaatApiAssessmentResponse.class),
                 any(ApplicationDTO.class));
     }
-}
+
+    @Test
+    void givenValidWorkflowRequestAndRepOrder_whenUpdateEvidenceIsInvoked_thenApiServicesCalledAndResponseMapped() {
+        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
+        RepOrderDTO repOrder = TestModelDataBuilder.buildRepOrderDTO("CURR");
+
+        when(incomeEvidenceMapper.workflowRequestToApiUpdateIncomeEvidenceRequest(any(ApplicationDTO.class), any(UserDTO.class)))
+                .thenReturn(new ApiUpdateIncomeEvidenceRequest());
+        when(evidenceApiService.updateEvidence(any(ApiUpdateIncomeEvidenceRequest.class)))
+                .thenReturn(new ApiUpdateIncomeEvidenceResponse());
+        when(incomeEvidenceMapper.mapUpdateEvidenceToMaatApiUpdateAssessment(any(WorkflowRequest.class), any(RepOrderDTO.class), any(ApiUpdateIncomeEvidenceResponse.class)))
+                .thenReturn(new MaatApiUpdateAssessment());
+        when(maatCourtDataApiService.updateFinancialAssessment(any(MaatApiUpdateAssessment.class)))
+                .thenReturn(new MaatApiAssessmentResponse());
+
+        incomeEvidenceService.updateEvidence(workflowRequest, repOrder);
+
+        verify(evidenceApiService).updateEvidence(any(ApiUpdateIncomeEvidenceRequest.class));
+        verify(maatCourtDataApiService).updateFinancialAssessment(any(MaatApiUpdateAssessment.class));
+        verify(incomeEvidenceMapper).maatApiAssessmentResponseToApplicationDTO(any(MaatApiAssessmentResponse.class),
+                any(ApplicationDTO.class));
+    }}
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1660)

Created New Orchestration Flow for Updating Income Evidence Records.

As part of the manage_income_evidence stored procedure migration, we need an endpoint that can process any updates to an existing income evidence. When the income evidence data is changed in the MAAT UI this end point will be invoked to process the changes to the relevant income evidence data.

This flow needs to be enhanced further to handle the uplifts. There is a spike for investigating the options to migrate the uplift logic - https://dsdmoj.atlassian.net/browse/LCAM-1666

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.