### PR TITLE
LCAM-2055 - Find Passport Evidence Mapping

### DIFF
--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/client/EvidenceApiClient.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/client/EvidenceApiClient.java
@@ -1,14 +1,14 @@
 package uk.gov.justice.laa.crime.orchestration.client;
 
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.service.annotation.GetExchange;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceRequest;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceResponse;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiGetPassportEvidenceResponse;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiUpdateIncomeEvidenceRequest;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiUpdateIncomeEvidenceResponse;
 
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.service.annotation.GetExchange;
 import org.springframework.web.service.annotation.HttpExchange;
 import org.springframework.web.service.annotation.PostExchange;
 import org.springframework.web.service.annotation.PutExchange;
@@ -22,6 +22,6 @@ public interface EvidenceApiClient {
     @PutExchange
     ApiUpdateIncomeEvidenceResponse updateEvidence(@RequestBody ApiUpdateIncomeEvidenceRequest request);
 
-    @GetExchange("/passported/{passportedAssessmentId}")
-    ApiGetPassportEvidenceResponse findPassportedEvidence(@PathVariable int passportedAssessmentId);
+    @GetExchange("/passport/{passportedAssessmentId}")
+    ApiGetPassportEvidenceResponse findPassportEvidence(@PathVariable int passportAssessmentId);
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/client/EvidenceApiClient.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/client/EvidenceApiClient.java
@@ -1,7 +1,10 @@
 package uk.gov.justice.laa.crime.orchestration.client;
 
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.service.annotation.GetExchange;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceRequest;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceResponse;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiGetPassportEvidenceResponse;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiUpdateIncomeEvidenceRequest;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiUpdateIncomeEvidenceResponse;
 
@@ -18,4 +21,7 @@ public interface EvidenceApiClient {
 
     @PutExchange
     ApiUpdateIncomeEvidenceResponse updateEvidence(@RequestBody ApiUpdateIncomeEvidenceRequest request);
+
+    @GetExchange("/passported/{passportedAssessmentId}")
+    ApiGetPassportEvidenceResponse findPassportedEvidence(@PathVariable int passportedAssessmentId);
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/client/EvidenceApiClient.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/client/EvidenceApiClient.java
@@ -22,6 +22,6 @@ public interface EvidenceApiClient {
     @PutExchange
     ApiUpdateIncomeEvidenceResponse updateEvidence(@RequestBody ApiUpdateIncomeEvidenceRequest request);
 
-    @GetExchange("/passport/{passportedAssessmentId}")
+    @GetExchange("/passport/{passportAssessmentId}")
     ApiGetPassportEvidenceResponse findPassportEvidence(@PathVariable int passportAssessmentId);
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapper.java
@@ -26,6 +26,8 @@ public class PassportAssessmentMapper {
 
     private static final String ASSESSMENT_STATUS_DESCRIPTION = "Complete";
 
+    private final PassportEvidenceMapper passportEvidenceMapper;
+
     private PartnerDTO applicantDTOToPartnerDTO(ApplicantDTO applicant) {
         return PartnerDTO.builder()
                 .firstName(applicant.getFirstName())
@@ -66,14 +68,15 @@ public class PassportAssessmentMapper {
     }
 
     public PassportedDTO apiGetPassportedAssessmentResponseToPassportedDTO(
-            ApiGetPassportedAssessmentResponse assessment, ApiGetPassportEvidenceResponse evidence, ApplicantDTO applicant) {
+            ApiGetPassportedAssessmentResponse assessment,
+            ApiGetPassportEvidenceResponse evidence,
+            ApplicantDTO applicant) {
 
         AssessmentStatusDTO assessmentStatusDTO = AssessmentStatusDTO.builder()
                 .status(AssessmentStatusDTO.COMPLETE)
                 .description(ASSESSMENT_STATUS_DESCRIPTION)
                 .build();
 
-        // TODO: Need to populate passportSummaryEvidenceDTO following completion of LCAM-2002
         // TODO: Might need to amend mapping of legacy age related values following completion of LCAM-2016
         // Not setting dwpResult and dwpWhoChecked as these are no longer used in MAAT and so can left as null
         PassportedDTO dto = PassportedDTO.builder()
@@ -87,6 +90,8 @@ public class PassportAssessmentMapper {
                 .notes(assessment.getNotes())
                 .result(assessment.getAssessmentDecision().getCode())
                 .under18HeardYouthCourt(assessment.getDeclaredUnder18())
+                .passportSummaryEvidenceDTO(
+                        passportEvidenceMapper.apiGetPassportEvidenceResponseToIncomeEvidenceSummaryDTO(evidence))
                 .build();
 
         if (assessment.getUsn() != null) {

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapper.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.laa.crime.orchestration.mapper;
 
 import lombok.RequiredArgsConstructor;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiGetPassportEvidenceResponse;
 import uk.gov.justice.laa.crime.common.model.passported.ApiGetPassportedAssessmentResponse;
 import uk.gov.justice.laa.crime.common.model.passported.DeclaredBenefit;
 import uk.gov.justice.laa.crime.enums.BenefitType;
@@ -65,7 +66,7 @@ public class PassportAssessmentMapper {
     }
 
     public PassportedDTO apiGetPassportedAssessmentResponseToPassportedDTO(
-            ApiGetPassportedAssessmentResponse response, ApplicantDTO applicantDTO) {
+            ApiGetPassportedAssessmentResponse assessment, ApiGetPassportEvidenceResponse evidence, ApplicantDTO applicant) {
 
         AssessmentStatusDTO assessmentStatusDTO = AssessmentStatusDTO.builder()
                 .status(AssessmentStatusDTO.COMPLETE)
@@ -76,31 +77,31 @@ public class PassportAssessmentMapper {
         // TODO: Might need to amend mapping of legacy age related values following completion of LCAM-2016
         // Not setting dwpResult and dwpWhoChecked as these are no longer used in MAAT and so can left as null
         PassportedDTO dto = PassportedDTO.builder()
-                .passportedId(Long.valueOf(response.getLegacyAssessmentId()))
-                .cmuId(Long.valueOf(response.getCaseManagementUnitId()))
-                .date(DateUtil.toDate(response.getAssessmentDate()))
+                .passportedId(Long.valueOf(assessment.getLegacyAssessmentId()))
+                .cmuId(Long.valueOf(assessment.getCaseManagementUnitId()))
+                .date(DateUtil.toDate(assessment.getAssessmentDate()))
                 .assessementStatusDTO(assessmentStatusDTO)
                 .passportConfirmationDTO(
-                        passportAssessmentDecisionReasonToPassportConfirmationDTO(response.getDecisionReason()))
-                .newWorkReason(newWorkReasonToNewWorkReasonDTO(response.getAssessmentReason()))
-                .notes(response.getNotes())
-                .result(response.getAssessmentDecision().getCode())
-                .under18HeardYouthCourt(response.getDeclaredUnder18())
+                        passportAssessmentDecisionReasonToPassportConfirmationDTO(assessment.getDecisionReason()))
+                .newWorkReason(newWorkReasonToNewWorkReasonDTO(assessment.getAssessmentReason()))
+                .notes(assessment.getNotes())
+                .result(assessment.getAssessmentDecision().getCode())
+                .under18HeardYouthCourt(assessment.getDeclaredUnder18())
                 .build();
 
-        if (response.getUsn() != null) {
-            dto.setUsn(Long.valueOf(response.getUsn()));
+        if (assessment.getUsn() != null) {
+            dto.setUsn(Long.valueOf(assessment.getUsn()));
         }
 
-        if (response.getReviewType() != null) {
-            dto.setReviewType(reviewTypeToReviewTypeDTO(response.getReviewType()));
+        if (assessment.getReviewType() != null) {
+            dto.setReviewType(reviewTypeToReviewTypeDTO(assessment.getReviewType()));
         }
 
-        DeclaredBenefit declaredBenefit = response.getDeclaredBenefit();
+        DeclaredBenefit declaredBenefit = assessment.getDeclaredBenefit();
         if (declaredBenefit != null) {
-            if (applicantDTO != null) {
+            if (applicant != null) {
                 dto.setBenefitClaimedByPartner(true);
-                dto.setPartnerDetails(applicantDTOToPartnerDTO(applicantDTO));
+                dto.setPartnerDetails(applicantDTOToPartnerDTO(applicant));
             }
 
             switch (declaredBenefit.getBenefitType()) {

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapper.java
@@ -70,14 +70,13 @@ public class PassportAssessmentMapper {
     public PassportedDTO apiGetPassportedAssessmentResponseToPassportedDTO(
             ApiGetPassportedAssessmentResponse assessment,
             ApiGetPassportEvidenceResponse evidence,
-            ApplicantDTO applicant) {
+            ApplicantDTO partner) {
 
         AssessmentStatusDTO assessmentStatusDTO = AssessmentStatusDTO.builder()
                 .status(AssessmentStatusDTO.COMPLETE)
                 .description(ASSESSMENT_STATUS_DESCRIPTION)
                 .build();
 
-        // TODO: Might need to amend mapping of legacy age related values following completion of LCAM-2016
         // Not setting dwpResult and dwpWhoChecked as these are no longer used in MAAT and so can left as null
         PassportedDTO dto = PassportedDTO.builder()
                 .passportedId(Long.valueOf(assessment.getLegacyAssessmentId()))
@@ -104,9 +103,9 @@ public class PassportAssessmentMapper {
 
         DeclaredBenefit declaredBenefit = assessment.getDeclaredBenefit();
         if (declaredBenefit != null) {
-            if (applicant != null) {
+            if (partner != null) {
                 dto.setBenefitClaimedByPartner(true);
-                dto.setPartnerDetails(applicantDTOToPartnerDTO(applicant));
+                dto.setPartnerDetails(applicantDTOToPartnerDTO(partner));
             }
 
             switch (declaredBenefit.getBenefitType()) {

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapper.java
@@ -89,8 +89,6 @@ public class PassportAssessmentMapper {
                 .notes(assessment.getNotes())
                 .result(assessment.getAssessmentDecision().getCode())
                 .under18HeardYouthCourt(assessment.getDeclaredUnder18())
-                .passportSummaryEvidenceDTO(
-                        passportEvidenceMapper.apiGetPassportEvidenceResponseToIncomeEvidenceSummaryDTO(evidence))
                 .build();
 
         if (assessment.getUsn() != null) {
@@ -115,6 +113,11 @@ public class PassportAssessmentMapper {
                 case BenefitType.ESA -> dto.setBenefitEmploymentSupport(true);
                 case BenefitType.UC -> dto.setBenefitUniversalCredit(true);
             }
+        }
+
+        if (evidence != null) {
+            dto.setPassportSummaryEvidenceDTO(
+                    passportEvidenceMapper.apiGetPassportEvidenceResponseToIncomeEvidenceSummaryDTO(evidence));
         }
 
         return dto;

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportEvidenceMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportEvidenceMapper.java
@@ -42,6 +42,10 @@ public class PassportEvidenceMapper {
 
     private ExtraEvidenceDTO apiIncomeEvidenceToExtraEvidenceDTO(ApiIncomeEvidence evidenceItem, boolean isPartner) {
         return ExtraEvidenceDTO.builder()
+                .id(Long.valueOf(evidenceItem.getId()))
+                .evidenceTypeDTO(incomeEvidenceTypeToEvidenceTypeDTO(evidenceItem.getEvidenceType()))
+                .dateReceived(
+                        evidenceItem.getDateReceived() != null ? DateUtil.asDate(evidenceItem.getDateReceived()) : null)
                 .otherText(evidenceItem.getDescription())
                 .mandatory(evidenceItem.getMandatory())
                 .adhoc(isPartner ? "P" : "A")

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportEvidenceMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportEvidenceMapper.java
@@ -1,0 +1,101 @@
+package uk.gov.justice.laa.crime.orchestration.mapper;
+
+import lombok.RequiredArgsConstructor;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiGetPassportEvidenceResponse;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiIncomeEvidence;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiPassportEvidenceMetadata;
+import uk.gov.justice.laa.crime.enums.evidence.IncomeEvidenceType;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.EvidenceDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.EvidenceTypeDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.ExtraEvidenceDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.IncomeEvidenceSummaryDTO;
+import uk.gov.justice.laa.crime.util.DateUtil;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PassportEvidenceMapper {
+
+    private EvidenceTypeDTO incomeEvidenceTypeToEvidenceTypeDTO(IncomeEvidenceType evidenceType) {
+        return EvidenceTypeDTO.builder()
+                .evidence(evidenceType.getName())
+                .description(evidenceType.getDescription())
+                .build();
+    }
+
+    private EvidenceDTO apiIncomeEvidenceToEvidenceDTO(ApiIncomeEvidence evidenceItem) {
+        return EvidenceDTO.builder()
+                .id(Long.valueOf(evidenceItem.getId()))
+                .evidenceTypeDTO(incomeEvidenceTypeToEvidenceTypeDTO(evidenceItem.getEvidenceType()))
+                .otherDescription(evidenceItem.getDescription())
+                .dateReceived(
+                        evidenceItem.getDateReceived() != null ? DateUtil.asDate(evidenceItem.getDateReceived()) : null)
+                .build();
+    }
+
+    private ExtraEvidenceDTO apiIncomeEvidenceToExtraEvidenceDTO(ApiIncomeEvidence evidenceItem, boolean isPartner) {
+        return ExtraEvidenceDTO.builder()
+                .otherText(evidenceItem.getDescription())
+                .mandatory(evidenceItem.getMandatory())
+                .adhoc(isPartner ? "P" : "A")
+                .build();
+    }
+
+    public IncomeEvidenceSummaryDTO apiGetPassportEvidenceResponseToIncomeEvidenceSummaryDTO(
+            ApiGetPassportEvidenceResponse evidence) {
+        ApiPassportEvidenceMetadata metadata = evidence.getPassportEvidenceMetadata();
+
+        Map<Boolean, List<ApiIncomeEvidence>> applicantEvidenceItems = evidence.getApplicantEvidenceItems().stream()
+                .collect(Collectors.partitioningBy(
+                        evidenceItem -> evidenceItem.getEvidenceType().isExtra()));
+        Map<Boolean, List<ApiIncomeEvidence>> partnerEvidenceItems = evidence.getPartnerEvidenceItems().stream()
+                .collect(Collectors.partitioningBy(
+                        evidenceItem -> evidenceItem.getEvidenceType().isExtra()));
+        Collection<ExtraEvidenceDTO> extraEvidenceItems = Stream.concat(
+                        applicantEvidenceItems.get(true).stream()
+                                .map(evidenceItem -> apiIncomeEvidenceToExtraEvidenceDTO(evidenceItem, false)),
+                        partnerEvidenceItems.get(true).stream()
+                                .map(evidenceItem -> apiIncomeEvidenceToExtraEvidenceDTO(evidenceItem, true)))
+                .toList();
+
+        return IncomeEvidenceSummaryDTO.builder()
+                .evidenceDueDate(
+                        metadata.getEvidenceDueDate() != null ? DateUtil.asDate(metadata.getEvidenceDueDate()) : null)
+                .evidenceReceivedDate(
+                        metadata.getEvidenceReceivedDate() != null
+                                ? DateUtil.asDate(metadata.getEvidenceReceivedDate())
+                                : null)
+                .upliftAppliedDate(
+                        metadata.getUpliftAppliedDate() != null
+                                ? DateUtil.asDate(metadata.getUpliftAppliedDate())
+                                : null)
+                .upliftRemovedDate(
+                        metadata.getUpliftRemovedDate() != null
+                                ? DateUtil.asDate(metadata.getUpliftRemovedDate())
+                                : null)
+                .firstReminderDate(
+                        metadata.getFirstReminderDate() != null
+                                ? DateUtil.asDate(metadata.getFirstReminderDate())
+                                : null)
+                .secondReminderDate(
+                        metadata.getSecondReminderDate() != null
+                                ? DateUtil.asDate(metadata.getSecondReminderDate())
+                                : null)
+                .incomeEvidenceNotes(metadata.getIncomeEvidenceNotes())
+                .applicantIncomeEvidenceList(applicantEvidenceItems.get(false).stream()
+                        .map(this::apiIncomeEvidenceToEvidenceDTO)
+                        .toList())
+                .partnerIncomeEvidenceList(partnerEvidenceItems.get(false).stream()
+                        .map(this::apiIncomeEvidenceToEvidenceDTO)
+                        .toList())
+                .extraEvidenceList(extraEvidenceItems)
+                .build();
+    }
+}

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportEvidenceMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportEvidenceMapper.java
@@ -1,6 +1,5 @@
 package uk.gov.justice.laa.crime.orchestration.mapper;
 
-import lombok.RequiredArgsConstructor;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiGetPassportEvidenceResponse;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiIncomeEvidence;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiPassportEvidenceMetadata;
@@ -20,7 +19,6 @@ import java.util.stream.Stream;
 import org.springframework.stereotype.Component;
 
 @Component
-@RequiredArgsConstructor
 public class PassportEvidenceMapper {
 
     private EvidenceTypeDTO incomeEvidenceTypeToEvidenceTypeDTO(IncomeEvidenceType evidenceType) {
@@ -40,6 +38,7 @@ public class PassportEvidenceMapper {
                 .build();
     }
 
+    // Not setting otherDescription as this doesn't appear to be utilised for extra evidence
     private ExtraEvidenceDTO apiIncomeEvidenceToExtraEvidenceDTO(ApiIncomeEvidence evidenceItem, boolean isPartner) {
         return ExtraEvidenceDTO.builder()
                 .id(Long.valueOf(evidenceItem.getId()))

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/PassportAssessmentService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/PassportAssessmentService.java
@@ -30,13 +30,14 @@ public class PassportAssessmentService {
     public PassportedDTO find(int id) {
         ApiGetPassportedAssessmentResponse assessment = assessmentApiService.findPassportAssessment(id);
 
-        ApiGetPassportEvidenceResponse evidence = evidenceApiService.getPassportedEvidence(id);
+        ApiGetPassportEvidenceResponse evidence = evidenceApiService.getPassportEvidence(id);
 
         DeclaredBenefit declaredBenefit = assessment.getDeclaredBenefit();
         ApplicantDTO applicant = hasPartnerBenefit(declaredBenefit)
                 ? maatCourtDataApiService.getApplicant(declaredBenefit.getLegacyPartnerId())
                 : null;
 
-        return passportAssessmentMapper.apiGetPassportedAssessmentResponseToPassportedDTO(assessment, evidence, applicant);
+        return passportAssessmentMapper.apiGetPassportedAssessmentResponseToPassportedDTO(
+                assessment, evidence, applicant);
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/PassportAssessmentService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/PassportAssessmentService.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.laa.crime.orchestration.service;
 
 import lombok.RequiredArgsConstructor;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiGetPassportEvidenceResponse;
 import uk.gov.justice.laa.crime.common.model.passported.ApiGetPassportedAssessmentResponse;
 import uk.gov.justice.laa.crime.common.model.passported.DeclaredBenefit;
 import uk.gov.justice.laa.crime.enums.BenefitRecipient;
@@ -8,6 +9,7 @@ import uk.gov.justice.laa.crime.orchestration.dto.maat.PassportedDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.ApplicantDTO;
 import uk.gov.justice.laa.crime.orchestration.mapper.PassportAssessmentMapper;
 import uk.gov.justice.laa.crime.orchestration.service.api.AssessmentApiService;
+import uk.gov.justice.laa.crime.orchestration.service.api.EvidenceApiService;
 import uk.gov.justice.laa.crime.orchestration.service.api.MaatCourtDataApiService;
 
 import org.springframework.stereotype.Service;
@@ -18,6 +20,7 @@ public class PassportAssessmentService {
 
     private final AssessmentApiService assessmentApiService;
     private final MaatCourtDataApiService maatCourtDataApiService;
+    private final EvidenceApiService evidenceApiService;
     private final PassportAssessmentMapper passportAssessmentMapper;
 
     private boolean hasPartnerBenefit(DeclaredBenefit declaredBenefit) {
@@ -25,13 +28,15 @@ public class PassportAssessmentService {
     }
 
     public PassportedDTO find(int id) {
-        ApiGetPassportedAssessmentResponse response = assessmentApiService.findPassportAssessment(id);
+        ApiGetPassportedAssessmentResponse assessment = assessmentApiService.findPassportAssessment(id);
 
-        DeclaredBenefit declaredBenefit = response.getDeclaredBenefit();
-        ApplicantDTO applicantDTO = hasPartnerBenefit(declaredBenefit)
+        ApiGetPassportEvidenceResponse evidence = evidenceApiService.getPassportedEvidence(id);
+
+        DeclaredBenefit declaredBenefit = assessment.getDeclaredBenefit();
+        ApplicantDTO applicant = hasPartnerBenefit(declaredBenefit)
                 ? maatCourtDataApiService.getApplicant(declaredBenefit.getLegacyPartnerId())
                 : null;
 
-        return passportAssessmentMapper.apiGetPassportedAssessmentResponseToPassportedDTO(response, applicantDTO);
+        return passportAssessmentMapper.apiGetPassportedAssessmentResponseToPassportedDTO(assessment, evidence, applicant);
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/PassportAssessmentService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/PassportAssessmentService.java
@@ -33,11 +33,11 @@ public class PassportAssessmentService {
         ApiGetPassportEvidenceResponse evidence = evidenceApiService.getPassportEvidence(id);
 
         DeclaredBenefit declaredBenefit = assessment.getDeclaredBenefit();
-        ApplicantDTO applicant = hasPartnerBenefit(declaredBenefit)
+        ApplicantDTO partner = hasPartnerBenefit(declaredBenefit)
                 ? maatCourtDataApiService.getApplicant(declaredBenefit.getLegacyPartnerId())
                 : null;
 
         return passportAssessmentMapper.apiGetPassportedAssessmentResponseToPassportedDTO(
-                assessment, evidence, applicant);
+                assessment, evidence, partner);
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/api/EvidenceApiService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/api/EvidenceApiService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceRequest;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceResponse;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiGetPassportEvidenceResponse;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiUpdateIncomeEvidenceRequest;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiUpdateIncomeEvidenceResponse;
 import uk.gov.justice.laa.crime.orchestration.client.EvidenceApiClient;
@@ -36,5 +37,12 @@ public class EvidenceApiService {
                 evidenceApiClient.updateEvidence(apiUpdateIncomeEvidenceRequest);
         log.debug(RESPONSE_STRING, apiUpdateIncomeEvidenceResponse);
         return apiUpdateIncomeEvidenceResponse;
+    }
+
+    public ApiGetPassportEvidenceResponse getPassportedEvidence(int passportedAssessmentId) {
+        log.debug("Request to evidence service to retrieve evidence for passported assessment: {}", passportedAssessmentId);
+        ApiGetPassportEvidenceResponse response = evidenceApiClient.findPassportedEvidence(passportedAssessmentId);
+        log.debug(RESPONSE_STRING, response);
+        return response;
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/api/EvidenceApiService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/api/EvidenceApiService.java
@@ -39,9 +39,9 @@ public class EvidenceApiService {
         return apiUpdateIncomeEvidenceResponse;
     }
 
-    public ApiGetPassportEvidenceResponse getPassportedEvidence(int passportedAssessmentId) {
-        log.debug("Request to evidence service to retrieve evidence for passported assessment: {}", passportedAssessmentId);
-        ApiGetPassportEvidenceResponse response = evidenceApiClient.findPassportedEvidence(passportedAssessmentId);
+    public ApiGetPassportEvidenceResponse getPassportEvidence(int passportAssessmentId) {
+        log.debug("Request to evidence service to retrieve evidence for passport assessment: {}", passportAssessmentId);
+        ApiGetPassportEvidenceResponse response = evidenceApiClient.findPassportEvidence(passportAssessmentId);
         log.debug(RESPONSE_STRING, response);
         return response;
     }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/Constants.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/Constants.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.laa.crime.orchestration.data;
 
 import uk.gov.justice.laa.crime.enums.HardshipReviewResult;
+import uk.gov.justice.laa.crime.enums.evidence.IncomeEvidenceType;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -41,4 +42,23 @@ public class Constants {
     public static final boolean WITH_PARTNER = true;
     public static final boolean WITHOUT_PARTNER = false;
     public static final boolean WITHOUT_AUTH = false;
+    public static final LocalDateTime DATE_RECEIVED = LocalDateTime.of(2022, 10, 13, 0, 0, 0);
+    public static final LocalDateTime DATE_MODIFIED = LocalDateTime.of(2023, 10, 13, 10, 15, 30);
+
+    // Evidence
+    public static final LocalDateTime INCOME_UPLIFT_APPLY_DATE = LocalDateTime.of(2021, 12, 12, 0, 0, 0);
+    public static final LocalDateTime INCOME_UPLIFT_REMOVE_DATE = INCOME_UPLIFT_APPLY_DATE.plusDays(10);
+    public static final LocalDateTime INCOME_EVIDENCE_DUE_DATE = LocalDateTime.of(2020, 10, 5, 0, 0, 0);
+    public static final LocalDateTime INCOME_EVIDENCE_RECEIVED_DATE = LocalDateTime.of(2020, 10, 1, 0, 0, 0);
+    public static final LocalDateTime EXTRA_INCOME_EVIDENCE_RECEIVED_DATE = LocalDateTime.of(2020, 10, 12, 0, 0, 0);
+    public static final LocalDateTime FIRST_REMINDER_DATE = LocalDateTime.of(2020, 10, 2, 0, 0, 0);
+    public static final LocalDateTime SECOND_REMINDER_DATE = LocalDateTime.of(2020, 10, 2, 0, 0, 0);
+    public static final String INCOME_EVIDENCE_DESCRIPTION = IncomeEvidenceType.TAX_RETURN.getDescription();
+    public static final String INCOME_EVIDENCE = IncomeEvidenceType.TAX_RETURN.getName();
+    public static final String EXTRA_INCOME_EVIDENCE_DESCRIPTION = IncomeEvidenceType.OTHER_ADHOC.getDescription();
+    public static final String EXTRA_INCOME_EVIDENCE = IncomeEvidenceType.OTHER_ADHOC.getName();
+    public static final Integer PARTNER_EVIDENCE_ID = 9552473;
+    public static final Integer APPLICANT_EVIDENCE_ID = 552473;
+    public static final Integer EXTRA_EVIDENCE_ID = 52473;
+    public static final String OTHER_DESCRIPTION = "OTHER DESCRIPTION";
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/Constants.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/Constants.java
@@ -36,23 +36,25 @@ public class Constants {
     public static final Integer USN = 123456789;
     public static final LocalDateTime ASSESSMENT_DATETIME = LocalDateTime.of(2022, 9, 3, 0, 0, 0);
     public static final String NOTES = "This is a test note.";
-    public static final int PASSPORT_ASSESSMENT_ID = 123;
     public static final int CASE_MANAGEMENT_UNIT_ID = 50;
-    public static final LocalDateTime LAST_SIGNON_DATETIME = LocalDateTime.of(2022, 8, 3, 0, 0, 0);
     public static final boolean WITH_PARTNER = true;
     public static final boolean WITHOUT_PARTNER = false;
     public static final boolean WITHOUT_AUTH = false;
     public static final LocalDateTime DATE_RECEIVED = LocalDateTime.of(2022, 10, 13, 0, 0, 0);
-    public static final LocalDateTime DATE_MODIFIED = LocalDateTime.of(2023, 10, 13, 10, 15, 30);
+    public static final LocalDateTime DATE_MODIFIED = DATE_RECEIVED.plusHours(7);
+
+    // Passport
+    public static final int PASSPORT_ASSESSMENT_ID = 123;
+    public static final LocalDateTime LAST_SIGNON_DATETIME = LocalDateTime.of(2022, 8, 3, 0, 0, 0);
 
     // Evidence
-    public static final LocalDateTime INCOME_UPLIFT_APPLY_DATE = LocalDateTime.of(2021, 12, 12, 0, 0, 0);
+    public static final LocalDateTime FIRST_REMINDER_DATE = DATE_RECEIVED.plusDays(14);
+    public static final LocalDateTime INCOME_EVIDENCE_RECEIVED_DATE = FIRST_REMINDER_DATE.plusDays(1);
+    public static final LocalDateTime EXTRA_INCOME_EVIDENCE_RECEIVED_DATE = FIRST_REMINDER_DATE.plusDays(1);
+    public static final LocalDateTime SECOND_REMINDER_DATE = FIRST_REMINDER_DATE.plusDays(7);
+    public static final LocalDateTime INCOME_EVIDENCE_DUE_DATE = SECOND_REMINDER_DATE;
+    public static final LocalDateTime INCOME_UPLIFT_APPLY_DATE = SECOND_REMINDER_DATE.plusDays(1);
     public static final LocalDateTime INCOME_UPLIFT_REMOVE_DATE = INCOME_UPLIFT_APPLY_DATE.plusDays(10);
-    public static final LocalDateTime INCOME_EVIDENCE_DUE_DATE = LocalDateTime.of(2020, 10, 5, 0, 0, 0);
-    public static final LocalDateTime INCOME_EVIDENCE_RECEIVED_DATE = LocalDateTime.of(2020, 10, 1, 0, 0, 0);
-    public static final LocalDateTime EXTRA_INCOME_EVIDENCE_RECEIVED_DATE = LocalDateTime.of(2020, 10, 12, 0, 0, 0);
-    public static final LocalDateTime FIRST_REMINDER_DATE = LocalDateTime.of(2020, 10, 2, 0, 0, 0);
-    public static final LocalDateTime SECOND_REMINDER_DATE = LocalDateTime.of(2020, 10, 2, 0, 0, 0);
     public static final String INCOME_EVIDENCE_DESCRIPTION = IncomeEvidenceType.TAX_RETURN.getDescription();
     public static final String INCOME_EVIDENCE = IncomeEvidenceType.TAX_RETURN.getName();
     public static final String EXTRA_INCOME_EVIDENCE_DESCRIPTION = IncomeEvidenceType.OTHER_ADHOC.getDescription();

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/EvidenceDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/EvidenceDataBuilder.java
@@ -75,11 +75,16 @@ public class EvidenceDataBuilder {
                 .withMandatory(true);
     }
 
-    public static ApiGetPassportEvidenceResponse getApiGetPassportEvidenceResponse() {
-        return new ApiGetPassportEvidenceResponse()
+    public static ApiGetPassportEvidenceResponse getApiGetPassportEvidenceResponse(boolean withPartner) {
+        ApiGetPassportEvidenceResponse response = new ApiGetPassportEvidenceResponse()
                 .withPassportEvidenceMetadata(getApiPassportEvidenceMetadata())
-                .withApplicantEvidenceItems(List.of(getApiIncomeEvidence(false), getExtraApiIncomeEvidence()))
-                .withPartnerEvidenceItems(List.of(getApiIncomeEvidence(true)));
+                .withApplicantEvidenceItems(List.of(getApiIncomeEvidence(false), getExtraApiIncomeEvidence()));
+
+        if (withPartner) {
+            response.setPartnerEvidenceItems(List.of(getApiIncomeEvidence(true)));
+        }
+
+        return response;
     }
 
     public static EvidenceDTO getApplicantEvidenceDTO() {
@@ -100,13 +105,12 @@ public class EvidenceDataBuilder {
                 .build();
     }
 
-    public static IncomeEvidenceSummaryDTO getIncomeEvidenceSummaryDTO() {
-        return IncomeEvidenceSummaryDTO.builder()
+    public static IncomeEvidenceSummaryDTO getIncomeEvidenceSummaryDTO(boolean withPartner) {
+        IncomeEvidenceSummaryDTO incomeEvidenceSummaryDTO = IncomeEvidenceSummaryDTO.builder()
                 .upliftAppliedDate(toDate(Constants.INCOME_UPLIFT_APPLY_DATE))
                 .upliftRemovedDate(toDate(Constants.INCOME_UPLIFT_REMOVE_DATE))
                 .incomeEvidenceNotes(Constants.NOTES)
                 .applicantIncomeEvidenceList(List.of(getApplicantEvidenceDTO()))
-                .partnerIncomeEvidenceList(List.of(getPartnerEvidenceDTO()))
                 .extraEvidenceList(List.of(getExtraIncomeEvidenceDTO(false)))
                 .evidenceReceivedDate(toDate(Constants.INCOME_EVIDENCE_RECEIVED_DATE))
                 .evidenceDueDate(toDate(Constants.INCOME_EVIDENCE_DUE_DATE))
@@ -114,5 +118,11 @@ public class EvidenceDataBuilder {
                 .secondReminderDate(toDate(Constants.SECOND_REMINDER_DATE))
                 .enabled(Boolean.FALSE)
                 .build();
+
+        if (withPartner) {
+            incomeEvidenceSummaryDTO.setPartnerIncomeEvidenceList(List.of(getPartnerEvidenceDTO()));
+        }
+
+        return incomeEvidenceSummaryDTO;
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/EvidenceDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/EvidenceDataBuilder.java
@@ -1,0 +1,118 @@
+package uk.gov.justice.laa.crime.orchestration.data.builder;
+
+import static uk.gov.justice.laa.crime.util.DateUtil.parseLocalDate;
+import static uk.gov.justice.laa.crime.util.DateUtil.toDate;
+import static uk.gov.justice.laa.crime.util.DateUtil.toZonedDateTime;
+
+import uk.gov.justice.laa.crime.common.model.evidence.ApiGetPassportEvidenceResponse;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiIncomeEvidence;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiPassportEvidenceMetadata;
+import uk.gov.justice.laa.crime.enums.evidence.IncomeEvidenceType;
+import uk.gov.justice.laa.crime.orchestration.data.Constants;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.EvidenceDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.EvidenceTypeDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.ExtraEvidenceDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.IncomeEvidenceSummaryDTO;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class EvidenceDataBuilder {
+
+    private static ApiPassportEvidenceMetadata getApiPassportEvidenceMetadata() {
+        return new ApiPassportEvidenceMetadata()
+                .withEvidenceDueDate(parseLocalDate(Constants.INCOME_EVIDENCE_DUE_DATE))
+                .withEvidenceReceivedDate(parseLocalDate(Constants.INCOME_EVIDENCE_RECEIVED_DATE))
+                .withUpliftAppliedDate(parseLocalDate(Constants.INCOME_UPLIFT_APPLY_DATE))
+                .withUpliftRemovedDate(parseLocalDate(Constants.INCOME_UPLIFT_REMOVE_DATE))
+                .withFirstReminderDate(parseLocalDate(Constants.FIRST_REMINDER_DATE))
+                .withSecondReminderDate(parseLocalDate(Constants.SECOND_REMINDER_DATE))
+                .withIncomeEvidenceNotes(Constants.NOTES);
+    }
+
+    private static EvidenceTypeDTO getEvidenceTypeDTO() {
+        return EvidenceTypeDTO.builder()
+                .evidence(Constants.INCOME_EVIDENCE)
+                .description(Constants.INCOME_EVIDENCE_DESCRIPTION)
+                .build();
+    }
+
+    private static EvidenceTypeDTO getExtraEvidenceTypeDTO() {
+        return EvidenceTypeDTO.builder()
+                .evidence(Constants.EXTRA_INCOME_EVIDENCE)
+                .description(Constants.EXTRA_INCOME_EVIDENCE_DESCRIPTION)
+                .build();
+    }
+
+    private static ExtraEvidenceDTO getExtraIncomeEvidenceDTO(boolean isPartner) {
+        return ExtraEvidenceDTO.builder()
+                .adhoc(isPartner ? "P" : "A")
+                .id(Constants.EXTRA_EVIDENCE_ID.longValue())
+                .evidenceTypeDTO(getExtraEvidenceTypeDTO())
+                .dateReceived(toDate(Constants.EXTRA_INCOME_EVIDENCE_RECEIVED_DATE))
+                .otherText(Constants.OTHER_DESCRIPTION)
+                .mandatory(true)
+                .timestamp(toZonedDateTime(Constants.DATE_MODIFIED))
+                .build();
+    }
+
+    private static ApiIncomeEvidence getApiIncomeEvidence(boolean isPartner) {
+        return new ApiIncomeEvidence()
+                .withId(isPartner ? Constants.PARTNER_EVIDENCE_ID : Constants.APPLICANT_EVIDENCE_ID)
+                .withDateReceived(parseLocalDate(Constants.INCOME_EVIDENCE_RECEIVED_DATE))
+                .withEvidenceType(IncomeEvidenceType.TAX_RETURN)
+                .withMandatory(true);
+    }
+
+    private static ApiIncomeEvidence getExtraApiIncomeEvidence() {
+        return new ApiIncomeEvidence()
+                .withId(Constants.EXTRA_EVIDENCE_ID)
+                .withDateReceived(parseLocalDate(Constants.INCOME_EVIDENCE_RECEIVED_DATE))
+                .withEvidenceType(IncomeEvidenceType.OTHER_ADHOC)
+                .withDescription(Constants.OTHER_DESCRIPTION)
+                .withMandatory(true);
+    }
+
+    public static ApiGetPassportEvidenceResponse getApiGetPassportEvidenceResponse() {
+        return new ApiGetPassportEvidenceResponse()
+                .withPassportEvidenceMetadata(getApiPassportEvidenceMetadata())
+                .withApplicantEvidenceItems(List.of(getApiIncomeEvidence(false), getExtraApiIncomeEvidence()))
+                .withPartnerEvidenceItems(List.of(getApiIncomeEvidence(true)));
+    }
+
+    public static EvidenceDTO getApplicantEvidenceDTO() {
+        return EvidenceDTO.builder()
+                .id(Constants.APPLICANT_EVIDENCE_ID.longValue())
+                .evidenceTypeDTO(getEvidenceTypeDTO())
+                .dateReceived(toDate(Constants.INCOME_EVIDENCE_RECEIVED_DATE))
+                .timestamp(toZonedDateTime(Constants.DATE_MODIFIED))
+                .build();
+    }
+
+    public static EvidenceDTO getPartnerEvidenceDTO() {
+        return EvidenceDTO.builder()
+                .id(Constants.PARTNER_EVIDENCE_ID.longValue())
+                .evidenceTypeDTO(getEvidenceTypeDTO())
+                .dateReceived(toDate(Constants.INCOME_EVIDENCE_RECEIVED_DATE))
+                .timestamp(toZonedDateTime(Constants.DATE_MODIFIED))
+                .build();
+    }
+
+    public static IncomeEvidenceSummaryDTO getIncomeEvidenceSummaryDTO() {
+        return IncomeEvidenceSummaryDTO.builder()
+                .upliftAppliedDate(toDate(Constants.INCOME_UPLIFT_APPLY_DATE))
+                .upliftRemovedDate(toDate(Constants.INCOME_UPLIFT_REMOVE_DATE))
+                .incomeEvidenceNotes(Constants.NOTES)
+                .applicantIncomeEvidenceList(List.of(getApplicantEvidenceDTO()))
+                .partnerIncomeEvidenceList(List.of(getPartnerEvidenceDTO()))
+                .extraEvidenceList(List.of(getExtraIncomeEvidenceDTO(false)))
+                .evidenceReceivedDate(toDate(Constants.INCOME_EVIDENCE_RECEIVED_DATE))
+                .evidenceDueDate(toDate(Constants.INCOME_EVIDENCE_DUE_DATE))
+                .firstReminderDate(toDate(Constants.FIRST_REMINDER_DATE))
+                .secondReminderDate(toDate(Constants.SECOND_REMINDER_DATE))
+                .enabled(Boolean.FALSE)
+                .build();
+    }
+}

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/EvidenceDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/EvidenceDataBuilder.java
@@ -54,7 +54,6 @@ public class EvidenceDataBuilder {
                 .dateReceived(toDate(Constants.EXTRA_INCOME_EVIDENCE_RECEIVED_DATE))
                 .otherText(Constants.OTHER_DESCRIPTION)
                 .mandatory(true)
-                .timestamp(toZonedDateTime(Constants.DATE_MODIFIED))
                 .build();
     }
 
@@ -69,7 +68,7 @@ public class EvidenceDataBuilder {
     private static ApiIncomeEvidence getExtraApiIncomeEvidence() {
         return new ApiIncomeEvidence()
                 .withId(Constants.EXTRA_EVIDENCE_ID)
-                .withDateReceived(parseLocalDate(Constants.INCOME_EVIDENCE_RECEIVED_DATE))
+                .withDateReceived(parseLocalDate(Constants.EXTRA_INCOME_EVIDENCE_RECEIVED_DATE))
                 .withEvidenceType(IncomeEvidenceType.OTHER_ADHOC)
                 .withDescription(Constants.OTHER_DESCRIPTION)
                 .withMandatory(true);
@@ -92,7 +91,6 @@ public class EvidenceDataBuilder {
                 .id(Constants.APPLICANT_EVIDENCE_ID.longValue())
                 .evidenceTypeDTO(getEvidenceTypeDTO())
                 .dateReceived(toDate(Constants.INCOME_EVIDENCE_RECEIVED_DATE))
-                .timestamp(toZonedDateTime(Constants.DATE_MODIFIED))
                 .build();
     }
 
@@ -101,7 +99,6 @@ public class EvidenceDataBuilder {
                 .id(Constants.PARTNER_EVIDENCE_ID.longValue())
                 .evidenceTypeDTO(getEvidenceTypeDTO())
                 .dateReceived(toDate(Constants.INCOME_EVIDENCE_RECEIVED_DATE))
-                .timestamp(toZonedDateTime(Constants.DATE_MODIFIED))
                 .build();
     }
 

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/EvidenceDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/EvidenceDataBuilder.java
@@ -2,7 +2,6 @@ package uk.gov.justice.laa.crime.orchestration.data.builder;
 
 import static uk.gov.justice.laa.crime.util.DateUtil.parseLocalDate;
 import static uk.gov.justice.laa.crime.util.DateUtil.toDate;
-import static uk.gov.justice.laa.crime.util.DateUtil.toZonedDateTime;
 
 import uk.gov.justice.laa.crime.common.model.evidence.ApiGetPassportEvidenceResponse;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiIncomeEvidence;

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/MeansAssessmentDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/MeansAssessmentDataBuilder.java
@@ -702,7 +702,7 @@ public class MeansAssessmentDataBuilder {
                 .fullAvailable(true)
                 .full(getFullAssessmentDTO())
                 .initial(getInitialAssessmentDTO())
-                .incomeEvidence(EvidenceDataBuilder.getIncomeEvidenceSummaryDTO())
+                .incomeEvidence(EvidenceDataBuilder.getIncomeEvidenceSummaryDTO(Constants.WITH_PARTNER))
                 .build();
     }
 

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/MeansAssessmentDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/MeansAssessmentDataBuilder.java
@@ -55,17 +55,13 @@ import uk.gov.justice.laa.crime.orchestration.dto.maat.ContributionsDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.CrownCourtOverviewDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.CrownCourtSummaryDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.EmploymentStatusDTO;
-import uk.gov.justice.laa.crime.orchestration.dto.maat.EvidenceDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.EvidenceFeeDTO;
-import uk.gov.justice.laa.crime.orchestration.dto.maat.EvidenceTypeDTO;
-import uk.gov.justice.laa.crime.orchestration.dto.maat.ExtraEvidenceDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.FinancialAssessmentDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.FrequenciesDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.FullAssessmentDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.HardshipOverviewDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.HardshipReviewDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.IOJAppealDTO;
-import uk.gov.justice.laa.crime.orchestration.dto.maat.IncomeEvidenceSummaryDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.InitialAssessmentDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.NewWorkReasonDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.OffenceDTO;
@@ -97,11 +93,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class MeansAssessmentDataBuilder {
     public static final BigDecimal ANNUAL_DISPOSABLE_INCOME = BigDecimal.valueOf(1000.00);
-    private static final Integer PARTNER_EVIDENCE_ID = 9552473;
-    private static final Integer APPLICANT_EVIDENCE_ID = 552473;
-    private static final Integer PARTNER_ID = 88;
-    private static final String INCOME_EVIDENCE_DESCRIPTION = "Tax Return";
-    private static final String INCOME_EVIDENCE = "TAX RETURN";
     private static final String EVIDENCE_FEE_LEVEL_1 = "LEVEL1";
     private static final Integer PASSPORTED_ID = 777;
     private static final Integer APPLICANT_HISTORY_ID = 666;
@@ -127,13 +118,6 @@ public class MeansAssessmentDataBuilder {
     private static final BigDecimal PARTNER_ANNUAL_TOTAL = BigDecimal.valueOf(12000);
     private static final BigDecimal ANNUAL_TOTAL = APPLICANT_ANNUAL_TOTAL.add(PARTNER_ANNUAL_TOTAL);
     private static final String EMPLOYMENT_STATUS = "EMPLOY";
-    private static final String INCOME_EVIDENCE_NOTES = "Mock Income evidence notes";
-    private static final LocalDateTime INCOME_UPLIFT_APPLY_DATE = LocalDateTime.of(2021, 12, 12, 0, 0, 0);
-    private static final LocalDateTime INCOME_UPLIFT_REMOVE_DATE = INCOME_UPLIFT_APPLY_DATE.plusDays(10);
-    private static final LocalDateTime INCOME_EVIDENCE_DUE_DATE = LocalDateTime.of(2020, 10, 5, 0, 0, 0);
-    private static final LocalDateTime INCOME_EVIDENCE_RECEIVED_DATE = LocalDateTime.of(2020, 10, 1, 0, 0, 0);
-    private static final LocalDateTime FIRST_REMINDER_DATE = LocalDateTime.of(2020, 10, 2, 0, 0, 0);
-    private static final LocalDateTime SECOND_REMINDER_DATE = LocalDateTime.of(2020, 10, 2, 0, 0, 0);
     private static final String TRANSACTION_ID = "7c49ebfe-fe3a-4f2f-8dad-f7b8f03b8327";
     private static final BigDecimal THRESHOLD = BigDecimal.valueOf(5000.00);
     private static final BigDecimal AGGREGATED_EXPENSE = BigDecimal.valueOf(22000.00);
@@ -170,16 +154,12 @@ public class MeansAssessmentDataBuilder {
     private static final ZonedDateTime TIME_STAMP = toZonedDateTime(DATE_MODIFIED);
     public static final String SECTION = "INITA";
     public static final Integer INIT_MEANS_ID = 90;
-    private static final LocalDateTime PARTNER_EVIDENCE_RECEIVED_DATE = LocalDateTime.of(2020, 9, 13, 0, 0, 0);
-    private static final LocalDateTime APPLICANT_EVIDENCE_RECEIVED_DATE = LocalDateTime.of(2020, 10, 1, 0, 0, 0);
     public static final Date APPEAL_RECEIVED_DATE = new GregorianCalendar(2023, Calendar.MARCH, 18).getTime();
     public static final Integer TEST_REP_ID = 42312;
     public static final LocalDateTime TEST_MAGS_OUTCOME_DATE = LocalDateTime.of(2022, 6, 5, 0, 0);
 
     private static final LocalDateTime APPLICATION_TIMESTAMP = LocalDateTime.of(2022, 10, 1, 0, 0, 0);
     public static final Date APPEAL_SENTENCE_ORDER_DATE = new GregorianCalendar(2023, Calendar.AUGUST, 3).getTime();
-    public static final String OTHER_DESCRIPTION = "OTHER DESCRIPTION";
-    private static final Integer EXTRA_EVIDENCE_ID = 52473;
 
     public static ApiUserSession getApiUserSession() {
         return new ApiUserSession().withUserName(USERNAME).withSessionId(USER_SESSION);
@@ -477,59 +457,6 @@ public class MeansAssessmentDataBuilder {
         return UserDTO.builder().userName(USERNAME).userSession(USER_SESSION).build();
     }
 
-    public static IncomeEvidenceSummaryDTO getIncomeEvidenceSummaryDTO() {
-        return IncomeEvidenceSummaryDTO.builder()
-                .upliftAppliedDate(toDate(INCOME_UPLIFT_APPLY_DATE))
-                .upliftRemovedDate(toDate(INCOME_UPLIFT_REMOVE_DATE))
-                .incomeEvidenceNotes(INCOME_EVIDENCE_NOTES)
-                .applicantIncomeEvidenceList(List.of(getApplicantEvidenceDTO()))
-                .partnerIncomeEvidenceList(List.of(getPartnerEvidenceDTO()))
-                .extraEvidenceList(List.of(getExtraIncomeEvidenceDTO()))
-                .evidenceReceivedDate(toDate(INCOME_EVIDENCE_RECEIVED_DATE))
-                .evidenceDueDate(toDate(INCOME_EVIDENCE_DUE_DATE))
-                .firstReminderDate(toDate(FIRST_REMINDER_DATE))
-                .secondReminderDate(toDate(SECOND_REMINDER_DATE))
-                .enabled(Boolean.FALSE)
-                .build();
-    }
-
-    private static ExtraEvidenceDTO getExtraIncomeEvidenceDTO() {
-        return ExtraEvidenceDTO.builder()
-                .adhoc("Y")
-                .id(EXTRA_EVIDENCE_ID.longValue())
-                .evidenceTypeDTO(getEvidenceTypeDTO())
-                .dateReceived(toDate(DATETIME_RECEIVED))
-                .otherText(OTHER_DESCRIPTION)
-                .mandatory(true)
-                .timestamp(TIME_STAMP)
-                .build();
-    }
-
-    public static EvidenceDTO getApplicantEvidenceDTO() {
-        return EvidenceDTO.builder()
-                .id(APPLICANT_EVIDENCE_ID.longValue())
-                .evidenceTypeDTO(getEvidenceTypeDTO())
-                .dateReceived(toDate(APPLICANT_EVIDENCE_RECEIVED_DATE))
-                .timestamp(TIME_STAMP)
-                .build();
-    }
-
-    public static EvidenceDTO getPartnerEvidenceDTO() {
-        return EvidenceDTO.builder()
-                .id(PARTNER_EVIDENCE_ID.longValue())
-                .evidenceTypeDTO(getEvidenceTypeDTO())
-                .dateReceived(toDate(PARTNER_EVIDENCE_RECEIVED_DATE))
-                .timestamp(TIME_STAMP)
-                .build();
-    }
-
-    private static EvidenceTypeDTO getEvidenceTypeDTO() {
-        return EvidenceTypeDTO.builder()
-                .evidence(INCOME_EVIDENCE)
-                .description(INCOME_EVIDENCE_DESCRIPTION)
-                .build();
-    }
-
     private static AppealDTO getAppealDTO() {
         return AppealDTO.builder()
                 .available(true)
@@ -663,13 +590,13 @@ public class MeansAssessmentDataBuilder {
 
     public static ApiIncomeEvidenceSummary getApiIncomeEvidenceSummary() {
         return new ApiIncomeEvidenceSummary()
-                .withIncomeEvidenceNotes(INCOME_EVIDENCE_NOTES)
-                .withEvidenceDueDate(INCOME_EVIDENCE_DUE_DATE)
-                .withUpliftAppliedDate(INCOME_UPLIFT_APPLY_DATE)
-                .withEvidenceReceivedDate(INCOME_EVIDENCE_RECEIVED_DATE)
-                .withFirstReminderDate(FIRST_REMINDER_DATE)
-                .withSecondReminderDate(SECOND_REMINDER_DATE)
-                .withUpliftRemovedDate(INCOME_UPLIFT_REMOVE_DATE)
+                .withIncomeEvidenceNotes(Constants.NOTES)
+                .withEvidenceDueDate(Constants.INCOME_EVIDENCE_DUE_DATE)
+                .withUpliftAppliedDate(Constants.INCOME_UPLIFT_APPLY_DATE)
+                .withEvidenceReceivedDate(Constants.INCOME_EVIDENCE_RECEIVED_DATE)
+                .withFirstReminderDate(Constants.FIRST_REMINDER_DATE)
+                .withSecondReminderDate(Constants.SECOND_REMINDER_DATE)
+                .withUpliftRemovedDate(Constants.INCOME_UPLIFT_REMOVE_DATE)
                 .withIncomeEvidence(getIncomeEvidence(true));
     }
 
@@ -677,28 +604,28 @@ public class MeansAssessmentDataBuilder {
         List<ApiIncomeEvidence> incomeEvidences = new ArrayList<>();
 
         incomeEvidences.add(new ApiIncomeEvidence()
-                .withId(APPLICANT_EVIDENCE_ID)
+                .withId(Constants.APPLICANT_EVIDENCE_ID)
                 .withApplicantId(Constants.APPLICANT_ID)
-                .withDateReceived(APPLICANT_EVIDENCE_RECEIVED_DATE)
-                .withDateModified(DATE_MODIFIED)
-                .withIncomeEvidence(INCOME_EVIDENCE));
+                .withDateReceived(Constants.INCOME_EVIDENCE_RECEIVED_DATE)
+                .withDateModified(Constants.DATE_MODIFIED)
+                .withIncomeEvidence(Constants.INCOME_EVIDENCE));
 
         incomeEvidences.add(new ApiIncomeEvidence()
-                .withId(PARTNER_EVIDENCE_ID)
-                .withApplicantId(PARTNER_ID)
-                .withDateReceived(PARTNER_EVIDENCE_RECEIVED_DATE)
-                .withDateModified(DATE_MODIFIED)
-                .withIncomeEvidence(INCOME_EVIDENCE));
+                .withId(Constants.PARTNER_EVIDENCE_ID)
+                .withApplicantId(Constants.PARTNER_ID)
+                .withDateReceived(Constants.INCOME_EVIDENCE_RECEIVED_DATE)
+                .withDateModified(Constants.DATE_MODIFIED)
+                .withIncomeEvidence(Constants.INCOME_EVIDENCE));
 
         if (withExtra) {
             incomeEvidences.add(new ApiIncomeEvidence()
-                    .withAdhoc("Y")
-                    .withId(EXTRA_EVIDENCE_ID)
-                    .withIncomeEvidence(INCOME_EVIDENCE)
-                    .withDateReceived(DATETIME_RECEIVED)
-                    .withOtherText(OTHER_DESCRIPTION)
+                    .withAdhoc("A")
+                    .withId(Constants.EXTRA_EVIDENCE_ID)
+                    .withIncomeEvidence(Constants.INCOME_EVIDENCE)
+                    .withDateReceived(Constants.DATE_RECEIVED)
+                    .withOtherText(Constants.OTHER_DESCRIPTION)
                     .withMandatory("true")
-                    .withDateModified(DATE_MODIFIED));
+                    .withDateModified(Constants.DATE_MODIFIED));
         }
 
         return incomeEvidences;
@@ -775,7 +702,7 @@ public class MeansAssessmentDataBuilder {
                 .fullAvailable(true)
                 .full(getFullAssessmentDTO())
                 .initial(getInitialAssessmentDTO())
-                .incomeEvidence(getIncomeEvidenceSummaryDTO())
+                .incomeEvidence(EvidenceDataBuilder.getIncomeEvidenceSummaryDTO())
                 .build();
     }
 

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/PassportAssessmentDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/PassportAssessmentDataBuilder.java
@@ -111,6 +111,7 @@ public class PassportAssessmentDataBuilder {
                 .benefitClaimedByPartner(hasPartner)
                 .partnerDetails(hasPartner ? getPartnerDTO() : new PartnerDTO())
                 .under18HeardYouthCourt(false)
+                .passportSummaryEvidenceDTO(EvidenceDataBuilder.getIncomeEvidenceSummaryDTO())
                 .build();
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/PassportAssessmentDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/PassportAssessmentDataBuilder.java
@@ -111,7 +111,7 @@ public class PassportAssessmentDataBuilder {
                 .benefitClaimedByPartner(hasPartner)
                 .partnerDetails(hasPartner ? getPartnerDTO() : new PartnerDTO())
                 .under18HeardYouthCourt(false)
-                .passportSummaryEvidenceDTO(EvidenceDataBuilder.getIncomeEvidenceSummaryDTO())
+                .passportSummaryEvidenceDTO(EvidenceDataBuilder.getIncomeEvidenceSummaryDTO(hasPartner))
                 .build();
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/integration/PassportAssessmentIntegrationTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/integration/PassportAssessmentIntegrationTest.java
@@ -7,10 +7,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.justice.laa.crime.orchestration.data.Constants.PASSPORT_ASSESSMENT_ID;
 import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.stubForFindPassportAssessment;
+import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.stubForFindPassportEvidence;
 import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.stubForGetApplicant;
 import static uk.gov.justice.laa.crime.util.RequestBuilderUtils.buildRequest;
 
 import uk.gov.justice.laa.crime.orchestration.data.Constants;
+import uk.gov.justice.laa.crime.orchestration.data.builder.EvidenceDataBuilder;
 import uk.gov.justice.laa.crime.orchestration.data.builder.PassportAssessmentDataBuilder;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.PassportedDTO;
 
@@ -63,6 +65,8 @@ class PassportAssessmentIntegrationTest extends WiremockIntegrationTest {
         stubForOAuth();
         stubForFindPassportAssessment(objectMapper.writeValueAsString(
                 PassportAssessmentDataBuilder.getApiGetPassportedAssessmentResponse(Constants.WITHOUT_PARTNER)));
+        stubForFindPassportEvidence(objectMapper.writeValueAsString(
+                EvidenceDataBuilder.getApiGetPassportEvidenceResponse(Constants.WITHOUT_PARTNER)));
         stubForGetApplicant(objectMapper.writeValueAsString(PassportAssessmentDataBuilder.getApplicantDTO()));
 
         PassportedDTO expected = PassportAssessmentDataBuilder.getPassportedDTO(Constants.WITHOUT_PARTNER);

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/integration/PassportAssessmentIntegrationTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/integration/PassportAssessmentIntegrationTest.java
@@ -15,9 +15,7 @@ import uk.gov.justice.laa.crime.orchestration.data.Constants;
 import uk.gov.justice.laa.crime.orchestration.data.builder.EvidenceDataBuilder;
 import uk.gov.justice.laa.crime.orchestration.data.builder.PassportAssessmentDataBuilder;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.PassportedDTO;
-
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
+import uk.gov.justice.laa.crime.orchestration.utils.TestUtils;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,6 +60,8 @@ class PassportAssessmentIntegrationTest extends WiremockIntegrationTest {
 
     @Test
     void givenValidId_whenFindIsInvoked_thenPassportAssessmentIsReturned() throws Exception {
+        PassportedDTO expected = PassportAssessmentDataBuilder.getPassportedDTO(Constants.WITHOUT_PARTNER);
+
         stubForOAuth();
         stubForFindPassportAssessment(objectMapper.writeValueAsString(
                 PassportAssessmentDataBuilder.getApiGetPassportedAssessmentResponse(Constants.WITHOUT_PARTNER)));
@@ -69,24 +69,21 @@ class PassportAssessmentIntegrationTest extends WiremockIntegrationTest {
                 EvidenceDataBuilder.getApiGetPassportEvidenceResponse(Constants.WITHOUT_PARTNER)));
         stubForGetApplicant(objectMapper.writeValueAsString(PassportAssessmentDataBuilder.getApplicantDTO()));
 
-        PassportedDTO expected = PassportAssessmentDataBuilder.getPassportedDTO(Constants.WITHOUT_PARTNER);
-
-        DateTimeFormatter expectedDateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'+00:00'");
-
-        String expectedDate =
-                expected.getDate().toInstant().atOffset(ZoneOffset.UTC).format(expectedDateFormat);
-
         mvc.perform(buildRequest(HttpMethod.GET, ENDPOINT_URL + "/" + PASSPORT_ASSESSMENT_ID))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.passportedId").value(expected.getPassportedId()))
                 .andExpect(jsonPath("$.cmuId").value(expected.getCmuId()))
                 .andExpect(jsonPath("$.usn").value(expected.getUsn()))
-                .andExpect(jsonPath("$.date").value(expectedDate))
-                .andExpect(jsonPath("$.assessementStatusDTO").value(expected.getAssessementStatusDTO()))
-                .andExpect(jsonPath("$.passportConfirmationDTO").value(expected.getPassportConfirmationDTO()))
-                .andExpect(jsonPath("$.newWorkReason").value(expected.getNewWorkReason()))
-                .andExpect(jsonPath("$.reviewType").value(expected.getReviewType()))
+                .andExpect(jsonPath("$.date").value(TestUtils.formatDate(expected.getDate())))
+                .andExpect(jsonPath("$.assessementStatusDTO.status")
+                        .value(expected.getAssessementStatusDTO().getStatus()))
+                .andExpect(jsonPath("$.passportConfirmationDTO.confirmation")
+                        .value(expected.getPassportConfirmationDTO().getConfirmation()))
+                .andExpect(jsonPath("$.newWorkReason.code")
+                        .value(expected.getNewWorkReason().getCode()))
+                .andExpect(jsonPath("$.reviewType.code")
+                        .value(expected.getReviewType().getCode()))
                 .andExpect(jsonPath("$.dwpResult").value(expected.getDwpResult()))
                 .andExpect(jsonPath("$.benefitIncomeSupport").value(expected.getBenefitIncomeSupport()))
                 .andExpect(jsonPath("$.benefitJobSeeker").value(expected.getBenefitJobSeeker()))
@@ -103,7 +100,30 @@ class PassportAssessmentIntegrationTest extends WiremockIntegrationTest {
                 .andExpect(jsonPath("$.under18FullEducation").value(expected.getUnder18FullEducation()))
                 .andExpect(jsonPath("$.under16").value(expected.getUnder16()))
                 .andExpect(jsonPath("$.between1617").value(expected.getBetween1617()))
-                .andExpect(jsonPath("$.passportSummaryEvidenceDTO").value(expected.getPassportSummaryEvidenceDTO()))
+                .andExpect(jsonPath("$.passportSummaryEvidenceDTO.evidenceDueDate")
+                        .value(TestUtils.formatDate(
+                                expected.getPassportSummaryEvidenceDTO().getEvidenceDueDate())))
+                .andExpect(jsonPath("$.passportSummaryEvidenceDTO.evidenceReceivedDate")
+                        .value(TestUtils.formatDate(
+                                expected.getPassportSummaryEvidenceDTO().getEvidenceReceivedDate())))
+                .andExpect(jsonPath("$.passportSummaryEvidenceDTO.upliftAppliedDate")
+                        .value(TestUtils.formatDate(
+                                expected.getPassportSummaryEvidenceDTO().getUpliftAppliedDate())))
+                .andExpect(jsonPath("$.passportSummaryEvidenceDTO.upliftRemovedDate")
+                        .value(TestUtils.formatDate(
+                                expected.getPassportSummaryEvidenceDTO().getUpliftRemovedDate())))
+                .andExpect(jsonPath("$.passportSummaryEvidenceDTO.incomeEvidenceNotes")
+                        .value(expected.getPassportSummaryEvidenceDTO().getIncomeEvidenceNotes()))
+                .andExpect(jsonPath("$.passportSummaryEvidenceDTO.firstReminderDate")
+                        .value(TestUtils.formatDate(
+                                expected.getPassportSummaryEvidenceDTO().getFirstReminderDate())))
+                .andExpect(jsonPath("$.passportSummaryEvidenceDTO.secondReminderDate")
+                        .value(TestUtils.formatDate(
+                                expected.getPassportSummaryEvidenceDTO().getSecondReminderDate())))
+                .andExpect(jsonPath("$.passportSummaryEvidenceDTO.applicantIncomeEvidenceList[0].id")
+                        .value(Constants.APPLICANT_EVIDENCE_ID))
+                .andExpect(jsonPath("$.passportSummaryEvidenceDTO.extraEvidenceList[0].otherText")
+                        .value(Constants.OTHER_DESCRIPTION))
                 .andExpect(jsonPath("$.whoDwpChecked").value(expected.getWhoDwpChecked()));
     }
 

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/integration/PassportAssessmentIntegrationTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/integration/PassportAssessmentIntegrationTest.java
@@ -103,6 +103,7 @@ class PassportAssessmentIntegrationTest extends WiremockIntegrationTest {
                 .andExpect(jsonPath("$.under18FullEducation").value(expected.getUnder18FullEducation()))
                 .andExpect(jsonPath("$.under16").value(expected.getUnder16()))
                 .andExpect(jsonPath("$.between1617").value(expected.getBetween1617()))
+                .andExpect(jsonPath("$.passportSummaryEvidenceDTO").value(expected.getPassportSummaryEvidenceDTO()))
                 .andExpect(jsonPath("$.whoDwpChecked").value(expected.getWhoDwpChecked()));
     }
 

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/IncomeEvidenceMapperTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/IncomeEvidenceMapperTest.java
@@ -16,6 +16,7 @@ import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.MaatApiUpda
 import uk.gov.justice.laa.crime.enums.AssessmentType;
 import uk.gov.justice.laa.crime.enums.CourtType;
 import uk.gov.justice.laa.crime.enums.evidence.IncomeEvidenceType;
+import uk.gov.justice.laa.crime.orchestration.data.builder.EvidenceDataBuilder;
 import uk.gov.justice.laa.crime.orchestration.data.builder.MeansAssessmentDataBuilder;
 import uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
@@ -148,9 +149,9 @@ class IncomeEvidenceMapperTest {
         ApplicationDTO applicationDTO = MeansAssessmentDataBuilder.getApplicationDTO();
 
         when(meansAssessmentMapper.getEvidenceDTO(incomeEvidences.get(0)))
-                .thenReturn(MeansAssessmentDataBuilder.getApplicantEvidenceDTO());
+                .thenReturn(EvidenceDataBuilder.getApplicantEvidenceDTO());
         when(meansAssessmentMapper.getEvidenceDTO(incomeEvidences.get(1)))
-                .thenReturn(MeansAssessmentDataBuilder.getPartnerEvidenceDTO());
+                .thenReturn(EvidenceDataBuilder.getPartnerEvidenceDTO());
 
         incomeEvidenceMapper.maatApiAssessmentResponseToApplicationDTO(maatApiAssessmentResponse, applicationDTO);
 
@@ -159,13 +160,13 @@ class IncomeEvidenceMapperTest {
                         .getFinancialAssessmentDTO()
                         .getIncomeEvidence()
                         .getApplicantIncomeEvidenceList())
-                .isEqualTo(List.of(MeansAssessmentDataBuilder.getApplicantEvidenceDTO()));
+                .isEqualTo(List.of(EvidenceDataBuilder.getApplicantEvidenceDTO()));
         softly.assertThat(applicationDTO
                         .getAssessmentDTO()
                         .getFinancialAssessmentDTO()
                         .getIncomeEvidence()
                         .getPartnerIncomeEvidenceList())
-                .isEqualTo(List.of(MeansAssessmentDataBuilder.getPartnerEvidenceDTO()));
+                .isEqualTo(List.of(EvidenceDataBuilder.getPartnerEvidenceDTO()));
         softly.assertAll();
     }
 

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/MeansAssessmentMapperTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/MeansAssessmentMapperTest.java
@@ -49,6 +49,7 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -77,6 +78,8 @@ class MeansAssessmentMapperTest {
         softly.assertThat(actual)
                 .usingRecursiveComparison()
                 .ignoringCollectionOrder()
+                .withComparatorForType(Comparator.comparing(EvidenceDTO::getId), EvidenceDTO.class)
+                .withComparatorForType(Comparator.comparing(ExtraEvidenceDTO::getId), ExtraEvidenceDTO.class)
                 .isEqualTo(expected);
     }
 

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapperTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapperTest.java
@@ -3,8 +3,13 @@ package uk.gov.justice.laa.crime.orchestration.mapper;
 import uk.gov.justice.laa.crime.common.model.passported.ApiGetPassportedAssessmentResponse;
 import uk.gov.justice.laa.crime.enums.BenefitType;
 import uk.gov.justice.laa.crime.orchestration.data.Constants;
+import uk.gov.justice.laa.crime.orchestration.data.builder.EvidenceDataBuilder;
 import uk.gov.justice.laa.crime.orchestration.data.builder.PassportAssessmentDataBuilder;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.EvidenceDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.ExtraEvidenceDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.PassportedDTO;
+
+import java.util.Comparator;
 
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
@@ -17,7 +22,8 @@ import org.junit.jupiter.params.provider.EnumSource;
 @ExtendWith(SoftAssertionsExtension.class)
 class PassportAssessmentMapperTest {
 
-    PassportAssessmentMapper passportAssessmentMapper = new PassportAssessmentMapper();
+    PassportEvidenceMapper passportEvidenceMapper = new PassportEvidenceMapper();
+    PassportAssessmentMapper passportAssessmentMapper = new PassportAssessmentMapper(passportEvidenceMapper);
 
     @InjectSoftAssertions
     private SoftAssertions softly;
@@ -27,11 +33,15 @@ class PassportAssessmentMapperTest {
             givenValidApiResponse_whenApiGetPassportedAssessmentResponseToPassportedDTOIsInvoked_thenPassportDTOIsReturned() {
         PassportedDTO expected = PassportAssessmentDataBuilder.getPassportedDTO(Constants.WITHOUT_PARTNER);
         PassportedDTO actual = passportAssessmentMapper.apiGetPassportedAssessmentResponseToPassportedDTO(
-                PassportAssessmentDataBuilder.getApiGetPassportedAssessmentResponse(Constants.WITHOUT_PARTNER), null);
+                PassportAssessmentDataBuilder.getApiGetPassportedAssessmentResponse(Constants.WITHOUT_PARTNER),
+                EvidenceDataBuilder.getApiGetPassportEvidenceResponse(),
+                null);
 
         softly.assertThat(actual)
                 .usingRecursiveComparison()
                 .ignoringCollectionOrder()
+                .withComparatorForType(Comparator.comparing(EvidenceDTO::getId), EvidenceDTO.class)
+                .withComparatorForType(Comparator.comparing(ExtraEvidenceDTO::getId), ExtraEvidenceDTO.class)
                 .isEqualTo(expected);
     }
 
@@ -41,11 +51,14 @@ class PassportAssessmentMapperTest {
         PassportedDTO expected = PassportAssessmentDataBuilder.getPassportedDTO(Constants.WITH_PARTNER);
         PassportedDTO actual = passportAssessmentMapper.apiGetPassportedAssessmentResponseToPassportedDTO(
                 PassportAssessmentDataBuilder.getApiGetPassportedAssessmentResponse(Constants.WITH_PARTNER),
+                EvidenceDataBuilder.getApiGetPassportEvidenceResponse(),
                 PassportAssessmentDataBuilder.getApplicantDTO());
 
         softly.assertThat(actual)
                 .usingRecursiveComparison()
                 .ignoringCollectionOrder()
+                .withComparatorForType(Comparator.comparing(EvidenceDTO::getId), EvidenceDTO.class)
+                .withComparatorForType(Comparator.comparing(ExtraEvidenceDTO::getId), ExtraEvidenceDTO.class)
                 .isEqualTo(expected);
     }
 
@@ -67,12 +80,14 @@ class PassportAssessmentMapperTest {
         ApiGetPassportedAssessmentResponse response =
                 PassportAssessmentDataBuilder.getApiGetPassportedAssessmentResponse(Constants.WITHOUT_PARTNER);
         response.getDeclaredBenefit().setBenefitType(benefit);
-        PassportedDTO actual =
-                passportAssessmentMapper.apiGetPassportedAssessmentResponseToPassportedDTO(response, null);
+        PassportedDTO actual = passportAssessmentMapper.apiGetPassportedAssessmentResponseToPassportedDTO(
+                response, EvidenceDataBuilder.getApiGetPassportEvidenceResponse(), null);
 
         softly.assertThat(actual)
                 .usingRecursiveComparison()
                 .ignoringCollectionOrder()
+                .withComparatorForType(Comparator.comparing(EvidenceDTO::getId), EvidenceDTO.class)
+                .withComparatorForType(Comparator.comparing(ExtraEvidenceDTO::getId), ExtraEvidenceDTO.class)
                 .isEqualTo(expected);
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapperTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapperTest.java
@@ -1,65 +1,57 @@
 package uk.gov.justice.laa.crime.orchestration.mapper;
 
+import static org.mockito.Mockito.when;
+
+import uk.gov.justice.laa.crime.common.model.evidence.ApiGetPassportEvidenceResponse;
 import uk.gov.justice.laa.crime.common.model.passported.ApiGetPassportedAssessmentResponse;
 import uk.gov.justice.laa.crime.enums.BenefitType;
 import uk.gov.justice.laa.crime.orchestration.data.Constants;
 import uk.gov.justice.laa.crime.orchestration.data.builder.EvidenceDataBuilder;
 import uk.gov.justice.laa.crime.orchestration.data.builder.PassportAssessmentDataBuilder;
-import uk.gov.justice.laa.crime.orchestration.dto.maat.EvidenceDTO;
-import uk.gov.justice.laa.crime.orchestration.dto.maat.ExtraEvidenceDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.PassportedDTO;
-
-import java.util.Comparator;
+import uk.gov.justice.laa.crime.orchestration.dto.maat_api.ApplicantDTO;
 
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 @ExtendWith(SoftAssertionsExtension.class)
 class PassportAssessmentMapperTest {
 
-    PassportEvidenceMapper passportEvidenceMapper = new PassportEvidenceMapper();
-    PassportAssessmentMapper passportAssessmentMapper = new PassportAssessmentMapper(passportEvidenceMapper);
+    @Mock
+    private PassportEvidenceMapper passportEvidenceMapper;
+
+    @InjectMocks
+    private PassportAssessmentMapper passportAssessmentMapper;
 
     @InjectSoftAssertions
     private SoftAssertions softly;
 
-    @Test
-    void
-            givenValidApiResponse_whenApiGetPassportedAssessmentResponseToPassportedDTOIsInvoked_thenPassportDTOIsReturned() {
-        PassportedDTO expected = PassportAssessmentDataBuilder.getPassportedDTO(Constants.WITHOUT_PARTNER);
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void givenValidApiResponse_whenApiGetPassportedAssessmentResponseToPassportedDTOIsInvoked_thenPassportDTOIsReturned(
+            boolean withPartner) {
+        PassportedDTO expected = PassportAssessmentDataBuilder.getPassportedDTO(withPartner);
+        ApiGetPassportEvidenceResponse evidence = EvidenceDataBuilder.getApiGetPassportEvidenceResponse(withPartner);
+        when(passportEvidenceMapper.apiGetPassportEvidenceResponseToIncomeEvidenceSummaryDTO(evidence))
+                .thenReturn(EvidenceDataBuilder.getIncomeEvidenceSummaryDTO(withPartner));
+        ApplicantDTO applicant = withPartner ? PassportAssessmentDataBuilder.getApplicantDTO() : null;
         PassportedDTO actual = passportAssessmentMapper.apiGetPassportedAssessmentResponseToPassportedDTO(
-                PassportAssessmentDataBuilder.getApiGetPassportedAssessmentResponse(Constants.WITHOUT_PARTNER),
-                EvidenceDataBuilder.getApiGetPassportEvidenceResponse(),
-                null);
+                PassportAssessmentDataBuilder.getApiGetPassportedAssessmentResponse(withPartner), evidence, applicant);
 
         softly.assertThat(actual)
                 .usingRecursiveComparison()
                 .ignoringCollectionOrder()
-                .withComparatorForType(Comparator.comparing(EvidenceDTO::getId), EvidenceDTO.class)
-                .withComparatorForType(Comparator.comparing(ExtraEvidenceDTO::getId), ExtraEvidenceDTO.class)
                 .isEqualTo(expected);
-    }
-
-    @Test
-    void
-            givenValidApiResponseWithPartner_whenApiGetPassportedAssessmentResponseToPassportedDTOIsInvoked_thenPassportDTOIsReturned() {
-        PassportedDTO expected = PassportAssessmentDataBuilder.getPassportedDTO(Constants.WITH_PARTNER);
-        PassportedDTO actual = passportAssessmentMapper.apiGetPassportedAssessmentResponseToPassportedDTO(
-                PassportAssessmentDataBuilder.getApiGetPassportedAssessmentResponse(Constants.WITH_PARTNER),
-                EvidenceDataBuilder.getApiGetPassportEvidenceResponse(),
-                PassportAssessmentDataBuilder.getApplicantDTO());
-
-        softly.assertThat(actual)
-                .usingRecursiveComparison()
-                .ignoringCollectionOrder()
-                .withComparatorForType(Comparator.comparing(EvidenceDTO::getId), EvidenceDTO.class)
-                .withComparatorForType(Comparator.comparing(ExtraEvidenceDTO::getId), ExtraEvidenceDTO.class)
-                .isEqualTo(expected);
+        softly.assertAll();
     }
 
     @ParameterizedTest
@@ -76,18 +68,20 @@ class PassportAssessmentMapperTest {
             case BenefitType.ESA -> expected.setBenefitEmploymentSupport(true);
             case BenefitType.UC -> expected.setBenefitUniversalCredit(true);
         }
-
         ApiGetPassportedAssessmentResponse response =
                 PassportAssessmentDataBuilder.getApiGetPassportedAssessmentResponse(Constants.WITHOUT_PARTNER);
         response.getDeclaredBenefit().setBenefitType(benefit);
-        PassportedDTO actual = passportAssessmentMapper.apiGetPassportedAssessmentResponseToPassportedDTO(
-                response, EvidenceDataBuilder.getApiGetPassportEvidenceResponse(), null);
+        ApiGetPassportEvidenceResponse evidence =
+                EvidenceDataBuilder.getApiGetPassportEvidenceResponse(Constants.WITHOUT_PARTNER);
+        when(passportEvidenceMapper.apiGetPassportEvidenceResponseToIncomeEvidenceSummaryDTO(evidence))
+                .thenReturn(EvidenceDataBuilder.getIncomeEvidenceSummaryDTO(Constants.WITHOUT_PARTNER));
+        PassportedDTO actual =
+                passportAssessmentMapper.apiGetPassportedAssessmentResponseToPassportedDTO(response, evidence, null);
 
         softly.assertThat(actual)
                 .usingRecursiveComparison()
                 .ignoringCollectionOrder()
-                .withComparatorForType(Comparator.comparing(EvidenceDTO::getId), EvidenceDTO.class)
-                .withComparatorForType(Comparator.comparing(ExtraEvidenceDTO::getId), ExtraEvidenceDTO.class)
                 .isEqualTo(expected);
+        softly.assertAll();
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapperTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapperTest.java
@@ -56,9 +56,8 @@ class PassportAssessmentMapperTest {
 
     @ParameterizedTest
     @EnumSource(BenefitType.class)
-    void
-            givenDifferentDeclaredBenefitsInApiResponse_whenApiGetPassportedAssessmentResponseToPassportedDTOIsInvoked_thenAppropriateBenefitIsReturned(
-                    BenefitType benefit) {
+    void givenDifferentBenefitsInResponse_whenAssessmentResponseToPassportedIsInvoked_thenAppropriateBenefitIsReturned(
+            BenefitType benefit) {
         PassportedDTO expected = PassportAssessmentDataBuilder.getPassportedDTO(Constants.WITHOUT_PARTNER);
         expected.setBenefitIncomeSupport(false);
         switch (benefit) {

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportEvidenceMapperTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportEvidenceMapperTest.java
@@ -1,0 +1,44 @@
+package uk.gov.justice.laa.crime.orchestration.mapper;
+
+import uk.gov.justice.laa.crime.common.model.evidence.ApiGetPassportEvidenceResponse;
+import uk.gov.justice.laa.crime.orchestration.data.builder.EvidenceDataBuilder;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.EvidenceDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.ExtraEvidenceDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.IncomeEvidenceSummaryDTO;
+
+import java.util.Comparator;
+
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@ExtendWith(SoftAssertionsExtension.class)
+class PassportEvidenceMapperTest {
+
+    @InjectSoftAssertions
+    private SoftAssertions softly;
+
+    private final PassportEvidenceMapper passportEvidenceMapper = new PassportEvidenceMapper();
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void
+            givenValidEvidenceResponse_whenApiGetPassportEvidenceResponseToIncomeEvidenceSummaryDTOIsInvoked_thenIncomeEvidenceSummaryDTOIsReturned(
+                    boolean withPartner) {
+        IncomeEvidenceSummaryDTO expected = EvidenceDataBuilder.getIncomeEvidenceSummaryDTO(withPartner);
+        ApiGetPassportEvidenceResponse response = EvidenceDataBuilder.getApiGetPassportEvidenceResponse(withPartner);
+        IncomeEvidenceSummaryDTO actual =
+                passportEvidenceMapper.apiGetPassportEvidenceResponseToIncomeEvidenceSummaryDTO(response);
+
+        softly.assertThat(actual)
+                .usingRecursiveComparison()
+                .ignoringCollectionOrder()
+                .withComparatorForType(Comparator.comparing(EvidenceDTO::getId), EvidenceDTO.class)
+                .withComparatorForType(Comparator.comparing(ExtraEvidenceDTO::getId), ExtraEvidenceDTO.class)
+                .isEqualTo(expected);
+        softly.assertAll();
+    }
+}

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportEvidenceMapperTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportEvidenceMapperTest.java
@@ -36,8 +36,6 @@ class PassportEvidenceMapperTest {
         softly.assertThat(actual)
                 .usingRecursiveComparison()
                 .ignoringCollectionOrder()
-                .withComparatorForType(Comparator.comparing(EvidenceDTO::getId), EvidenceDTO.class)
-                .withComparatorForType(Comparator.comparing(ExtraEvidenceDTO::getId), ExtraEvidenceDTO.class)
                 .isEqualTo(expected);
         softly.assertAll();
     }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportEvidenceMapperTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportEvidenceMapperTest.java
@@ -2,11 +2,7 @@ package uk.gov.justice.laa.crime.orchestration.mapper;
 
 import uk.gov.justice.laa.crime.common.model.evidence.ApiGetPassportEvidenceResponse;
 import uk.gov.justice.laa.crime.orchestration.data.builder.EvidenceDataBuilder;
-import uk.gov.justice.laa.crime.orchestration.dto.maat.EvidenceDTO;
-import uk.gov.justice.laa.crime.orchestration.dto.maat.ExtraEvidenceDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.IncomeEvidenceSummaryDTO;
-
-import java.util.Comparator;
 
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
@@ -25,9 +21,8 @@ class PassportEvidenceMapperTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    void
-            givenValidEvidenceResponse_whenApiGetPassportEvidenceResponseToIncomeEvidenceSummaryDTOIsInvoked_thenIncomeEvidenceSummaryDTOIsReturned(
-                    boolean withPartner) {
+    void givenValidEvidenceResponse_whenEvidenceResponseToEvidenceSummaryIsInvoked_thenMappingIsSuccessful(
+            boolean withPartner) {
         IncomeEvidenceSummaryDTO expected = EvidenceDataBuilder.getIncomeEvidenceSummaryDTO(withPartner);
         ApiGetPassportEvidenceResponse response = EvidenceDataBuilder.getApiGetPassportEvidenceResponse(withPartner);
         IncomeEvidenceSummaryDTO actual =

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/PassportAssessmentServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/PassportAssessmentServiceTest.java
@@ -4,13 +4,16 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import uk.gov.justice.laa.crime.common.model.evidence.ApiGetPassportEvidenceResponse;
 import uk.gov.justice.laa.crime.common.model.passported.ApiGetPassportedAssessmentResponse;
 import uk.gov.justice.laa.crime.orchestration.data.Constants;
+import uk.gov.justice.laa.crime.orchestration.data.builder.EvidenceDataBuilder;
 import uk.gov.justice.laa.crime.orchestration.data.builder.PassportAssessmentDataBuilder;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.PassportedDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.ApplicantDTO;
 import uk.gov.justice.laa.crime.orchestration.mapper.PassportAssessmentMapper;
 import uk.gov.justice.laa.crime.orchestration.service.api.AssessmentApiService;
+import uk.gov.justice.laa.crime.orchestration.service.api.EvidenceApiService;
 import uk.gov.justice.laa.crime.orchestration.service.api.MaatCourtDataApiService;
 
 import org.junit.jupiter.api.Test;
@@ -26,6 +29,9 @@ class PassportAssessmentServiceTest {
     private AssessmentApiService assessmentApiService;
 
     @Mock
+    private EvidenceApiService evidenceApiService;
+
+    @Mock
     private PassportAssessmentMapper passportAssessmentMapper;
 
     @Mock
@@ -36,15 +42,19 @@ class PassportAssessmentServiceTest {
 
     @Test
     void givenValidIdWithPartner_whenFindIsInvoked_thenPassportedDTOIsReturned() {
-        ApiGetPassportedAssessmentResponse response =
+        ApiGetPassportedAssessmentResponse assessment =
                 PassportAssessmentDataBuilder.getApiGetPassportedAssessmentResponse(Constants.WITH_PARTNER);
-        ApplicantDTO applicantDTO = PassportAssessmentDataBuilder.getApplicantDTO();
+        ApiGetPassportEvidenceResponse evidence = EvidenceDataBuilder.getApiGetPassportEvidenceResponse();
+        ApplicantDTO applicant = PassportAssessmentDataBuilder.getApplicantDTO();
         PassportedDTO passportedDTO = PassportAssessmentDataBuilder.getPassportedDTO(Constants.WITH_PARTNER);
 
         when(assessmentApiService.findPassportAssessment(Constants.PASSPORT_ASSESSMENT_ID))
-                .thenReturn(response);
-        when(maatCourtDataApiService.getApplicant(Constants.PARTNER_ID)).thenReturn(applicantDTO);
-        when(passportAssessmentMapper.apiGetPassportedAssessmentResponseToPassportedDTO(response, applicantDTO))
+                .thenReturn(assessment);
+        when(evidenceApiService.getPassportEvidence(Constants.PASSPORT_ASSESSMENT_ID))
+                .thenReturn(evidence);
+        when(maatCourtDataApiService.getApplicant(Constants.PARTNER_ID)).thenReturn(applicant);
+        when(passportAssessmentMapper.apiGetPassportedAssessmentResponseToPassportedDTO(
+                        assessment, evidence, applicant))
                 .thenReturn(passportedDTO);
 
         assertThat(passportAssessmentService.find(Constants.PASSPORT_ASSESSMENT_ID))
@@ -53,13 +63,16 @@ class PassportAssessmentServiceTest {
 
     @Test
     void givenValidId_whenFindIsInvoked_thenPassportDTOIsReturned() {
-        ApiGetPassportedAssessmentResponse response =
+        ApiGetPassportedAssessmentResponse assessment =
                 PassportAssessmentDataBuilder.getApiGetPassportedAssessmentResponse(Constants.WITHOUT_PARTNER);
+        ApiGetPassportEvidenceResponse evidence = EvidenceDataBuilder.getApiGetPassportEvidenceResponse();
         PassportedDTO passportedDTO = PassportAssessmentDataBuilder.getPassportedDTO(Constants.WITHOUT_PARTNER);
 
         when(assessmentApiService.findPassportAssessment(Constants.PASSPORT_ASSESSMENT_ID))
-                .thenReturn(response);
-        when(passportAssessmentMapper.apiGetPassportedAssessmentResponseToPassportedDTO(response, null))
+                .thenReturn(assessment);
+        when(evidenceApiService.getPassportEvidence(Constants.PASSPORT_ASSESSMENT_ID))
+                .thenReturn(evidence);
+        when(passportAssessmentMapper.apiGetPassportedAssessmentResponseToPassportedDTO(assessment, evidence, null))
                 .thenReturn(passportedDTO);
 
         verifyNoInteractions(maatCourtDataApiService);

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/PassportAssessmentServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/PassportAssessmentServiceTest.java
@@ -44,7 +44,8 @@ class PassportAssessmentServiceTest {
     void givenValidIdWithPartner_whenFindIsInvoked_thenPassportedDTOIsReturned() {
         ApiGetPassportedAssessmentResponse assessment =
                 PassportAssessmentDataBuilder.getApiGetPassportedAssessmentResponse(Constants.WITH_PARTNER);
-        ApiGetPassportEvidenceResponse evidence = EvidenceDataBuilder.getApiGetPassportEvidenceResponse();
+        ApiGetPassportEvidenceResponse evidence =
+                EvidenceDataBuilder.getApiGetPassportEvidenceResponse(Constants.WITH_PARTNER);
         ApplicantDTO applicant = PassportAssessmentDataBuilder.getApplicantDTO();
         PassportedDTO passportedDTO = PassportAssessmentDataBuilder.getPassportedDTO(Constants.WITH_PARTNER);
 
@@ -65,7 +66,8 @@ class PassportAssessmentServiceTest {
     void givenValidId_whenFindIsInvoked_thenPassportDTOIsReturned() {
         ApiGetPassportedAssessmentResponse assessment =
                 PassportAssessmentDataBuilder.getApiGetPassportedAssessmentResponse(Constants.WITHOUT_PARTNER);
-        ApiGetPassportEvidenceResponse evidence = EvidenceDataBuilder.getApiGetPassportEvidenceResponse();
+        ApiGetPassportEvidenceResponse evidence =
+                EvidenceDataBuilder.getApiGetPassportEvidenceResponse(Constants.WITHOUT_PARTNER);
         PassportedDTO passportedDTO = PassportAssessmentDataBuilder.getPassportedDTO(Constants.WITHOUT_PARTNER);
 
         when(assessmentApiService.findPassportAssessment(Constants.PASSPORT_ASSESSMENT_ID))

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/api/EvidenceApiServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/api/EvidenceApiServiceTest.java
@@ -6,9 +6,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import uk.gov.justice.laa.crime.common.model.evidence.ApiCreateIncomeEvidenceRequest;
+import uk.gov.justice.laa.crime.common.model.evidence.ApiGetPassportEvidenceResponse;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiUpdateIncomeEvidenceRequest;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiUpdateIncomeEvidenceResponse;
 import uk.gov.justice.laa.crime.orchestration.client.EvidenceApiClient;
+import uk.gov.justice.laa.crime.orchestration.data.Constants;
+import uk.gov.justice.laa.crime.orchestration.data.builder.EvidenceDataBuilder;
 
 import java.time.LocalDate;
 
@@ -40,6 +43,19 @@ class EvidenceApiServiceTest {
         when(evidenceApiClient.updateEvidence(any(ApiUpdateIncomeEvidenceRequest.class)))
                 .thenReturn(expectedResponse);
         var actualResponse = evidenceApiService.updateEvidence(new ApiUpdateIncomeEvidenceRequest());
+        assertThat(actualResponse).isEqualTo(expectedResponse);
+    }
+
+    @Test
+    void givenValidId_whenGetPassportEvidenceIsInvoked_thenApiGetPassportEvidenceResponseIsReturned() {
+        ApiGetPassportEvidenceResponse expectedResponse =
+                EvidenceDataBuilder.getApiGetPassportEvidenceResponse(Constants.WITH_PARTNER);
+
+        when(evidenceApiClient.findPassportEvidence(Constants.PASSPORT_ASSESSMENT_ID))
+                .thenReturn(expectedResponse);
+
+        ApiGetPassportEvidenceResponse actualResponse =
+                evidenceApiService.getPassportEvidence(Constants.PASSPORT_ASSESSMENT_ID);
         assertThat(actualResponse).isEqualTo(expectedResponse);
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/utils/TestUtils.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/utils/TestUtils.java
@@ -1,0 +1,14 @@
+package uk.gov.justice.laa.crime.orchestration.utils;
+
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+
+public class TestUtils {
+
+    public static String formatDate(Date date) {
+        DateTimeFormatter expectedDateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'+00:00'");
+
+        return date.toInstant().atOffset(ZoneOffset.UTC).format(expectedDateFormat);
+    }
+}

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/utils/WiremockStubs.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/utils/WiremockStubs.java
@@ -193,6 +193,13 @@ public class WiremockStubs {
                         .withBody(response)));
     }
 
+    public static void stubForFindPassportEvidence(String response) {
+        stubFor(get(urlMatching("/api/internal/v1/evidence/passport/" + Constants.PASSPORT_ASSESSMENT_ID))
+                .willReturn(WireMock.ok()
+                        .withHeader("Content-Type", String.valueOf(MediaType.APPLICATION_JSON))
+                        .withBody(response)));
+    }
+
     public static void stubForCreateEvidence(String response) {
         stubFor(post(urlMatching("/api/internal/v1/evidence"))
                 .willReturn(WireMock.ok()

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/utils/WiremockStubs.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/utils/WiremockStubs.java
@@ -42,6 +42,8 @@ public class WiremockStubs {
     private static final String MAAT_API_ASSESSMENT_URL = "/api/internal/v1/assessment";
     private static final String CMA_ROLLBACK_URL = "/api/internal/v1/assessment/means/rollback/";
     private static final String MAAT_API_USER_URL = "/api/internal/v1/users/summary/";
+    private static final String IOJ_APPEALS_URL = "/api/internal/v1/ioj-appeals";
+    private static final String PASSPORT_URL = "/api/internal/v1/passport";
 
     public static void stubForOAuth() throws JsonProcessingException {
         ObjectMapper mapper = new ObjectMapper();
@@ -180,28 +182,28 @@ public class WiremockStubs {
     }
 
     public static void stubForFindIojAppeal(String response) {
-        stubFor(get(urlMatching("/api/internal/v1/ioj-appeals/lookup-by-legacy-id/" + LEGACY_APPEAL_ID))
+        stubFor(get(urlMatching(IOJ_APPEALS_URL + "/lookup-by-legacy-id/" + LEGACY_APPEAL_ID))
                 .willReturn(WireMock.ok()
                         .withHeader("Content-Type", String.valueOf(MediaType.APPLICATION_JSON))
                         .withBody(response)));
     }
 
     public static void stubForFindPassportAssessment(String response) {
-        stubFor(get(urlMatching("/api/internal/v1/passport/lookup-by-legacy-id/" + Constants.PASSPORT_ASSESSMENT_ID))
+        stubFor(get(urlMatching(PASSPORT_URL + "/lookup-by-legacy-id/" + Constants.PASSPORT_ASSESSMENT_ID))
                 .willReturn(WireMock.ok()
                         .withHeader("Content-Type", String.valueOf(MediaType.APPLICATION_JSON))
                         .withBody(response)));
     }
 
     public static void stubForFindPassportEvidence(String response) {
-        stubFor(get(urlMatching("/api/internal/v1/evidence/passport/" + Constants.PASSPORT_ASSESSMENT_ID))
+        stubFor(get(urlMatching(EVIDENCE_URL + "/passport/" + Constants.PASSPORT_ASSESSMENT_ID))
                 .willReturn(WireMock.ok()
                         .withHeader("Content-Type", String.valueOf(MediaType.APPLICATION_JSON))
                         .withBody(response)));
     }
 
     public static void stubForCreateEvidence(String response) {
-        stubFor(post(urlMatching("/api/internal/v1/evidence"))
+        stubFor(post(urlMatching(EVIDENCE_URL))
                 .willReturn(WireMock.ok()
                         .withHeader("Content-Type", String.valueOf(MediaType.APPLICATION_JSON))
                         .withBody(response)));
@@ -212,7 +214,7 @@ public class WiremockStubs {
     }
 
     public static void stubForCreateIojAppeal(String response) {
-        stubFor(post(urlMatching("/api/internal/v1/ioj-appeals"))
+        stubFor(post(urlMatching(IOJ_APPEALS_URL))
                 .willReturn(WireMock.ok()
                         .withHeader("Content-Type", String.valueOf(MediaType.APPLICATION_JSON))
                         .withBody(response)));
@@ -279,7 +281,7 @@ public class WiremockStubs {
     }
 
     public static void stubForRollbackIojAppeal(String response) {
-        stubFor(post(urlMatching("/api/internal/v1/ioj-appeals/" + APPEAL_ID + "/rollback"))
+        stubFor(post(urlMatching(IOJ_APPEALS_URL + "/" + APPEAL_ID + "/rollback"))
                 .willReturn(WireMock.ok()
                         .withHeader("Content-Type", String.valueOf(MediaType.APPLICATION_JSON))
                         .withBody(response)));


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/projects/LCAM/boards/881?selectedIssue=LCAM-2055)

- Added logic to call the Evidence Service during the find passport assessment to retrieve the evidence associated with the passport assessment to map it into the PassportDTO to return to MAAT.
- Some reworking of evidence test data creation to locate the helper methods and constants all in one place to be used for both income and passport evidence testing.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.