### PR TITLE
LCAM-1647-consistent-use-of-assertJ

### DIFF
--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/CCLFUpdateServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/CCLFUpdateServiceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.laa.crime.orchestration.service;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -24,7 +25,6 @@ import java.util.Date;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder.*;
@@ -85,14 +85,14 @@ class CCLFUpdateServiceTest {
     void givenValidInputWithUpdateAction_whenUpdateSendToCCLFIsInvoked_thenNoExceptionIsThrown() {
         WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
         RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTO("CURR");
-        assertDoesNotThrow(() -> cclfUpdateService.updateSendToCCLF(workflowRequest, repOrderDTO));
+        Assertions.assertThatCode(() -> cclfUpdateService.updateSendToCCLF(workflowRequest, repOrderDTO)).doesNotThrowAnyException();
     }
 
     @Test
     void givenValidInputWithNullAction_whenUpdateSendToCCLFIsInvoked_thenNoExceptionIsThrown() {
         WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
         RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTO("CURR");
-        assertDoesNotThrow(() -> cclfUpdateService.updateSendToCCLF(workflowRequest, repOrderDTO));
+        Assertions.assertThatCode(() -> cclfUpdateService.updateSendToCCLF(workflowRequest, repOrderDTO)).doesNotThrowAnyException();
     }
 
     @Test
@@ -101,7 +101,7 @@ class CCLFUpdateServiceTest {
         LocalDateTime DECISION_DATETIME = LocalDateTime.of(2000, 10, 13, 0, 0, 0);
         workflowRequest.getApplicationDTO().setDecisionDate(Date.from(DECISION_DATETIME.atZone(ZoneId.systemDefault()).toInstant()));
         RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTO("CURR");
-        assertDoesNotThrow(() -> cclfUpdateService.updateSendToCCLF(workflowRequest, repOrderDTO));
+        Assertions.assertThatCode(() -> cclfUpdateService.updateSendToCCLF(workflowRequest, repOrderDTO)).doesNotThrowAnyException();
     }
 
     @Test
@@ -124,7 +124,7 @@ class CCLFUpdateServiceTest {
     void givenValidInput_whenUpdateSendToCCLFIsInvoked_thenOKResponseIsReturned() {
         WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
         RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTO("CURR");
-        assertDoesNotThrow(() -> cclfUpdateService.updateSendToCCLF(workflowRequest, repOrderDTO));
+        Assertions.assertThatCode(() -> cclfUpdateService.updateSendToCCLF(workflowRequest, repOrderDTO)).doesNotThrowAnyException();
         verify(maatCourtDataApiService).updateSendToCCLF(any());
     }
 
@@ -139,21 +139,21 @@ class CCLFUpdateServiceTest {
     void givenInputWithOutCCO_whenGetWithdrawalDateIsInvoked_thenNullIsReturned() {
         ApplicationDTO applicationDTO = TestModelDataBuilder.buildWorkFlowRequest().getApplicationDTO();
         applicationDTO.setCrownCourtOverviewDTO(null);
-        assertNull(cclfUpdateService.getWithDrawalDate(applicationDTO));
+        assertThat(cclfUpdateService.getWithDrawalDate(applicationDTO)).isNull();
     }
 
     @Test
     void givenInputWithOutCCSummary_whenGetWithdrawalDateIsInvoked_thenNullIsReturned() {
         ApplicationDTO applicationDTO = TestModelDataBuilder.buildWorkFlowRequest().getApplicationDTO();
         applicationDTO.getCrownCourtOverviewDTO().setCrownCourtSummaryDTO(null);
-        assertNull(cclfUpdateService.getWithDrawalDate(applicationDTO));
+        assertThat(cclfUpdateService.getWithDrawalDate(applicationDTO)).isNull();
     }
 
     @Test
     void givenInputWithOutCCWithdrawal_whenGetWithdrawalDateIsInvoked_thenNullIsReturned() {
         ApplicationDTO applicationDTO = TestModelDataBuilder.buildWorkFlowRequest().getApplicationDTO();
         applicationDTO.getCrownCourtOverviewDTO().getCrownCourtSummaryDTO().setCcWithDrawalDate(null);
-        assertNull(cclfUpdateService.getWithDrawalDate(applicationDTO));
+        assertThat(cclfUpdateService.getWithDrawalDate(applicationDTO)).isNull();
     }
 
     @Test
@@ -167,21 +167,21 @@ class CCLFUpdateServiceTest {
     void givenInputWithOutCCO_whenGetRepOrderDateIsInvoked_thenNullIsReturned() {
         ApplicationDTO applicationDTO = TestModelDataBuilder.buildWorkFlowRequest().getApplicationDTO();
         applicationDTO.setCrownCourtOverviewDTO(null);
-        assertNull(cclfUpdateService.getRepOrderDate(applicationDTO));
+        assertThat(cclfUpdateService.getRepOrderDate(applicationDTO)).isNull();
     }
 
     @Test
     void givenInputWithOutCCSummary_whenGetRepOrderDateIsInvoked_thenNullIsReturned() {
         ApplicationDTO applicationDTO = TestModelDataBuilder.buildWorkFlowRequest().getApplicationDTO();
         applicationDTO.getCrownCourtOverviewDTO().setCrownCourtSummaryDTO(null);
-        assertNull(cclfUpdateService.getRepOrderDate(applicationDTO));
+        assertThat(cclfUpdateService.getRepOrderDate(applicationDTO)).isNull();
     }
 
     @Test
     void givenInputWithOutCCRepOrder_whenGetRepOrderDateIsInvoked_thenNullIsReturned() {
         ApplicationDTO applicationDTO = TestModelDataBuilder.buildWorkFlowRequest().getApplicationDTO();
         applicationDTO.getCrownCourtOverviewDTO().getCrownCourtSummaryDTO().setCcRepOrderDate(null);
-        assertNull(cclfUpdateService.getRepOrderDate(applicationDTO));
+        assertThat(cclfUpdateService.getRepOrderDate(applicationDTO)).isNull();
     }
 
     @Test
@@ -190,7 +190,7 @@ class CCLFUpdateServiceTest {
         Date result = cclfUpdateService.parseDate(date);
         SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
         Date expected = format.parse(date);
-        assertEquals(expected, result);
+        assertThat(expected).isEqualTo(result);
     }
 
     @Test()
@@ -200,34 +200,34 @@ class CCLFUpdateServiceTest {
 
     @Test()
     void parseNullDate() {
-        assertNull(cclfUpdateService.parseDate(null));
+        assertThat(cclfUpdateService.parseDate(null)).isNull();
     }
 
     @Test
     void givenValidInput_whenGetRepOrderCcOutcomeIsInvoked_thenValidResponseIsReturned() {
         RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTO("CURR");
         repOrderDTO.getRepOrderCCOutcome().add(TestModelDataBuilder.getRepOrderCCOutcomeDTO());
-        assertEquals("CONVICTED", CCLFUpdateService.getRepOrderCcOutcome(repOrderDTO));
+        assertThat("CONVICTED").isEqualTo(CCLFUpdateService.getRepOrderCcOutcome(repOrderDTO));
     }
 
     @Test
     void givenValidInput_whenGetAppealTypeIsInvoked_thenValidResponseIsReturned() {
         ApplicationDTO applicationDTO = TestModelDataBuilder.buildWorkFlowRequest().getApplicationDTO();
         applicationDTO.getCrownCourtOverviewDTO().getAppealDTO().getAppealTypeDTO().setCode(AppealType.ACS.getCode());
-        assertEquals(AppealType.ACS.getCode(), CCLFUpdateService.getAppealType(applicationDTO));
+        assertThat(AppealType.ACS.getCode()).isEqualTo(CCLFUpdateService.getAppealType(applicationDTO));
     }
 
     @Test
     void givenValidInput_whenGetOutcomeIsInvoked_thenValidResponseIsReturned() {
         ApplicationDTO applicationDTO = TestModelDataBuilder.buildWorkFlowRequest().getApplicationDTO();
         applicationDTO.getCrownCourtOverviewDTO().getCrownCourtSummaryDTO().setCcOutcome(TestModelDataBuilder.getOutcomeDTO());
-        assertEquals(CrownCourtOutcome.SUCCESSFUL.toString(), CCLFUpdateService.getOutcome(applicationDTO));
+        assertThat(CrownCourtOutcome.SUCCESSFUL.toString()).isEqualTo(CCLFUpdateService.getOutcome(applicationDTO));
     }
 
     @Test
     void givenValidInput_whenGetFeeLevelIsInvoked_thenValidResponseIsReturned() {
         ApplicationDTO applicationDTO = TestModelDataBuilder.buildWorkFlowRequest().getApplicationDTO();
         applicationDTO.getCrownCourtOverviewDTO().getCrownCourtSummaryDTO().getEvidenceProvisionFee().setFeeLevel("TEST");
-        assertEquals("TEST", CCLFUpdateService.getFeeLevel(applicationDTO));
+        assertThat("TEST").isEqualTo(CCLFUpdateService.getFeeLevel(applicationDTO));
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/CCLFUpdateServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/CCLFUpdateServiceTest.java
@@ -221,7 +221,7 @@ class CCLFUpdateServiceTest {
     void givenValidInput_whenGetOutcomeIsInvoked_thenValidResponseIsReturned() {
         ApplicationDTO applicationDTO = TestModelDataBuilder.buildWorkFlowRequest().getApplicationDTO();
         applicationDTO.getCrownCourtOverviewDTO().getCrownCourtSummaryDTO().setCcOutcome(TestModelDataBuilder.getOutcomeDTO());
-        assertThat(CrownCourtOutcome.SUCCESSFUL.toString()).isEqualTo(CCLFUpdateService.getOutcome(applicationDTO));
+        assertThat(CrownCourtOutcome.SUCCESSFUL.getCode()).isEqualTo(CCLFUpdateService.getOutcome(applicationDTO));
     }
 
     @Test

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/FeatureDecisionServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/FeatureDecisionServiceTest.java
@@ -1,6 +1,5 @@
 package uk.gov.justice.laa.crime.orchestration.service;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -51,7 +50,7 @@ class FeatureDecisionServiceTest {
         Method method = FeatureDecisionService.class.getMethod(methodName, WorkflowRequest.class);
         boolean result = (boolean) method.invoke(featureDecisionService, request);
 
-        Assertions.assertFalse(result);
+        assertThat(result).isFalse();
     }
 
     @ParameterizedTest
@@ -84,7 +83,7 @@ class FeatureDecisionServiceTest {
         Method method = FeatureDecisionService.class.getMethod(methodName, WorkflowRequest.class);
         boolean result = (boolean) method.invoke(featureDecisionService, request);
 
-        Assertions.assertFalse(result);
+        assertThat(result).isFalse();
     }
 
     @ParameterizedTest

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/ValidationServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/ValidationServiceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.laa.crime.orchestration.service;
 
+import org.assertj.core.api.Assertions;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,7 +12,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.crime.enums.NewWorkReason;
 import uk.gov.justice.laa.crime.enums.RepOrderStatus;
 import uk.gov.justice.laa.crime.enums.orchestration.Action;
-import uk.gov.justice.laa.crime.exception.ValidationException;
 import uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
@@ -27,16 +27,8 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder.TEST_USER_SESSION;
-import static uk.gov.justice.laa.crime.orchestration.service.ValidationService.ACTION_NEW_WORK_REASON_AND_SESSION_DOES_NOT_EXIST;
-import static uk.gov.justice.laa.crime.orchestration.service.ValidationService.CANNOT_MODIFY_APPLICATION_ERROR;
-import static uk.gov.justice.laa.crime.orchestration.service.ValidationService.USER_DOES_NOT_HAVE_A_ROLE_CAPABLE_OF_PERFORMING_THIS_ACTION;
-import static uk.gov.justice.laa.crime.orchestration.service.ValidationService.USER_DOES_NOT_HAVE_A_VALID_NEW_WORK_REASON_CODE;
-import static uk.gov.justice.laa.crime.orchestration.service.ValidationService.USER_HAVE_AN_EXISTING_RESERVATION_RESERVATION_NOT_ALLOWED;
+import static uk.gov.justice.laa.crime.orchestration.service.ValidationService.*;
 
 @ExtendWith(MockitoExtension.class)
 class ValidationServiceTest {
@@ -107,8 +99,7 @@ class ValidationServiceTest {
     void validateApplicationTimestamp_whenApplicationTimestampIsNull_thenNoExceptionIsThrow() {
         WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
         RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTOWithModifiedDate();
-
-        assertDoesNotThrow(() -> validationService.validate(workflowRequest, repOrderDTO));
+        Assertions.assertThatCode(() -> validationService.validate(workflowRequest, repOrderDTO)).doesNotThrowAnyException();
     }
 
     @Test
@@ -118,7 +109,7 @@ class ValidationServiceTest {
         WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkflowRequestForApplicationTimestampValidation(Optional.of(timestamp));
         RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTOWithModifiedDateOf(timestamp);
 
-        assertDoesNotThrow(() -> validationService.validate(workflowRequest, repOrderDTO));
+        Assertions.assertThatCode(() -> validationService.validate(workflowRequest, repOrderDTO)).doesNotThrowAnyException();
     }
 
     @Test
@@ -129,29 +120,25 @@ class ValidationServiceTest {
         WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkflowRequestForApplicationTimestampValidation(Optional.of(applicationTimestamp));
         RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTOWithModifiedDateOf(repOrderTimestamp);
 
-        assertDoesNotThrow(() -> validationService.validate(workflowRequest, repOrderDTO));
+        Assertions.assertThatCode(() -> validationService.validate(workflowRequest, repOrderDTO)).doesNotThrowAnyException();
     }
 
     @ParameterizedTest
     @MethodSource("validateApplicationTimestamp")
     void validateApplicationTimestamp_whenApplicationHasBeenModifiedByAnotherUser_thenExceptionIsThrown(final WorkflowRequest workflowRequest, final RepOrderDTO repOrderDTO) {
-        ValidationException validationException = assertThrows(ValidationException.class, () -> validationService.
-                validate(workflowRequest, repOrderDTO));
-        assertThat(validationException.getMessage()).isEqualTo(CANNOT_MODIFY_APPLICATION_ERROR);
+        assertThatThrownBy(() -> validationService. validate(workflowRequest, repOrderDTO)).hasMessageContaining(CANNOT_MODIFY_APPLICATION_ERROR);
     }
 
     @ParameterizedTest
     @MethodSource("validateApplicationStatus")
     void validateApplicationStatus(final WorkflowRequest workflowRequest, final RepOrderDTO repOrderDTO) {
-        ValidationException validationException = assertThrows(ValidationException.class, () -> validationService.
-                validate(workflowRequest, repOrderDTO));
-        assertThat(validationException.getMessage()).contains("Cannot update case in status of");
+        assertThatThrownBy(() -> validationService. validate(workflowRequest, repOrderDTO)).hasMessageContaining("Cannot update case in status of");
     }
 
     @ParameterizedTest
     @MethodSource("validateApplicationStatusNoException")
     void validateApplicationStatus_noException(final WorkflowRequest workflowRequest, final RepOrderDTO repOrderDTO) {
-        assertDoesNotThrow(() -> validationService.validate(workflowRequest, repOrderDTO));
+        Assertions.assertThatCode(() -> validationService.validate(workflowRequest, repOrderDTO)).doesNotThrowAnyException();
     }
 
     @Test
@@ -159,7 +146,7 @@ class ValidationServiceTest {
         UserSummaryDTO userSummaryDTO = TestModelDataBuilder.getUserSummaryDTO();
         Boolean isUserActionValid =
                 validationService.isUserActionValid(TestModelDataBuilder.getUserActionDTO(), userSummaryDTO);
-        assertTrue(isUserActionValid);
+        assertThat(isUserActionValid).isTrue();
     }
 
     @Test
@@ -319,7 +306,7 @@ class ValidationServiceTest {
         UserSummaryDTO userSummaryDTO = TestModelDataBuilder.getUserSummaryDTO();
 
         boolean isUserActionValid = validationService.isUserActionValid(userActionDTO, userSummaryDTO);
-        assertTrue(isUserActionValid);
+        assertThat(isUserActionValid).isTrue();
     }
 
     @Test
@@ -330,7 +317,7 @@ class ValidationServiceTest {
         UserSummaryDTO userSummaryDTO = TestModelDataBuilder.getUserSummaryDTO();
 
         boolean isUserActionValid = validationService.isUserActionValid(userActionDTO, userSummaryDTO);
-        assertTrue(isUserActionValid);
+        assertThat(isUserActionValid).isTrue();
     }
 
     @Test
@@ -356,7 +343,7 @@ class ValidationServiceTest {
 
         boolean isUserActionValid = validationService.isUserActionValid(userActionDTO, userSummaryDTO);
 
-        assertTrue(isUserActionValid);
+        assertThat(isUserActionValid).isTrue();
     }
 
     @Test
@@ -365,7 +352,7 @@ class ValidationServiceTest {
 
         boolean result = validationService.isUserAuthorisedToEditField(userSummaryDTO, RestrictedField.APPEAL_CC_OUTCOME);
 
-        assertFalse(result);
+        assertThat(result).isFalse();
     }
 
     @ParameterizedTest
@@ -379,7 +366,7 @@ class ValidationServiceTest {
 
         boolean result = validationService.isUserAuthorisedToEditField(userSummaryDTO, restrictedField);
 
-        assertFalse(result);
+        assertThat(result).isFalse();
     }
 
     @Test
@@ -395,7 +382,7 @@ class ValidationServiceTest {
 
         boolean result = validationService.isUserAuthorisedToEditField(userSummaryDTO, restrictedField);
 
-        assertFalse(result);
+        assertThat(result).isFalse();
     }
 
     @ParameterizedTest
@@ -412,15 +399,15 @@ class ValidationServiceTest {
 
         boolean result = validationService.isUserAuthorisedToEditField(userSummaryDTO, restrictedField);
 
-        assertTrue(result);
+        assertThat(result).isTrue();
     }
 
     @Test
     void givenUserHasNoUpliftPermissions_whenCheckUpliftFieldPermissionsInInvoked_thenExceptionIsThrown() {
         UserSummaryDTO userSummaryDTO = TestModelDataBuilder.getUserSummaryDTO();
 
-        ValidationException validationException = assertThrows(ValidationException.class, () -> validationService.checkUpliftFieldPermissions(userSummaryDTO));
-        assertThat(validationException.getMessage()).isEqualTo(USER_DOES_NOT_HAVE_A_ROLE_CAPABLE_OF_PERFORMING_THIS_ACTION);
+        assertThatThrownBy(() -> validationService.checkUpliftFieldPermissions(userSummaryDTO))
+                .hasMessageContaining(USER_DOES_NOT_HAVE_A_ROLE_CAPABLE_OF_PERFORMING_THIS_ACTION);
     }
 
     @Test
@@ -431,8 +418,9 @@ class ValidationServiceTest {
         );
         UserSummaryDTO userSummaryDTO = TestModelDataBuilder.getUserSummaryDTO(roleDataItems);
 
-        ValidationException validationException = assertThrows(ValidationException.class, () -> validationService.checkUpliftFieldPermissions(userSummaryDTO));
-        assertThat(validationException.getMessage()).isEqualTo(USER_DOES_NOT_HAVE_A_ROLE_CAPABLE_OF_PERFORMING_THIS_ACTION);
+        assertThatThrownBy(() -> validationService.checkUpliftFieldPermissions(userSummaryDTO))
+                .hasMessageContaining(USER_DOES_NOT_HAVE_A_ROLE_CAPABLE_OF_PERFORMING_THIS_ACTION);
+
     }
 
     @Test
@@ -443,6 +431,6 @@ class ValidationServiceTest {
         );
         UserSummaryDTO userSummaryDTO = TestModelDataBuilder.getUserSummaryDTO(roleDataItems);
 
-        assertDoesNotThrow(() -> validationService.checkUpliftFieldPermissions(userSummaryDTO));
+        Assertions.assertThatCode(() -> validationService.checkUpliftFieldPermissions(userSummaryDTO)).doesNotThrowAnyException();
     }
 }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1647)

Replace all JUnit 5 assertions with AssertJ assertions in Orchestration Service codebase

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.