### PR TITLE
Use correct timestamp set in Rep Order by Hibernate in ApplicationDTO

### DIFF
--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/ApplicationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/ApplicationService.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
 
 @Slf4j
 @Service
@@ -15,9 +16,8 @@ public class ApplicationService {
     private final RepOrderService repOrderService;
 
     public void updateDateModified(WorkflowRequest request, ApplicationDTO applicationDTO) {
-        LocalDateTime updatedDateModified = LocalDateTime.now();
+        RepOrderDTO updatedRepOrder = repOrderService.updateRepOrderDateModified(request, LocalDateTime.now());
 
-        repOrderService.updateRepOrderDateModified(request, updatedDateModified);
-        applicationDTO.setTimestamp(updatedDateModified.atZone(ZoneOffset.UTC));
+        applicationDTO.setTimestamp(updatedRepOrder.getDateModified().atZone(ZoneOffset.UTC));
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/RepOrderService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/RepOrderService.java
@@ -19,10 +19,12 @@ public class RepOrderService {
         return maatCourtDataService.findRepOrder(repId);
     }
 
-    public void updateRepOrderDateModified(WorkflowRequest workflowRequest, LocalDateTime dateModified) {
+    public RepOrderDTO updateRepOrderDateModified(WorkflowRequest workflowRequest, LocalDateTime dateModified) {
         int repId = workflowRequest.getApplicationDTO().getRepId().intValue();
         Map<String, Object> fieldsToUpdate = Map.of("dateModified", dateModified);
 
         maatCourtDataService.updateRepOrderDateModified(repId, fieldsToUpdate);
+
+        return getRepOrder(workflowRequest);
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/MeansAssessmentDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/MeansAssessmentDataBuilder.java
@@ -364,6 +364,7 @@ public class MeansAssessmentDataBuilder {
                 .catyCaseType(CaseType.EITHER_WAY.getCaseType())
                 .magsOutcome(MagCourtOutcome.COMMITTED.getOutcome())
                 .magsOutcomeDate("05-JUN-22")
+                .dateModified(LocalDateTime.of(2022, 6, 5, 12, 0))
                 .magsOutcomeDateSet(TEST_MAGS_OUTCOME_DATE)
                 .committalDate(TEST_MAGS_OUTCOME_DATE.toLocalDate())
                 .decisionReasonCode("rder-code")

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/ApplicationServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/ApplicationServiceTest.java
@@ -2,7 +2,9 @@ package uk.gov.justice.laa.crime.orchestration.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -15,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
 
 @ExtendWith(MockitoExtension.class)
 class ApplicationServiceTest {
@@ -27,13 +30,17 @@ class ApplicationServiceTest {
     @Test
     void givenValidRequest_whenUpdateDateModifiedIsInvoked_thenDateModifiedIsUpdated() {
         WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
-        ZonedDateTime initialDateModified = LocalDateTime.MIN.atZone(ZoneOffset.UTC);
-
         ApplicationDTO applicationDTO = workflowRequest.getApplicationDTO();
-        applicationDTO.setTimestamp(initialDateModified);
+        applicationDTO.setTimestamp(LocalDateTime.MIN.atZone(ZoneOffset.UTC));
+
+        ZonedDateTime updatedDateModified = LocalDateTime.MIN.atZone(ZoneOffset.UTC);
+        when(repOrderService.updateRepOrderDateModified(eq(workflowRequest), any())).thenReturn(
+            RepOrderDTO.builder()
+                .dateModified(updatedDateModified.toLocalDateTime())
+                .build());
 
         applicationService.updateDateModified(workflowRequest, workflowRequest.getApplicationDTO());
 
-        assertThat(applicationDTO.getTimestamp()).isNotEqualTo(initialDateModified);
+        assertThat(applicationDTO.getTimestamp()).isEqualTo(updatedDateModified);
     }
 }


### PR DESCRIPTION
This PR updates the _RepOrderService_ to get and return the latest _RepOrderDTO_ immediately after updating the date modified on the Rep Order.

The reason for this change is because Hibernate automatically updates the date modified field of the Rep Order entity whenever there are _any_ changes to said Rep Order; this is resulting in a situation at the moment where a request to patch the Rep Order in the Court Data API with a new date modified first updates the field to the value we pass, but is then updated immediately after by Hibernate because the Rep Order entity was changed.

This is a separate issue in its own right and a [task has been captured to return the updated _RepOrderDTO_ from the Court Data API endpoint] (https://dsdmoj.atlassian.net/browse/LCAM-1806) that we are calling to patch the Rep Order. Until that work is done, the most straightforward and quickest fix to this issue (which is causing API test failures) is to manually get the latest Rep Order after we update the date modified, then use the timestamp from this entity when setting the application timestamp returned upstream.

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1739)