### PR TITLE
Set securityContext property for containers

### DIFF
--- a/helm_deploy/laa-maat-orchestration/values-dev.yaml
+++ b/helm_deploy/laa-maat-orchestration/values-dev.yaml
@@ -112,3 +112,11 @@ actuator:
 
 logging:
   level: DEBUG
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault

--- a/helm_deploy/laa-maat-orchestration/values-prod.yaml
+++ b/helm_deploy/laa-maat-orchestration/values-prod.yaml
@@ -113,3 +113,11 @@ actuator:
 
 logging:
   level: INFO
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault

--- a/helm_deploy/laa-maat-orchestration/values-test.yaml
+++ b/helm_deploy/laa-maat-orchestration/values-test.yaml
@@ -113,3 +113,11 @@ actuator:
 
 logging:
   level: INFO
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault

--- a/helm_deploy/laa-maat-orchestration/values-uat.yaml
+++ b/helm_deploy/laa-maat-orchestration/values-uat.yaml
@@ -113,3 +113,11 @@ actuator:
 
 logging:
   level: INFO
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault


### PR DESCRIPTION
This PR sets the `securityContext` property and associated values for the app containers. This should remove the warnings currently raised when running `helm upgrade` during deployment and improve the security of the running containers.

Specifically, it sets the `allowPrivilegeEscalation`, `capabilities`, `runAsNonRoot` and `seccompProfile` settings to those values recommended by Helm (raised as warnings) when running `helm upgrade` during deployment.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-3604)