### PR TITLE
Fix security vulnerability in spring-security-crypto

### DIFF
--- a/maat-orchestration/build.gradle
+++ b/maat-orchestration/build.gradle
@@ -20,7 +20,9 @@ def versions = [
 		commonsModSchemas       : "1.32.0",
 		crimeCommonsClasses     : "4.4.0",
 		commonsRestClient       : "3.20.0",
-		wmStubRunnerVersion    	: "4.2.0"
+		wmStubRunnerVersion    	: "4.2.0",
+		oauth2ResourceServer    : "3.4.1",
+		securityCrypto          : "6.4.4"
 ]
 
 configurations {
@@ -46,9 +48,10 @@ dependencies {
 	implementation "io.micrometer:micrometer-registry-prometheus"
 	implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:$versions.springdocVersion"
 
-	implementation "org.springframework.boot:spring-boot-starter-oauth2-resource-server"
+	implementation "org.springframework.boot:spring-boot-starter-oauth2-resource-server:$versions.oauth2ResourceServer"
 	implementation "org.springframework.boot:spring-boot-starter-security"
 	implementation "org.springframework.boot:spring-boot-starter-validation"
+	implementation "org.springframework.security:spring-security-crypto:$versions.securityCrypto"
 
 	compileOnly "org.projectlombok:lombok"
 	annotationProcessor "org.projectlombok:lombok"


### PR DESCRIPTION
This PR fixes the [recently published security vulnerability] (https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKSECURITY-9486467) in `spring-security-crypto` by forcibly bumping the dependency up to version `6.4.4`.

Spring Boot version `3.4.4` does patch `spring-security-crypto` to this same version, but in order to upgrade Spring Boot, Crime Commons modules also need to be upgraded at the same time, which has more potential to cause problems elsewhere. In that context and to ensure that the Orchestration Service can be as quickly fixed to allow deployments once again, this temporary fix is made in this PR until such time as Spring Boot is upgraded to `3.4.4`.

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1788)