### PR TITLE
Pass existing Crown Court hardship review assessment to C3

### DIFF
--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/ContributionMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/ContributionMapper.java
@@ -137,6 +137,22 @@ public class ContributionMapper extends CrownCourtMapper {
                             .withStatus(CurrentStatus.getFrom(passported.getAssessementStatusDTO().getStatus()))
             );
         }
+
+        if (financialAssessmentDTO.getHardship() != null) {
+            HardshipReviewDTO crownCourtHardshipReviewDTO = financialAssessmentDTO.getHardship().getCrownCourtHardship();
+
+            if (crownCourtHardshipReviewDTO != null && crownCourtHardshipReviewDTO.getId() != null) {
+                log.info("applicationDtoToAssessments.crownCourtHardshipReviewDTO.status-->" + crownCourtHardshipReviewDTO.getAsessmentStatus().getStatus());
+                assessmentList.add(
+                    new ApiAssessment()
+                        .withAssessmentType(AssessmentType.HARDSHIP)
+                        .withResult(AssessmentResult.getFrom(crownCourtHardshipReviewDTO.getReviewResult()))
+                        .withAssessmentDate(toLocalDateTime(crownCourtHardshipReviewDTO.getReviewDate()))
+                        .withNewWorkReason(NewWorkReason.getFrom(crownCourtHardshipReviewDTO.getNewWorkReason().getCode()))
+                        .withStatus(CurrentStatus.getFrom(crownCourtHardshipReviewDTO.getAsessmentStatus().getStatus())));
+            }
+        }
+
         log.info("applicationDtoToAssessments.assessmentList-->" + assessmentList);
         return assessmentList;
     }


### PR DESCRIPTION
This PR adds mapping of an existing Crown Court hardship review assessment to the _ApiMaatCalculateContributionRequest_ sent to the Contributions Service for the purpose of calculating contributions.

This mapping fixes a bug where contributions were not calculated after a passing Crown Court hardship review, as to the Contributions Service there had been no overall change in assessment status, meaning that contributions were calculated to be the same as previous and therefore no new contribution was persisted.

As part of this work, it was considered to also map Magistrates Court hardship review assessments to the same request to the Contributions Service, as the mapping method changed in this commit is called from various paths, including when creating and updating means assessments, updating evidence and when creating and updating either Magistrates or Crown Court hardship reviews. For the purposes of the specific bug this PR looks to address, as well as how the existing legacy stored procedure (`calc_appeal_contrib`) currently operates, the decision has been made to only map Crown Court hardship reviews, however this may need to be revisited in the future.

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1729)