### PR TITLE
LASB-3782 - fixed NPE in assessment mapping

### DIFF
--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/MeansAssessmentMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/MeansAssessmentMapper.java
@@ -228,20 +228,31 @@ public class MeansAssessmentMapper {
                 );
     }
 
-    private List<ApiAssessmentSectionSummary> sectionSummariesBuilder(
+    List<ApiAssessmentSectionSummary> sectionSummariesBuilder(
             Collection<AssessmentSectionSummaryDTO> sectionSummaries) {
         List<ApiAssessmentSectionSummary> apiAssessmentSectionSummaries = new ArrayList<>();
         if (sectionSummaries != null) {
             for (AssessmentSectionSummaryDTO sectionSummaryDTO : sectionSummaries) {
+                if (sectionSummaryDTO == null) {
+                    continue;
+                }
+
+                // Use default null values if any of the numeric fields are null.
+                BigDecimal annualTotal = sectionSummaryDTO.getAnnualTotal() != null ?
+                        BigDecimal.valueOf(sectionSummaryDTO.getAnnualTotal()) : null;
+                BigDecimal applicantAnnualTotal = sectionSummaryDTO.getApplicantAnnualTotal() != null ?
+                        BigDecimal.valueOf(sectionSummaryDTO.getApplicantAnnualTotal()) : null;
+                BigDecimal partnerAnnualTotal = sectionSummaryDTO.getPartnerAnnualTotal() != null ?
+                        BigDecimal.valueOf(sectionSummaryDTO.getPartnerAnnualTotal()) : null;
+
                 apiAssessmentSectionSummaries.add(
                         new ApiAssessmentSectionSummary()
-                                .withAnnualTotal(BigDecimal.valueOf(sectionSummaryDTO.getAnnualTotal()))
+                                .withAnnualTotal(annualTotal)
                                 .withAssessmentDetails(
                                         assessmentDetailsBuilder(sectionSummaryDTO.getAssessmentDetail()))
                                 .withSection(sectionSummaryDTO.getSection())
-                                .withApplicantAnnualTotal(
-                                        BigDecimal.valueOf(sectionSummaryDTO.getApplicantAnnualTotal()))
-                                .withPartnerAnnualTotal(BigDecimal.valueOf(sectionSummaryDTO.getPartnerAnnualTotal()))
+                                .withApplicantAnnualTotal(applicantAnnualTotal)
+                                .withPartnerAnnualTotal(partnerAnnualTotal)
                 );
             }
         }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-3782)

Fixed NPE in assessment mapping. 

The cma endpoint within MAAT orchestration service is receiving WorkflowRequest to create crime means assessments. This MAAT orchestration service maps the incoming WorkflowRequest in to a ApiCreateMeansAssessmentRequest in order to call the downstream CMA service to perform the work. During the mapping some of the WorkflowRequest's values are null causing NPEs. This fixes the cause of the NPEs - passing nulls to the BigDecimal.valueOf method.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.