### PR TITLE
Fix precision of solicitors hours to 2dp

### DIFF
--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/HardshipMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/HardshipMapper.java
@@ -106,9 +106,8 @@ public class HardshipMapper {
             return new SolicitorCosts()
                     .withVat(solicitorsCosts.getSolicitorVat())
                     .withRate(solicitorsCosts.getSolicitorRate())
-                    // Converting from double to BigDecimal, truncate to 1 decimal place
                     .withHours(BigDecimal.valueOf(solicitorsCosts.getSolicitorHours())
-                            .setScale(1, RoundingMode.DOWN))
+                            .setScale(2, RoundingMode.DOWN))
                     .withDisbursements(solicitorsCosts.getSolicitorDisb())
                     .withEstimatedTotal(solicitorsCosts.getSolicitorEstimatedTotalCost());
         }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/TestModelDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/TestModelDataBuilder.java
@@ -105,8 +105,8 @@ public class TestModelDataBuilder {
     private static final BigDecimal SOLICITOR_DISBURSEMENTS = BigDecimal.valueOf(375);
     private static final BigDecimal SOLICITOR_RATE = BigDecimal.valueOf(200);
     // Solicitors Costs
-    private static final BigDecimal SOLICITOR_HOURS = BigDecimal.valueOf(50)
-            .setScale(1, RoundingMode.DOWN);
+    private static final BigDecimal SOLICITOR_HOURS = BigDecimal.valueOf(52.45)
+        .setScale(2, RoundingMode.DOWN);
     private static final LocalDateTime DATE_REVIEWED_DATETIME = LocalDateTime.of(2022, 11, 12, 0, 0, 0);
     private static final Date DATE_REVIEWED =
             Date.from(Instant.ofEpochSecond(DATE_REVIEWED_DATETIME.toEpochSecond(ZoneOffset.UTC)));


### PR DESCRIPTION
This PR fixes the precision of solicitors hours from 1dp to 2dp, which aligns with how solicitors log their time and how caseworkers expect to be able to input this into MAAT. Both MAAT and the Hardship Service already use a precision of 2dp for these hours, so this commit fixes the mapping between the Orchestration Service and the Hardship Service to ensure that the correct value is passed when creating the hardship review.

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1736)
