### PR TITLE
Fix inconsistencies with Rep Order date modified

### DIFF
--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/ApplicationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/ApplicationService.java
@@ -1,0 +1,23 @@
+package uk.gov.justice.laa.crime.orchestration.service;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ApplicationService {
+    private final RepOrderService repOrderService;
+
+    public void updateDateModified(WorkflowRequest request, ApplicationDTO applicationDTO) {
+        LocalDateTime updatedDateModified = LocalDateTime.now();
+
+        repOrderService.updateRepOrderDateModified(request, updatedDateModified);
+        applicationDTO.setTimestamp(updatedDateModified.atZone(ZoneOffset.UTC));
+    }
+}

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/EvidenceOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/EvidenceOrchestrationService.java
@@ -1,6 +1,5 @@
 package uk.gov.justice.laa.crime.orchestration.service.orchestration;
 
-import java.time.ZoneOffset;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import uk.gov.justice.laa.crime.enums.orchestration.Action;
@@ -10,6 +9,7 @@ import uk.gov.justice.laa.crime.orchestration.dto.maat_api.FinancialAssessmentDT
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.validation.UserActionDTO;
 import uk.gov.justice.laa.crime.orchestration.mapper.UserMapper;
+import uk.gov.justice.laa.crime.orchestration.service.ApplicationService;
 import uk.gov.justice.laa.crime.orchestration.service.ContributionService;
 import uk.gov.justice.laa.crime.orchestration.service.IncomeEvidenceService;
 import uk.gov.justice.laa.crime.orchestration.service.RepOrderService;
@@ -26,6 +26,7 @@ public class EvidenceOrchestrationService {
 
     private final IncomeEvidenceService incomeEvidenceService;
     private final RepOrderService repOrderService;
+    private final ApplicationService applicationService;
     private final UserMapper userMapper;
     private final WorkflowPreProcessorService workflowPreProcessorService;
     private final ContributionService contributionService;
@@ -43,9 +44,7 @@ public class EvidenceOrchestrationService {
             applicationDTO = contributionService.calculate(workflowRequest);
         }
 
-        LocalDateTime updatedDateModified = LocalDateTime.now();
-        repOrderService.updateRepOrderDateModified(workflowRequest, updatedDateModified);
-        applicationDTO.setTimestamp(updatedDateModified.atZone(ZoneOffset.UTC));
+        applicationService.updateDateModified(workflowRequest, applicationDTO);
 
         return applicationDTO;
     }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/EvidenceOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/EvidenceOrchestrationService.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.laa.crime.orchestration.service.orchestration;
 
+import java.time.ZoneOffset;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import uk.gov.justice.laa.crime.enums.orchestration.Action;
@@ -42,7 +43,9 @@ public class EvidenceOrchestrationService {
             applicationDTO = contributionService.calculate(workflowRequest);
         }
 
-        repOrderService.updateRepOrderDateModified(workflowRequest, LocalDateTime.now());
+        LocalDateTime updatedDateModified = LocalDateTime.now();
+        repOrderService.updateRepOrderDateModified(workflowRequest, updatedDateModified);
+        applicationDTO.setTimestamp(updatedDateModified.atZone(ZoneOffset.UTC));
 
         return applicationDTO;
     }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/HardshipOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/HardshipOrchestrationService.java
@@ -1,8 +1,6 @@
 package uk.gov.justice.laa.crime.orchestration.service.orchestration;
 
 import io.sentry.Sentry;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -33,6 +31,7 @@ public class HardshipOrchestrationService implements AssessmentOrchestrator<Hard
     private final HardshipMapper hardshipMapper;
     private final WorkflowPreProcessorService workflowPreProcessorService;
     private final RepOrderService repOrderService;
+    private final ApplicationService applicationService;
 
     private final ApplicationTrackingMapper applicationTrackingMapper;
     private final CATDataService catDataService;
@@ -53,7 +52,7 @@ public class HardshipOrchestrationService implements AssessmentOrchestrator<Hard
         ApplicationDTO application = request.getApplicationDTO();
 
         ApiPerformHardshipResponse performHardshipResponse = hardshipService.create(request);
-        updateDateModified(request, application);
+        applicationService.updateDateModified(request, application);
         try {
             // Need to refresh from DB as HardshipDetail ids may have changed
             HardshipReviewDTO newHardship = hardshipService.find(performHardshipResponse.getHardshipReviewId());
@@ -97,7 +96,7 @@ public class HardshipOrchestrationService implements AssessmentOrchestrator<Hard
         validate(request, action, repOrderDTO);
 
         hardshipService.update(request);
-        updateDateModified(request, request.getApplicationDTO());
+        applicationService.updateDateModified(request, request.getApplicationDTO());
         try {
             HardshipOverviewDTO hardshipOverviewDTO = request.getApplicationDTO().getAssessmentDTO().getFinancialAssessmentDTO()
                     .getHardship();
@@ -123,13 +122,6 @@ public class HardshipOrchestrationService implements AssessmentOrchestrator<Hard
         }
 
         return request.getApplicationDTO();
-    }
-
-    private void updateDateModified(WorkflowRequest request, ApplicationDTO applicationDTO) {
-        LocalDateTime updatedDateModified = LocalDateTime.now();
-
-        repOrderService.updateRepOrderDateModified(request, updatedDateModified);
-        applicationDTO.setTimestamp(updatedDateModified.atZone(ZoneOffset.UTC));
     }
 
     private void validate(WorkflowRequest request, Action action, RepOrderDTO repOrderDTO) {
@@ -189,5 +181,4 @@ public class HardshipOrchestrationService implements AssessmentOrchestrator<Hard
 
         return request.getApplicationDTO();
     }
-
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/MeansAssessmentOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/MeansAssessmentOrchestrationService.java
@@ -1,8 +1,6 @@
 package uk.gov.justice.laa.crime.orchestration.service.orchestration;
 
 import io.sentry.Sentry;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -20,6 +18,7 @@ import uk.gov.justice.laa.crime.orchestration.dto.validation.UserActionDTO;
 import uk.gov.justice.laa.crime.orchestration.exception.CrimeValidationException;
 import uk.gov.justice.laa.crime.orchestration.exception.MaatOrchestrationException;
 import uk.gov.justice.laa.crime.orchestration.mapper.MeansAssessmentMapper;
+import uk.gov.justice.laa.crime.orchestration.service.ApplicationService;
 import uk.gov.justice.laa.crime.orchestration.service.AssessmentSummaryService;
 import uk.gov.justice.laa.crime.orchestration.service.ContributionService;
 import uk.gov.justice.laa.crime.orchestration.service.FeatureDecisionService;
@@ -44,6 +43,7 @@ public class MeansAssessmentOrchestrationService {
     private final AssessmentSummaryService assessmentSummaryService;
     private final FeatureDecisionService featureDecisionService;
     private final RepOrderService repOrderService;
+    private final ApplicationService applicationService;
     private final WorkflowPreProcessorService workflowPreProcessorService;
     private final MeansAssessmentMapper meansAssessmentMapper;
     private final MaatCourtDataApiService maatCourtDataApiService;
@@ -61,7 +61,7 @@ public class MeansAssessmentOrchestrationService {
             preProcessRequest(request, Action.CREATE_ASSESSMENT);
             meansAssessmentService.create(request);
             application = processCrownCourtProceedings(request);
-            updateDateModified(request, application);
+            applicationService.updateDateModified(request, application);
 
             log.debug("Created Means assessment for applicationId = {}", repId);
         } catch (ValidationException | CrimeValidationException exception) {
@@ -89,7 +89,7 @@ public class MeansAssessmentOrchestrationService {
             preProcessRequest(request, Action.UPDATE_ASSESSMENT);
             meansAssessmentService.update(request);
             application = processCrownCourtProceedings(request);
-            updateDateModified(request, application);
+            applicationService.updateDateModified(request, application);
 
             log.debug("Updated Means assessment for applicationId = {}", repId);
         } catch (ValidationException | CrimeValidationException exception) {
@@ -167,12 +167,5 @@ public class MeansAssessmentOrchestrationService {
 
         application.setTransactionId(null);
         return application;
-    }
-
-    private void updateDateModified(WorkflowRequest request, ApplicationDTO applicationDTO) {
-        LocalDateTime updatedDateModified = LocalDateTime.now();
-
-        repOrderService.updateRepOrderDateModified(request, updatedDateModified);
-        applicationDTO.setTimestamp(updatedDateModified.atZone(ZoneOffset.UTC));
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/MeansAssessmentOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/MeansAssessmentOrchestrationService.java
@@ -2,6 +2,7 @@ package uk.gov.justice.laa.crime.orchestration.service.orchestration;
 
 import io.sentry.Sentry;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -60,7 +61,7 @@ public class MeansAssessmentOrchestrationService {
             preProcessRequest(request, Action.CREATE_ASSESSMENT);
             meansAssessmentService.create(request);
             application = processCrownCourtProceedings(request);
-            repOrderService.updateRepOrderDateModified(request, LocalDateTime.now());
+            updateDateModified(request, application);
 
             log.debug("Created Means assessment for applicationId = {}", repId);
         } catch (ValidationException | CrimeValidationException exception) {
@@ -88,7 +89,7 @@ public class MeansAssessmentOrchestrationService {
             preProcessRequest(request, Action.UPDATE_ASSESSMENT);
             meansAssessmentService.update(request);
             application = processCrownCourtProceedings(request);
-            repOrderService.updateRepOrderDateModified(request, LocalDateTime.now());
+            updateDateModified(request, application);
 
             log.debug("Updated Means assessment for applicationId = {}", repId);
         } catch (ValidationException | CrimeValidationException exception) {
@@ -166,5 +167,12 @@ public class MeansAssessmentOrchestrationService {
 
         application.setTransactionId(null);
         return application;
+    }
+
+    private void updateDateModified(WorkflowRequest request, ApplicationDTO applicationDTO) {
+        LocalDateTime updatedDateModified = LocalDateTime.now();
+
+        repOrderService.updateRepOrderDateModified(request, updatedDateModified);
+        applicationDTO.setTimestamp(updatedDateModified.atZone(ZoneOffset.UTC));
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/ApplicationServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/ApplicationServiceTest.java
@@ -1,0 +1,39 @@
+package uk.gov.justice.laa.crime.orchestration.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder;
+import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
+
+@ExtendWith(MockitoExtension.class)
+class ApplicationServiceTest {
+    @Mock
+    private RepOrderService repOrderService;
+
+    @InjectMocks
+    private ApplicationService applicationService;
+
+    @Test
+    void givenValidRequest_whenUpdateDateModifiedIsInvoked_thenDateModifiedIsUpdated() {
+        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
+        ZonedDateTime initialDateModified = LocalDateTime.MIN.atZone(ZoneOffset.UTC);
+
+        ApplicationDTO applicationDTO = workflowRequest.getApplicationDTO();
+        applicationDTO.setTimestamp(initialDateModified);
+
+        applicationService.updateDateModified(workflowRequest, workflowRequest.getApplicationDTO());
+
+        assertThat(applicationDTO.getTimestamp()).isNotEqualTo(initialDateModified);
+    }
+}

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/EvidenceOrchestrationServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/EvidenceOrchestrationServiceTest.java
@@ -15,6 +15,7 @@ import uk.gov.justice.laa.crime.orchestration.dto.maat_api.FinancialAssessmentDT
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.validation.UserActionDTO;
 import uk.gov.justice.laa.crime.orchestration.mapper.UserMapper;
+import uk.gov.justice.laa.crime.orchestration.service.ApplicationService;
 import uk.gov.justice.laa.crime.orchestration.service.ContributionService;
 import uk.gov.justice.laa.crime.orchestration.service.IncomeEvidenceService;
 import uk.gov.justice.laa.crime.orchestration.service.RepOrderService;
@@ -39,6 +40,8 @@ class EvidenceOrchestrationServiceTest {
     private IncomeEvidenceService incomeEvidenceService;
     @Mock
     private RepOrderService repOrderService;
+    @Mock
+    private ApplicationService applicationService;
     @Mock
     private UserMapper userMapper;
     @Mock
@@ -65,7 +68,7 @@ class EvidenceOrchestrationServiceTest {
         ApplicationDTO actual = evidenceOrchestrationService.updateIncomeEvidence(workflowRequest);
 
         assertThat(actual).isEqualTo(expected);
-        verify(repOrderService).updateRepOrderDateModified(eq(workflowRequest), any());
+        verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
 
     @ParameterizedTest
@@ -81,7 +84,7 @@ class EvidenceOrchestrationServiceTest {
 
         ApplicationDTO actual = evidenceOrchestrationService.updateIncomeEvidence(workflowRequest);
         assertThat(actual).isEqualTo(expected);
-        verify(repOrderService).updateRepOrderDateModified(eq(workflowRequest), any());
+        verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
 
     private static Stream<Arguments> upliftChangeSet() {

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/HardshipOrchestrationServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/HardshipOrchestrationServiceTest.java
@@ -64,6 +64,9 @@ class HardshipOrchestrationServiceTest {
     private RepOrderService repOrderService;
 
     @Mock
+    private ApplicationService applicationService;
+
+    @Mock
     private WorkflowPreProcessorService workflowPreProcessorService;
 
     @Mock
@@ -134,7 +137,7 @@ class HardshipOrchestrationServiceTest {
 
         verify(assessmentSummaryService)
                 .updateApplication(any(ApplicationDTO.class), any(AssessmentSummaryDTO.class));
-        verify(repOrderService).updateRepOrderDateModified(eq(workflowRequest), any());
+        verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -163,7 +166,7 @@ class HardshipOrchestrationServiceTest {
 
         verify(assessmentSummaryService)
                 .updateApplication(any(ApplicationDTO.class), any(AssessmentSummaryDTO.class));
-        verify(repOrderService).updateRepOrderDateModified(eq(workflowRequest), any());
+        verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -199,7 +202,7 @@ class HardshipOrchestrationServiceTest {
 
         verify(assessmentSummaryService)
                 .updateApplication(any(ApplicationDTO.class), any(AssessmentSummaryDTO.class));
-        verify(repOrderService).updateRepOrderDateModified(eq(workflowRequest), any());
+        verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -212,7 +215,7 @@ class HardshipOrchestrationServiceTest {
         expected.setAsessmentStatus(getAssessmentStatusDTO(CurrentStatus.IN_PROGRESS));
         assertThat(actual.getAssessmentDTO().getFinancialAssessmentDTO().getHardship().getCrownCourtHardship())
                 .isEqualTo(expected);
-        verify(repOrderService).updateRepOrderDateModified(eq(workflowRequest), any());
+        verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -225,7 +228,7 @@ class HardshipOrchestrationServiceTest {
         expected.setAsessmentStatus(null);
         assertThat(actual.getAssessmentDTO().getFinancialAssessmentDTO().getHardship().getCrownCourtHardship())
                 .isEqualTo(expected);
-        verify(repOrderService).updateRepOrderDateModified(eq(workflowRequest), any());
+        verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -238,7 +241,7 @@ class HardshipOrchestrationServiceTest {
         expected.setAsessmentStatus(getAssessmentStatusDTO(CurrentStatus.IN_PROGRESS));
         assertThat(actual.getAssessmentDTO().getFinancialAssessmentDTO().getHardship().getMagCourtHardship())
                 .isEqualTo(expected);
-        verify(repOrderService).updateRepOrderDateModified(eq(workflowRequest), any());
+        verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -251,7 +254,7 @@ class HardshipOrchestrationServiceTest {
         expected.setAsessmentStatus(null);
         assertThat(actual.getAssessmentDTO().getFinancialAssessmentDTO().getHardship().getMagCourtHardship())
                 .isEqualTo(expected);
-        verify(repOrderService).updateRepOrderDateModified(eq(workflowRequest), any());
+        verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -277,7 +280,7 @@ class HardshipOrchestrationServiceTest {
 
         assertThatThrownBy(() -> orchestrationService.create(workflowRequest))
                 .isInstanceOf(MaatOrchestrationException.class);
-        verify(repOrderService).updateRepOrderDateModified(eq(workflowRequest), any());
+        verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -296,7 +299,7 @@ class HardshipOrchestrationServiceTest {
 
         assertThatThrownBy(() -> orchestrationService.create(workflowRequest))
                 .isInstanceOf(MaatOrchestrationException.class);
-        verify(repOrderService).updateRepOrderDateModified(eq(workflowRequest), any());
+        verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -319,7 +322,7 @@ class HardshipOrchestrationServiceTest {
 
         assertThatThrownBy(() -> orchestrationService.create(workflowRequest))
                 .isInstanceOf(MaatOrchestrationException.class);
-        verify(repOrderService).updateRepOrderDateModified(eq(workflowRequest), any());
+        verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -347,7 +350,7 @@ class HardshipOrchestrationServiceTest {
         verify(assessmentSummaryService)
                 .updateApplication(any(ApplicationDTO.class), any(AssessmentSummaryDTO.class));
 
-        verify(repOrderService).updateRepOrderDateModified(eq(workflowRequest), any());
+        verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -382,7 +385,7 @@ class HardshipOrchestrationServiceTest {
         verify(assessmentSummaryService)
                 .updateApplication(any(ApplicationDTO.class), any(AssessmentSummaryDTO.class));
 
-        verify(repOrderService).updateRepOrderDateModified(eq(workflowRequest), any());
+        verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -424,7 +427,7 @@ class HardshipOrchestrationServiceTest {
         verify(assessmentSummaryService)
                 .updateApplication(applicationDTO, assessmentSummaryDTO);
 
-        verify(repOrderService).updateRepOrderDateModified(eq(workflowRequest), any());
+        verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -446,7 +449,7 @@ class HardshipOrchestrationServiceTest {
         assertThat(actual.getAssessmentDTO().getFinancialAssessmentDTO().getHardship().getCrownCourtHardship())
                 .isEqualTo(expected);
 
-        verify(repOrderService).updateRepOrderDateModified(eq(workflowRequest), any());
+        verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -468,7 +471,7 @@ class HardshipOrchestrationServiceTest {
         assertThat(actual.getAssessmentDTO().getFinancialAssessmentDTO().getHardship().getCrownCourtHardship())
                 .isEqualTo(expected);
 
-        verify(repOrderService).updateRepOrderDateModified(eq(workflowRequest), any());
+        verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -490,7 +493,7 @@ class HardshipOrchestrationServiceTest {
         assertThat(actual.getAssessmentDTO().getFinancialAssessmentDTO().getHardship().getMagCourtHardship())
                 .isEqualTo(expected);
 
-        verify(repOrderService).updateRepOrderDateModified(eq(workflowRequest), any());
+        verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -512,7 +515,7 @@ class HardshipOrchestrationServiceTest {
         assertThat(actual.getAssessmentDTO().getFinancialAssessmentDTO().getHardship().getMagCourtHardship())
                 .isEqualTo(expected);
 
-        verify(repOrderService).updateRepOrderDateModified(eq(workflowRequest), any());
+        verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -536,7 +539,7 @@ class HardshipOrchestrationServiceTest {
         assertThatThrownBy(() -> orchestrationService.update(workflowRequest))
                 .isInstanceOf(MaatOrchestrationException.class);
 
-        verify(repOrderService).updateRepOrderDateModified(eq(workflowRequest), any());
+        verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -557,7 +560,7 @@ class HardshipOrchestrationServiceTest {
         assertThatThrownBy(() -> orchestrationService.update(workflowRequest))
                 .isInstanceOf(MaatOrchestrationException.class);
 
-        verify(repOrderService).updateRepOrderDateModified(eq(workflowRequest), any());
+        verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/MeansAssessmentOrchestrationServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/MeansAssessmentOrchestrationServiceTest.java
@@ -61,8 +61,10 @@ class MeansAssessmentOrchestrationServiceTest {
     private RepOrderService repOrderService;
 
     @Mock
-    private WorkflowPreProcessorService workflowPreProcessorService;
+    private ApplicationService applicationService;
 
+    @Mock
+    private WorkflowPreProcessorService workflowPreProcessorService;
 
     @Mock
     private CCLFUpdateService cclfUpdateService;
@@ -118,7 +120,7 @@ class MeansAssessmentOrchestrationServiceTest {
                 StoredProcedure.ASSESSMENT_POST_PROCESSING_PART_2
         );
         verify(assessmentSummaryService, times(1)).getSummary(any(FinancialAssessmentDTO.class));
-        verify(repOrderService).updateRepOrderDateModified(eq(workflowRequest), any());
+        verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -144,7 +146,7 @@ class MeansAssessmentOrchestrationServiceTest {
                 StoredProcedure.ASSESSMENT_POST_PROCESSING_PART_2
         );
         verify(assessmentSummaryService, times(1)).getSummary(any());
-        verify(repOrderService).updateRepOrderDateModified(eq(workflowRequest), any());
+        verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -175,7 +177,7 @@ class MeansAssessmentOrchestrationServiceTest {
                 StoredProcedure.ASSESSMENT_POST_PROCESSING_PART_2
         );
         verify(assessmentSummaryService, times(1)).getSummary(any());
-        verify(repOrderService).updateRepOrderDateModified(eq(workflowRequest), any());
+        verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -202,7 +204,7 @@ class MeansAssessmentOrchestrationServiceTest {
                 StoredProcedure.ASSESSMENT_POST_PROCESSING_PART_2
         );
         verify(assessmentSummaryService, times(1)).getSummary(any());
-        verify(repOrderService).updateRepOrderDateModified(eq(workflowRequest), any());
+        verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -223,7 +225,7 @@ class MeansAssessmentOrchestrationServiceTest {
                 StoredProcedure.PRE_UPDATE_CC_APPLICATION
         );
         verify(workflowPreProcessorService, times(0)).preProcessRequest(any(), any(), any());
-        verify(repOrderService).updateRepOrderDateModified(eq(workflowRequest), any());
+        verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -242,7 +244,7 @@ class MeansAssessmentOrchestrationServiceTest {
                 StoredProcedure.PRE_UPDATE_CC_APPLICATION
         );
         verify(workflowPreProcessorService).preProcessRequest(any(), any(), any());
-        verify(repOrderService).updateRepOrderDateModified(eq(workflowRequest), any());
+        verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -344,6 +346,6 @@ class MeansAssessmentOrchestrationServiceTest {
         verify(proceedingsService, times(1)).updateApplication(workflowRequest,
                 repOrderDTO);
         verify(meansAssessmentService, times(0)).rollback(any());
-        verify(repOrderService).updateRepOrderDateModified(eq(workflowRequest), any());
+        verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
 }


### PR DESCRIPTION
This PR fixes inconsistencies introduced regarding Rep Order date modified timestamps and the timestamp returned as part of the `ApplicationDTO` object. Previously, the date modified field of the Rep Order was being updated but the `timestamp` field of the `ApplicationDTO` was not altered, resulting in the caller receiving the previous date modified timestamp and not the updated one.

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1739)