### PR TITLE
Add CrownCourtController integration tests

### DIFF
--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/integration/CrownCourtIntegrationTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/integration/CrownCourtIntegrationTest.java
@@ -1,0 +1,147 @@
+package uk.gov.justice.laa.crime.orchestration.integration;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.DEFINED_PORT;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder.getApplicationDTO;
+import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.assertStubForInvokeStoredProcedure;
+import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.assertStubForUpdateCrownCourt;
+import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.assertStubForUpdateSendToCCLF;
+import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.stubForGetRepOrders;
+import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.stubForGetUserSummary;
+import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.stubForInvokeStoredProcedure;
+import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.stubForOAuth;
+import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.stubForUpdateCrownCourt;
+import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.stubForUpdateSendToCCLF;
+import static uk.gov.justice.laa.crime.util.RequestBuilderUtils.buildRequestGivenContent;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.web.FilterChainProxy;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import uk.gov.justice.laa.crime.common.model.proceeding.response.ApiUpdateCrownCourtOutcomeResponse;
+import uk.gov.justice.laa.crime.orchestration.config.OrchestrationTestConfiguration;
+import uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder;
+import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.maat_api.FeatureToggleDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.validation.UserSummaryDTO;
+import uk.gov.justice.laa.crime.orchestration.enums.FeatureToggle;
+import uk.gov.justice.laa.crime.orchestration.enums.FeatureToggleAction;
+
+@DirtiesContext
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Import(OrchestrationTestConfiguration.class)
+@SpringBootTest(classes = OrchestrationTestConfiguration.class, webEnvironment = DEFINED_PORT)
+@AutoConfigureWireMock(port = 9999)
+@AutoConfigureObservability
+class CrownCourtIntegrationTest {
+    private static final String ENDPOINT_URL = "/api/internal/v1/orchestration/crown-court";
+    private static final String MAAT_API_ASSESSMENT_URL = "/api/internal/v1/assessment";
+
+    private MockMvc mvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private FilterChainProxy springSecurityFilterChain;
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @Autowired
+    private WireMockServer wiremock;
+
+    @BeforeEach
+    void setUp() {
+        this.mvc = MockMvcBuilders.webAppContextSetup(this.webApplicationContext)
+            .addFilter(springSecurityFilterChain).build();
+    }
+
+    @AfterEach
+    void cleanUp() {
+        wiremock.resetAll();
+    }
+
+    @Test
+    void givenNoOAuthToken_whenUpdateIsInvoked_thenUnauthorisedResponseIsReturned() throws Exception {
+        mvc.perform(buildRequestGivenContent(HttpMethod.PUT, "{}", ENDPOINT_URL, false))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void givenBadRequest_whenUpdateIsInvoked_thenBadRequestResponseIsReturned() throws Exception {
+        WorkflowRequest request = TestModelDataBuilder.buildWorkFlowRequest();
+        request.setApplicationDTO(null);
+        String requestBody = objectMapper.writeValueAsString(request);
+
+        stubForOAuth();
+
+        mvc.perform(buildRequestGivenContent(HttpMethod.PUT, requestBody, ENDPOINT_URL))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void givenErrorCallingMaatApi_whenUpdateIsInvoked_thenServerErrorResponseIsReturned() throws Exception {
+        WorkflowRequest request = TestModelDataBuilder.buildWorkFlowRequest();
+        request.setApplicationDTO(getApplicationDTO());
+
+        String requestBody = objectMapper.writeValueAsString(request);
+
+        stubForOAuth();
+        stubFor(post(urlMatching(MAAT_API_ASSESSMENT_URL + "/execute-stored-procedure"))
+            .willReturn(WireMock.serverError()));
+
+        mvc.perform(buildRequestGivenContent(HttpMethod.PUT, requestBody, ENDPOINT_URL))
+            .andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    void givenValidRequest_whenUpdateIsInvoked_thenCrownCourtIsUpdated() throws Exception {
+        WorkflowRequest request = TestModelDataBuilder.buildWorkFlowRequest();
+        ApiUpdateCrownCourtOutcomeResponse updateCrownCourtOutcomeResponse = TestModelDataBuilder.getApiUpdateCrownCourtResponse();
+        ApplicationDTO applicationDTO = getApplicationDTO();
+        UserSummaryDTO userSummaryDTO = TestModelDataBuilder.getUserSummaryDTO();
+        userSummaryDTO.setFeatureToggle(List.of(FeatureToggleDTO.builder()
+            .featureName(FeatureToggle.MAAT_POST_ASSESSMENT_PROCESSING.getName())
+            .action(FeatureToggleAction.READ.getName())
+            .isEnabled("Y")
+            .build()));
+
+        request.setApplicationDTO(applicationDTO);
+
+        String requestBody = objectMapper.writeValueAsString(request);
+
+        stubForOAuth();
+        stubForInvokeStoredProcedure(objectMapper.writeValueAsString(applicationDTO));
+        stubForUpdateCrownCourt(objectMapper.writeValueAsString(updateCrownCourtOutcomeResponse));
+        stubForGetUserSummary(objectMapper.writeValueAsString(userSummaryDTO));
+        stubForGetRepOrders(objectMapper.writeValueAsString(TestModelDataBuilder.buildRepOrderDTO(null)));
+        stubForUpdateSendToCCLF();
+
+        mvc.perform(buildRequestGivenContent(HttpMethod.PUT, requestBody, ENDPOINT_URL))
+            .andExpect(status().isOk());
+
+        assertStubForUpdateCrownCourt(1);
+        assertStubForUpdateSendToCCLF(1);
+        assertStubForInvokeStoredProcedure(3);
+    }
+}

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/integration/CrownCourtIntegrationTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/integration/CrownCourtIntegrationTest.java
@@ -7,13 +7,13 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder.getApplicationDTO;
 import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.assertStubForInvokeStoredProcedure;
-import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.assertStubForUpdateCrownCourt;
+import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.assertStubForUpdateCrownCourtOutcome;
 import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.assertStubForUpdateSendToCCLF;
 import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.stubForGetRepOrders;
 import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.stubForGetUserSummary;
 import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.stubForInvokeStoredProcedure;
 import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.stubForOAuth;
-import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.stubForUpdateCrownCourt;
+import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.stubForUpdateCrownCourtOutcome;
 import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.stubForUpdateSendToCCLF;
 import static uk.gov.justice.laa.crime.util.RequestBuilderUtils.buildRequestGivenContent;
 
@@ -132,7 +132,7 @@ class CrownCourtIntegrationTest {
 
         stubForOAuth();
         stubForInvokeStoredProcedure(objectMapper.writeValueAsString(applicationDTO));
-        stubForUpdateCrownCourt(objectMapper.writeValueAsString(updateCrownCourtOutcomeResponse));
+        stubForUpdateCrownCourtOutcome(objectMapper.writeValueAsString(updateCrownCourtOutcomeResponse));
         stubForGetUserSummary(objectMapper.writeValueAsString(userSummaryDTO));
         stubForGetRepOrders(objectMapper.writeValueAsString(TestModelDataBuilder.buildRepOrderDTO(null)));
         stubForUpdateSendToCCLF();
@@ -140,7 +140,7 @@ class CrownCourtIntegrationTest {
         mvc.perform(buildRequestGivenContent(HttpMethod.PUT, requestBody, ENDPOINT_URL))
             .andExpect(status().isOk());
 
-        assertStubForUpdateCrownCourt(1);
+        assertStubForUpdateCrownCourtOutcome(1);
         assertStubForUpdateSendToCCLF(1);
         assertStubForInvokeStoredProcedure(3);
     }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/integration/HardshipIntegrationTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/integration/HardshipIntegrationTest.java
@@ -180,7 +180,19 @@ class HardshipIntegrationTest {
                 .andExpect(status().is5xxServerError());
         verify(exactly(1), putRequestedFor(urlPathMatching("/api/internal/v1/hardship/.*")));
         verify(exactly(1), patchRequestedFor(urlPathMatching("/api/internal/v1/hardship/.*")));
+    }
 
+    @Test
+    void givenAValidContent_whenUpdateIsInvoked_thenShouldSuccess() throws Exception {
+        stubForUpdateHardship();
+        String requestBody = objectMapper
+            .writeValueAsString(TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.MAGISTRATE));
+        mvc.perform(buildRequestGivenContent(HttpMethod.PUT, requestBody, ENDPOINT_URL))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.crownCourtOverviewDTO.contribution.monthlyContribs").value(150.0));
+
+        verifyStubForUpdateHardship(CourtType.MAGISTRATE);
     }
 
     @Test
@@ -207,18 +219,7 @@ class HardshipIntegrationTest {
         verify(exactly(0), patchRequestedFor(urlPathMatching("/api/internal/v1/hardship/.*")));
     }
 
-    @Test
-    void givenAValidContent_whenUpdateIsInvoked_thenShouldSuccess() throws Exception {
-        stubForUpdateHardship();
-        String requestBody = objectMapper
-                .writeValueAsString(TestModelDataBuilder.buildWorkflowRequestWithHardship(CourtType.MAGISTRATE));
-        mvc.perform(buildRequestGivenContent(HttpMethod.PUT, requestBody, ENDPOINT_URL))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.crownCourtOverviewDTO.contribution.monthlyContribs").value(150.0));
 
-        verifyStubForUpdateHardship(CourtType.MAGISTRATE);
-    }
 
     private void stubForUpdateHardship() throws JsonProcessingException {
         wiremock.stubFor(put(urlMatching("/api/internal/v1/hardship/.*"))

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/integration/MeansAssessmentIntegrationTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/integration/MeansAssessmentIntegrationTest.java
@@ -139,7 +139,7 @@ class MeansAssessmentIntegrationTest {
                 .willReturn(WireMock.ok()
                         .withHeader("Content-Type", String.valueOf(MediaType.APPLICATION_JSON))
                         .withBody(cmaResponse)));
-        stubForUpdateCrownCourtProceedings(ccpResponse);
+        stubForUpdateCrownCourtApplication(ccpResponse);
         stubForCalculateContributions(cccCalculateResponse);
         stubForGetContributionsSummary(cccSummariesResponse);
         stubForGetUserSummary(userSummaryResponse);
@@ -210,7 +210,7 @@ class MeansAssessmentIntegrationTest {
                 .willReturn(WireMock.ok()
                         .withHeader("Content-Type", String.valueOf(MediaType.APPLICATION_JSON))
                         .withBody(cmaResponse)));
-        stubForUpdateCrownCourtProceedings(ccpResponse);
+        stubForUpdateCrownCourtApplication(ccpResponse);
         stubForCalculateContributions(cccCalculateResponse);
         stubForGetContributionsSummary(cccSummariesResponse);
         stubForGetUserSummary(userSummaryResponse);

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/integration/MeansAssessmentIntegrationTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/integration/MeansAssessmentIntegrationTest.java
@@ -154,7 +154,7 @@ class MeansAssessmentIntegrationTest {
 
         mvc.perform(buildRequestGivenContent(HttpMethod.POST, requestBody, ENDPOINT_URL))
                 .andExpect(status().isOk());
-        assertStubForUpdateCrownCourtProceedings(1);
+        assertStubForUpdateCrownCourtApplication(1);
         assertStubForCalculateContributions(1);
         assertStubForGetContributionsSummary(1);
         assertStubForInvokeStoredProcedure(4);
@@ -225,7 +225,7 @@ class MeansAssessmentIntegrationTest {
 
         mvc.perform(buildRequestGivenContent(HttpMethod.PUT, requestBody, ENDPOINT_URL))
                 .andExpect(status().isOk());
-        assertStubForUpdateCrownCourtProceedings(1);
+        assertStubForUpdateCrownCourtApplication(1);
         assertStubForCalculateContributions(1);
         assertStubForGetContributionsSummary(1);
         assertStubForInvokeStoredProcedure(4);

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/utils/WiremockStubs.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/utils/WiremockStubs.java
@@ -46,7 +46,7 @@ public class WiremockStubs {
                     .withBody(response))));
     }
 
-    public static void stubForUpdateCrownCourt(String response) {
+    public static void stubForUpdateCrownCourtOutcome(String response) {
         stubFor((put(urlMatching(CCP_URL + "/update-crown-court"))
             .willReturn(WireMock.ok()
                 .withHeader("Content-Type", String.valueOf(MediaType.APPLICATION_JSON))
@@ -60,11 +60,11 @@ public class WiremockStubs {
                         .withBody(response))));
     }
 
-    public static void assertStubForUpdateCrownCourtProceedings(int times) {
+    public static void assertStubForUpdateCrownCourtApplication(int times) {
         verify(exactly(times), putRequestedFor(urlPathMatching(CCP_URL)));
     }
 
-    public static void assertStubForUpdateCrownCourt(int times) {
+    public static void assertStubForUpdateCrownCourtOutcome(int times) {
         verify(exactly(times), putRequestedFor(urlPathMatching(CCP_URL + "/update-crown-court")));
     }
 

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/utils/WiremockStubs.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/utils/WiremockStubs.java
@@ -18,6 +18,7 @@ public class WiremockStubs {
 
     private static final String CCP_URL = "/api/internal/v1/proceedings";
     private static final String CCC_URL = "/api/internal/v1/contribution";
+    private static final String MAAT_API_APPLICATION_URL = "/api/internal/v1/application";
     private static final String MAAT_API_ASSESSMENT_URL = "/api/internal/v1/assessment";
     private static final String CMA_ROLLBACK_URL = "/api/internal/v1/assessment/means/rollback/";
     private static final String MAAT_API_USER_URL = "/api/internal/v1/users/summary/";
@@ -38,11 +39,18 @@ public class WiremockStubs {
                     .withBody(mapper.writeValueAsString(token))));
     }
 
-    public static void stubForUpdateCrownCourtProceedings(String response) {
+    public static void stubForUpdateCrownCourtApplication(String response) {
         stubFor((put(urlMatching(CCP_URL))
             .willReturn(WireMock.ok()
                     .withHeader("Content-Type", String.valueOf(MediaType.APPLICATION_JSON))
                     .withBody(response))));
+    }
+
+    public static void stubForUpdateCrownCourt(String response) {
+        stubFor((put(urlMatching(CCP_URL + "/update-crown-court"))
+            .willReturn(WireMock.ok()
+                .withHeader("Content-Type", String.valueOf(MediaType.APPLICATION_JSON))
+                .withBody(response))));
     }
 
     public static void stubForGetAssessment(int financialAssessmentId, String response) {
@@ -54,6 +62,10 @@ public class WiremockStubs {
 
     public static void assertStubForUpdateCrownCourtProceedings(int times) {
         verify(exactly(times), putRequestedFor(urlPathMatching(CCP_URL)));
+    }
+
+    public static void assertStubForUpdateCrownCourt(int times) {
+        verify(exactly(times), putRequestedFor(urlPathMatching(CCP_URL + "/update-crown-court")));
     }
 
     public static void stubForCalculateContributions(String response) {
@@ -145,7 +157,11 @@ public class WiremockStubs {
     }
 
     public static void stubForUpdateSendToCCLF() {
-        stubFor(put(urlMatching(MAAT_API_ASSESSMENT_URL + "/rep-orders/" + TestModelDataBuilder.REP_ID + "/send-to-cclf"))
+        stubFor(put(urlMatching(MAAT_API_APPLICATION_URL + "/applicant/update-cclf"))
                 .willReturn(WireMock.ok()));
+    }
+
+    public static void assertStubForUpdateSendToCCLF(int times) {
+        verify(exactly(times), putRequestedFor(urlPathMatching(MAAT_API_APPLICATION_URL + "/applicant/update-cclf")));
     }
 }


### PR DESCRIPTION
This PR adds integration tests for the _CrownCourtController_, which calls through to update Crown Court proceedings via the Crown Court Proceedings Service.

This PR also renames the stub methods for the Crown Court Proceedings Service used to update proceedings, to make
it clearer what these methods are stubbing. This is especially true for the update method available at
`api/internal/v1/proceedings/update-crown-court` within CCP, which is not updateing the Crown Court but is actually
updating the Crown Court Outcome.

There should be a later clean-up task to update Crime Commons to rename the _ApiUpdateCrownCourtRequest_ class to be called _ApiUpdateCrownCourtOutcomeRequest_, to specify what it is actually being used for (which is **not** updating the Crown Court) and to align with the already correctly-named _ApiUpdateCrownCourtOutcomeResponse_ class.

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1731)