### PR TITLE
LCAM-1688|Enhance Update Income Evidence flow to include Uplift logic

### DIFF
--- a/maat-orchestration/build.gradle
+++ b/maat-orchestration/build.gradle
@@ -17,7 +17,7 @@ java {
 def versions = [
 		pitest                  : "1.16.1",
 		springdocVersion        : "2.5.0",
-		commonsModSchemas       : "1.25.0",
+		commonsModSchemas       : "1.30.0-20250127.224841-3",
 		crimeCommonsClasses     : "4.4.0",
 		commonsRestClient       : "3.20.0",
 		wmStubRunnerVersion    	: "4.2.0"

--- a/maat-orchestration/build.gradle
+++ b/maat-orchestration/build.gradle
@@ -17,7 +17,7 @@ java {
 def versions = [
 		pitest                  : "1.16.1",
 		springdocVersion        : "2.5.0",
-		commonsModSchemas       : "1.30.0-20250127.224841-3",
+		commonsModSchemas       : "1.31.0",
 		crimeCommonsClasses     : "4.4.0",
 		commonsRestClient       : "3.20.0",
 		wmStubRunnerVersion    	: "4.2.0"

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/IncomeEvidenceMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/IncomeEvidenceMapper.java
@@ -133,6 +133,9 @@ public class IncomeEvidenceMapper {
 
         incomeEvidenceSummary.setApplicantIncomeEvidenceList(applicantEvidence);
         incomeEvidenceSummary.setPartnerIncomeEvidenceList(partnerEvidence);
+        incomeEvidenceSummary.setEvidenceReceivedDate(DateUtil.toDate(assessmentResponse.getEvidenceReceivedDate()));
+        incomeEvidenceSummary.setUpliftAppliedDate(DateUtil.toDate(assessmentResponse.getIncomeUpliftApplyDate()));
+        incomeEvidenceSummary.setUpliftRemovedDate(DateUtil.toDate(assessmentResponse.getIncomeUpliftRemoveDate()));
     }
 
     private ApiApplicantDetails getPartnerDetails(Collection<ApplicantLinkDTO> applicantLinks) {
@@ -306,6 +309,9 @@ public class IncomeEvidenceMapper {
 
         MaatApiUpdateAssessment maatApiUpdateAssessment = mapToMaatApiUpdateAssessment(workflowRequest, repOrderDTO, evidenceResponse);
         maatApiUpdateAssessment.withIncomeEvidenceDueDate(DateUtil.convertDateToDateTime(evidenceResponse.getDueDate()));
+        maatApiUpdateAssessment.withEvidenceReceivedDate(DateUtil.convertDateToDateTime(evidenceResponse.getAllEvidenceReceivedDate()));
+        maatApiUpdateAssessment.withIncomeUpliftApplyDate(DateUtil.convertDateToDateTime(evidenceResponse.getUpliftAppliedDate()));
+        maatApiUpdateAssessment.withIncomeUpliftRemoveDate(DateUtil.convertDateToDateTime(evidenceResponse.getUpliftRemovedDate()));
         return maatApiUpdateAssessment;
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/WorkflowPreProcessorService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/WorkflowPreProcessorService.java
@@ -47,9 +47,12 @@ public class WorkflowPreProcessorService {
                 && !repOrderDTO.getRorsStatus().equalsIgnoreCase(status);
     }
 
-    public void preProcessEvidenceRequest(UserActionDTO userActionDTO) {
+    public void preProcessEvidenceRequest(UserActionDTO userActionDTO, boolean isUpliftChanged) {
         UserSummaryDTO userSummaryDTO = Optional.ofNullable(userActionDTO.getUsername())
                 .map(maatCourtDataService::getUserSummary).orElse(null);
         validationService.isUserActionValid(userActionDTO, userSummaryDTO);
+        if (isUpliftChanged) {
+            validationService.checkUpliftFieldPermissions(userSummaryDTO);
+        }
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/EvidenceOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/EvidenceOrchestrationService.java
@@ -46,11 +46,11 @@ public class EvidenceOrchestrationService {
     }
 
     private static boolean hasUpliftChanged(ApplicationDTO applicationDTO, RepOrderDTO repOrderDTO) {
-        LocalDateTime currentDate = LocalDateTime.now();
-        Date today = DateUtil.toDate(currentDate);
+        LocalDateTime defaultDateTime = LocalDateTime.of(9999, 12, 31, 0, 0, 0);
+        Date defaultDate = DateUtil.toDate(defaultDateTime);
         var incomeEvidenceSummaryDTO = applicationDTO.getAssessmentDTO().getFinancialAssessmentDTO().getIncomeEvidence();
-        Date upliftAppliedDate = Objects.requireNonNullElse(incomeEvidenceSummaryDTO.getUpliftAppliedDate(), today);
-        Date upliftRemovedDate = Objects.requireNonNullElse(incomeEvidenceSummaryDTO.getUpliftRemovedDate(), today);
+        Date upliftAppliedDate = Objects.requireNonNullElse(incomeEvidenceSummaryDTO.getUpliftAppliedDate(), defaultDate);
+        Date upliftRemovedDate = Objects.requireNonNullElse(incomeEvidenceSummaryDTO.getUpliftRemovedDate(), defaultDate);
 
         Integer financialAssessmentId = applicationDTO.getAssessmentDTO().getFinancialAssessmentDTO().getId().intValue();
         FinancialAssessmentDTO financialAssessmentDTO = repOrderDTO.getFinancialAssessments()
@@ -58,9 +58,9 @@ public class EvidenceOrchestrationService {
                 .filter(assessment -> assessment.getId().equals(financialAssessmentId))
                 .findFirst().orElse(FinancialAssessmentDTO.builder().build());
         Date oldUpliftAppliedDate = DateUtil
-                .toDate(Objects.requireNonNullElse(financialAssessmentDTO.getIncomeUpliftApplyDate(), currentDate));
+                .toDate(Objects.requireNonNullElse(financialAssessmentDTO.getIncomeUpliftApplyDate(), defaultDateTime));
         Date oldUpliftRemovedDate = DateUtil
-                .toDate(Objects.requireNonNullElse(financialAssessmentDTO.getIncomeUpliftRemoveDate(), currentDate));
+                .toDate(Objects.requireNonNullElse(financialAssessmentDTO.getIncomeUpliftRemoveDate(), defaultDateTime));
 
         return !upliftAppliedDate.equals(oldUpliftAppliedDate)
                 || !upliftRemovedDate.equals(oldUpliftRemovedDate);

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/EvidenceOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/EvidenceOrchestrationService.java
@@ -5,12 +5,19 @@ import org.springframework.stereotype.Service;
 import uk.gov.justice.laa.crime.enums.orchestration.Action;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.maat_api.FinancialAssessmentDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.validation.UserActionDTO;
 import uk.gov.justice.laa.crime.orchestration.mapper.UserMapper;
+import uk.gov.justice.laa.crime.orchestration.service.ContributionService;
 import uk.gov.justice.laa.crime.orchestration.service.IncomeEvidenceService;
 import uk.gov.justice.laa.crime.orchestration.service.RepOrderService;
 import uk.gov.justice.laa.crime.orchestration.service.WorkflowPreProcessorService;
+import uk.gov.justice.laa.crime.util.DateUtil;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -20,17 +27,48 @@ public class EvidenceOrchestrationService {
     private final RepOrderService repOrderService;
     private final UserMapper userMapper;
     private final WorkflowPreProcessorService workflowPreProcessorService;
+    private final ContributionService contributionService;
 
     public ApplicationDTO updateIncomeEvidence(WorkflowRequest workflowRequest) {
 
-        preProcessRequest(workflowRequest);
-
         RepOrderDTO repOrderDTO = repOrderService.getRepOrder(workflowRequest);
-        return incomeEvidenceService.updateEvidence(workflowRequest, repOrderDTO);
+        preProcessRequest(workflowRequest, repOrderDTO);
+
+        ApplicationDTO applicationDTO = incomeEvidenceService.updateEvidence(workflowRequest, repOrderDTO);
+
+        boolean isUpliftChanged = hasUpliftChanged(applicationDTO, repOrderDTO);
+        if (isUpliftChanged) {
+            workflowRequest.setApplicationDTO(applicationDTO);
+            return contributionService.calculate(workflowRequest);
+        } else {
+            return applicationDTO;
+        }
     }
 
-    private void preProcessRequest(WorkflowRequest request) {
+    private static boolean hasUpliftChanged(ApplicationDTO applicationDTO, RepOrderDTO repOrderDTO) {
+        LocalDateTime currentDate = LocalDateTime.now();
+        Date today = DateUtil.toDate(currentDate);
+        var incomeEvidenceSummaryDTO = applicationDTO.getAssessmentDTO().getFinancialAssessmentDTO().getIncomeEvidence();
+        Date upliftAppliedDate = Objects.requireNonNullElse(incomeEvidenceSummaryDTO.getUpliftAppliedDate(), today);
+        Date upliftRemovedDate = Objects.requireNonNullElse(incomeEvidenceSummaryDTO.getUpliftRemovedDate(), today);
+
+        Integer financialAssessmentId = applicationDTO.getAssessmentDTO().getFinancialAssessmentDTO().getId().intValue();
+        FinancialAssessmentDTO financialAssessmentDTO = repOrderDTO.getFinancialAssessments()
+                .stream()
+                .filter(assessment -> assessment.getId().equals(financialAssessmentId))
+                .findFirst().orElse(FinancialAssessmentDTO.builder().build());
+        Date oldUpliftAppliedDate = DateUtil
+                .toDate(Objects.requireNonNullElse(financialAssessmentDTO.getIncomeUpliftApplyDate(), currentDate));
+        Date oldUpliftRemovedDate = DateUtil
+                .toDate(Objects.requireNonNullElse(financialAssessmentDTO.getIncomeUpliftRemoveDate(), currentDate));
+
+        return !upliftAppliedDate.equals(oldUpliftAppliedDate)
+                || !upliftRemovedDate.equals(oldUpliftRemovedDate);
+    }
+
+    private void preProcessRequest(WorkflowRequest request, RepOrderDTO repOrderDTO) {
         UserActionDTO userActionDTO = userMapper.getUserActionDTO(request, Action.MANAGE_INCOME_EVIDENCE, null);
-        workflowPreProcessorService.preProcessEvidenceRequest(userActionDTO);
+        boolean isUpliftChanged = hasUpliftChanged(request.getApplicationDTO(), repOrderDTO);
+        workflowPreProcessorService.preProcessEvidenceRequest(userActionDTO, isUpliftChanged);
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/TestModelDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/TestModelDataBuilder.java
@@ -135,6 +135,8 @@ public class TestModelDataBuilder {
     public static final LocalDateTime EVIDENCE_DUE_DATE = LocalDateTime.of(2023, 3, 18, 0, 0, 0);
     public static final LocalDateTime INCOME_EVIDENCE_RECEIVED_DATE = LocalDateTime.of(2023, 2, 18, 0, 0, 0);
     public static final LocalDate ALL_EVIDENCE_RECEIVED_DATE = LocalDate.of(2024, 12, 18);
+    public static final LocalDate UPLIFT_APPLIED_DATE = LocalDate.of(2025, 1, 18);
+    public static final LocalDate UPLIFT_REMOVED_DATE = LocalDate.of(2025, 1, 21);
 
 
     public static ApiFindHardshipResponse getApiFindHardshipResponse() {
@@ -1425,7 +1427,9 @@ public class TestModelDataBuilder {
                                 .withIncomeEvidenceItems(List.of(getIncomeEvidence(PARTNER_EVIDENCE_ID)))
                 )
                 .withAllEvidenceReceivedDate(ALL_EVIDENCE_RECEIVED_DATE)
-                .withDueDate(EVIDENCE_DUE_DATE.toLocalDate());
+                .withDueDate(EVIDENCE_DUE_DATE.toLocalDate())
+                .withUpliftAppliedDate(UPLIFT_APPLIED_DATE)
+                .withUpliftRemovedDate(UPLIFT_REMOVED_DATE);
     }
 
     private static ApiIncomeEvidence getIncomeEvidence(Integer id) {

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/IncomeEvidenceMapperTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/IncomeEvidenceMapperTest.java
@@ -26,7 +26,9 @@ import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.UserDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
+import uk.gov.justice.laa.crime.util.DateUtil;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -35,11 +37,17 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.when;
 import static uk.gov.justice.laa.crime.enums.AssessmentType.FULL;
-import static uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder.EVIDENCE_RECEIVED_DATE;
 
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(SoftAssertionsExtension.class)
 class IncomeEvidenceMapperTest {
+
+    private static final LocalDateTime EVIDENCE_RECEIVED_DATE = DateUtil
+            .convertDateToDateTime(TestModelDataBuilder.ALL_EVIDENCE_RECEIVED_DATE);
+    private static final LocalDateTime INCOME_UPLIFT_APPLY_DATE = DateUtil
+            .convertDateToDateTime(TestModelDataBuilder.UPLIFT_APPLIED_DATE);
+    private static final LocalDateTime INCOME_UPLIFT_REMOVED_DATE = DateUtil
+            .convertDateToDateTime(TestModelDataBuilder.UPLIFT_REMOVED_DATE);
 
     @Mock
     private UserMapper userMapper;
@@ -176,7 +184,8 @@ class IncomeEvidenceMapperTest {
         noExistingEvidences.getFinAssIncomeEvidences().forEach(evidence -> evidence.setDateReceived(null));
 
         MaatApiUpdateAssessment existingEvidencesAssessment = TestModelDataBuilder.getMaatApiUpdateAssessment(FULL);
-        existingEvidencesAssessment.getFinAssIncomeEvidences().forEach(evidence -> evidence.setDateReceived(EVIDENCE_RECEIVED_DATE));
+        existingEvidencesAssessment.getFinAssIncomeEvidences()
+                .forEach(evidence -> evidence.setDateReceived(TestModelDataBuilder.EVIDENCE_RECEIVED_DATE));
         RepOrderDTO existingEvidencesRepOrderDTO = RepOrderDTO.builder()
                 .passportAssessments(List.of(TestModelDataBuilder.getPassportAssessmentDTO()))
                 .build();
@@ -231,6 +240,9 @@ class IncomeEvidenceMapperTest {
         WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest(CourtType.CROWN_COURT);
         ApiUpdateIncomeEvidenceResponse apiUpdateIncomeEvidenceResponse = TestModelDataBuilder.getUpdateIncomeEvidenceResponse();
         expectedAssessment.setIncomeEvidenceDueDate(TestModelDataBuilder.EVIDENCE_DUE_DATE);
+        expectedAssessment.setEvidenceReceivedDate(EVIDENCE_RECEIVED_DATE);
+        expectedAssessment.setIncomeUpliftApplyDate(INCOME_UPLIFT_APPLY_DATE);
+        expectedAssessment.setIncomeUpliftRemoveDate(INCOME_UPLIFT_REMOVED_DATE);
 
         when(meansAssessmentMapper.assessmentDetailsBuilder(anyList()))
                 .thenReturn(List.of(TestModelDataBuilder.getAssessmentDetail()));

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/WorkflowPreProcessorServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/WorkflowPreProcessorServiceTest.java
@@ -147,8 +147,21 @@ class WorkflowPreProcessorServiceTest {
         doThrow(new CrimeValidationException(List.of(ValidationService.USER_DOES_NOT_HAVE_A_ROLE_CAPABLE_OF_PERFORMING_THIS_ACTION)))
                 .when(validationService).isUserActionValid(userActionDTO, userSummaryDTO);
 
-        assertThatThrownBy(() -> workflowPreProcessorService.preProcessEvidenceRequest(userActionDTO))
+        assertThatThrownBy(() -> workflowPreProcessorService.preProcessEvidenceRequest(userActionDTO, false))
                 .isInstanceOf(CrimeValidationException.class);
     }
 
+    @Test
+    void givenUserNotAllowedToApplyUplift_whenPreProcessEvidenceRequestIsInvoked_thenExceptionIsThrown() {
+        UserActionDTO userActionDTO = TestModelDataBuilder.getUserActionDTO();
+        UserSummaryDTO userSummaryDTO = TestModelDataBuilder.getUserSummaryDTO();
+
+        when(maatCourtDataService.getUserSummary(userActionDTO.getUsername())).thenReturn(userSummaryDTO);
+        when(validationService.isUserActionValid(userActionDTO, userSummaryDTO)).thenReturn(true);
+        doThrow(new ValidationException(ValidationService.USER_DOES_NOT_HAVE_A_ROLE_CAPABLE_OF_PERFORMING_THIS_ACTION))
+                .when(validationService).checkUpliftFieldPermissions(userSummaryDTO);
+
+        assertThatThrownBy(() -> workflowPreProcessorService.preProcessEvidenceRequest(userActionDTO, true))
+                .isInstanceOf(ValidationException.class);
+    }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/EvidenceOrchestrationServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/EvidenceOrchestrationServiceTest.java
@@ -2,18 +2,27 @@ package uk.gov.justice.laa.crime.orchestration.service.orchestration;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.maat_api.FinancialAssessmentDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.validation.UserActionDTO;
 import uk.gov.justice.laa.crime.orchestration.mapper.UserMapper;
+import uk.gov.justice.laa.crime.orchestration.service.ContributionService;
 import uk.gov.justice.laa.crime.orchestration.service.IncomeEvidenceService;
 import uk.gov.justice.laa.crime.orchestration.service.RepOrderService;
 import uk.gov.justice.laa.crime.orchestration.service.WorkflowPreProcessorService;
+import uk.gov.justice.laa.crime.util.DateUtil;
+
+import java.time.LocalDateTime;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -32,21 +41,60 @@ class EvidenceOrchestrationServiceTest {
     private UserMapper userMapper;
     @Mock
     private WorkflowPreProcessorService workflowPreProcessorService;
+    @Mock
+    private ContributionService contributionService;
 
     @Test
     void givenWorkflowRequest_whenUpdateIncomeEvidenceIsInvoked_thenApplicationDTOisUpdatedWithEvidence() {
         WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
-        RepOrderDTO repOrder = TestModelDataBuilder.buildRepOrderDTO("CURR");
         ApplicationDTO expected = workflowRequest.getApplicationDTO();
+        var incomeEvidenceSummaryDTO = expected.getAssessmentDTO().getFinancialAssessmentDTO().getIncomeEvidence();
+        RepOrderDTO repOrder = TestModelDataBuilder.buildRepOrderDTOWithAssessorName();
+        FinancialAssessmentDTO financialAssessmentDTO = repOrder.getFinancialAssessments().get(0);
+        financialAssessmentDTO.setIncomeUpliftApplyDate(DateUtil.toLocalDateTime(incomeEvidenceSummaryDTO.getUpliftAppliedDate()));
+        financialAssessmentDTO.setIncomeUpliftRemoveDate(DateUtil.toLocalDateTime(incomeEvidenceSummaryDTO.getUpliftRemovedDate()));
 
         when(repOrderService.getRepOrder(workflowRequest)).thenReturn(repOrder);
         UserActionDTO userActionDTO = new UserActionDTO();
         when(userMapper.getUserActionDTO(any(), any(), any())).thenReturn(userActionDTO);
-        doNothing().when(workflowPreProcessorService).preProcessEvidenceRequest(userActionDTO);
+        doNothing().when(workflowPreProcessorService).preProcessEvidenceRequest(userActionDTO, false);
         when(incomeEvidenceService.updateEvidence(workflowRequest, repOrder)).thenReturn(expected);
 
         ApplicationDTO actual = evidenceOrchestrationService.updateIncomeEvidence(workflowRequest);
 
         assertThat(actual).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @MethodSource("upliftChangeSet")
+    void givenUpliftIsChanged_whenUpdateIncomeEvidenceIsInvoked_thenContributionsAreCalculated(WorkflowRequest workflowRequest, RepOrderDTO repOrder) {
+        ApplicationDTO expected = workflowRequest.getApplicationDTO();
+        when(repOrderService.getRepOrder(workflowRequest)).thenReturn(repOrder);
+        UserActionDTO userActionDTO = new UserActionDTO();
+        when(userMapper.getUserActionDTO(any(), any(), any())).thenReturn(userActionDTO);
+        doNothing().when(workflowPreProcessorService).preProcessEvidenceRequest(userActionDTO, true);
+        when(incomeEvidenceService.updateEvidence(workflowRequest, repOrder)).thenReturn(expected);
+        when(contributionService.calculate(workflowRequest)).thenReturn(expected);
+
+        ApplicationDTO actual = evidenceOrchestrationService.updateIncomeEvidence(workflowRequest);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> upliftChangeSet() {
+        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
+        var incomeEvidenceSummaryDTO = workflowRequest.getApplicationDTO().getAssessmentDTO().getFinancialAssessmentDTO().getIncomeEvidence();
+        RepOrderDTO repOrderApplyUplift = TestModelDataBuilder.buildRepOrderDTOWithAssessorName();
+        repOrderApplyUplift.getFinancialAssessments().get(0).setIncomeUpliftApplyDate(LocalDateTime.now());
+        repOrderApplyUplift.getFinancialAssessments().get(0).setIncomeUpliftRemoveDate(
+                DateUtil.toLocalDateTime(incomeEvidenceSummaryDTO.getUpliftRemovedDate()));
+
+        RepOrderDTO repOrderRemoveUplift = TestModelDataBuilder.buildRepOrderDTOWithAssessorName();
+        repOrderApplyUplift.getFinancialAssessments().get(0).setIncomeUpliftApplyDate(
+                DateUtil.toLocalDateTime(incomeEvidenceSummaryDTO.getUpliftAppliedDate()));
+        repOrderApplyUplift.getFinancialAssessments().get(0).setIncomeUpliftRemoveDate(LocalDateTime.now());
+        return Stream.of(
+                Arguments.of(workflowRequest, repOrderApplyUplift),
+                Arguments.of(workflowRequest, repOrderRemoveUplift)
+        );
     }
 }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1688)

Enhanced the update_income_evidence flow to include the business logic related to Uplift functionality.

When Uplift fields (Uplift Applied Date, Uplift Removed Date) are modified new validation is invoked to check the user privileges.

When the uplift is changed as a result of updating the income evidence, contribution is recalculated. 

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.