### PR TITLE
Upgrade Orchestration Service to use Java 21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ executors:
     working_directory: ~/laa-maat-orchestration/maat-orchestration
   build-executor:
     docker:
-      - image: cimg/openjdk:17.0.4
+      - image: cimg/openjdk:21.0.6
     working_directory: ~/laa-maat-orchestration/maat-orchestration
 
 # ------------------

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@
           uses: actions/setup-java@v3
           with:
             distribution: 'temurin'
-            java-version: 17
+            java-version: 21
 
         - name: Checkout repository
           uses: actions/checkout@v4

--- a/maat-orchestration/Dockerfile
+++ b/maat-orchestration/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:17-alpine
+FROM amazoncorretto:21-alpine
 RUN mkdir -p /opt/laa-maat-orchestration/
 WORKDIR /opt/laa-maat-orchestration/
 COPY ./build/libs/maat-orchestration.jar /opt/laa-maat-orchestration/app.jar

--- a/maat-orchestration/build.gradle
+++ b/maat-orchestration/build.gradle
@@ -10,8 +10,8 @@ plugins {
 group = "uk.gov.justice.laa.crime"
 
 java {
-	sourceCompatibility = JavaVersion.VERSION_17
-	targetCompatibility = JavaVersion.VERSION_17
+	sourceCompatibility = JavaVersion.VERSION_21
+	targetCompatibility = JavaVersion.VERSION_21
 }
 
 def versions = [
@@ -81,7 +81,7 @@ dependencies {
 }
 
 jacoco {
-	toolVersion = "0.8.8"
+	toolVersion = "0.8.13"
 }
 
 test {


### PR DESCRIPTION
This PR upgrades the Orchestration Service to use Java 21, which is the current long-term support (LTS) version of Java, as well as the code analysis and deployment pipelines to use Java 21.

It also updates the Jacoco plugin to a version compatible with Java 21.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4176)
