### PR TITLE
LCAM-1982 - Create Passport Assessment Orchestration

### DIFF
--- a/maat-orchestration/build.gradle
+++ b/maat-orchestration/build.gradle
@@ -73,6 +73,9 @@ dependencies {
 	annotationProcessor "org.projectlombok:lombok"
 	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
+	// ---- Pinned to Resolve Vulnerability CVE-2026-43512 ---
+	implementation "org.apache.tomcat.embed:tomcat-embed-core:10.1.55"
+
 	// ---- Testing ----
 	testImplementation "org.springframework.boot:spring-boot-starter-test"
 	testImplementation "org.wiremock.integrations:wiremock-spring-boot:$versions.wiremock"

--- a/maat-orchestration/build.gradle
+++ b/maat-orchestration/build.gradle
@@ -21,7 +21,7 @@ def versions = [
 		sentry					: "8.36.0",
 		springdocVersion        : "2.8.14",
 		commonsModSchemas       : "1.50.0",
-		crimeCommonsClasses     : "4.33.0",
+		crimeCommonsClasses     : "4.38.0",
 		wiremock				: "4.0.8",
 		resilience4jVersion     : "2.4.0",
 		commonsLang3Version		: "3.20.0",

--- a/maat-orchestration/build.gradle
+++ b/maat-orchestration/build.gradle
@@ -4,7 +4,7 @@ plugins {
 	id "org.sonarqube" version "7.2.3.7755"
 	id "com.diffplug.spotless" version "8.0.0"
 	id "info.solidsoft.pitest" version "1.19.0"
-	id "org.springframework.boot" version "3.5.13"
+	id "org.springframework.boot" version "3.5.14"
 	id "io.spring.dependency-management" version "1.1.7"
 }
 

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/client/CrimeAssessmentApiClient.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/client/CrimeAssessmentApiClient.java
@@ -30,5 +30,6 @@ public interface CrimeAssessmentApiClient {
     ApiGetPassportedAssessmentResponse getPassportAssessment(@PathVariable Integer id);
 
     @PostExchange("/passport")
-    ApiCreatePassportedAssessmentResponse createPassportAssessment(@RequestBody ApiCreatePassportedAssessmentRequest request);
+    ApiCreatePassportedAssessmentResponse createPassportAssessment(
+            @RequestBody ApiCreatePassportedAssessmentRequest request);
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/client/CrimeAssessmentApiClient.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/client/CrimeAssessmentApiClient.java
@@ -4,6 +4,8 @@ import uk.gov.justice.laa.crime.common.model.ioj.ApiCreateIojAppealRequest;
 import uk.gov.justice.laa.crime.common.model.ioj.ApiCreateIojAppealResponse;
 import uk.gov.justice.laa.crime.common.model.ioj.ApiGetIojAppealResponse;
 import uk.gov.justice.laa.crime.common.model.ioj.ApiRollbackIojAppealResponse;
+import uk.gov.justice.laa.crime.common.model.passported.ApiCreatePassportedAssessmentRequest;
+import uk.gov.justice.laa.crime.common.model.passported.ApiCreatePassportedAssessmentResponse;
 import uk.gov.justice.laa.crime.common.model.passported.ApiGetPassportedAssessmentResponse;
 
 import org.springframework.web.bind.annotation.PathVariable;
@@ -26,4 +28,7 @@ public interface CrimeAssessmentApiClient {
 
     @GetExchange("/passport/lookup-by-legacy-id/{id}")
     ApiGetPassportedAssessmentResponse getPassportAssessment(@PathVariable Integer id);
+
+    @PostExchange("/passport")
+    ApiCreatePassportedAssessmentResponse createPassportAssessment(@RequestBody ApiCreatePassportedAssessmentRequest request);
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/common/ApplicationDTOUtils.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/common/ApplicationDTOUtils.java
@@ -8,7 +8,7 @@ import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
 import java.util.Collection;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class ApplicationUtils {
+public class ApplicationDTOUtils {
 
     public static Integer getPartnerId(ApplicationDTO applicationDTO) {
         Collection<ApplicantLinkDTO> applicantLinks = applicationDTO.getApplicantLinks();

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/common/ApplicationUtils.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/common/ApplicationUtils.java
@@ -1,0 +1,26 @@
+package uk.gov.justice.laa.crime.orchestration.common;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicantLinkDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
+
+import java.util.Collection;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ApplicationUtils {
+
+    public static Integer getPartnerId(ApplicationDTO applicationDTO) {
+        Collection<ApplicantLinkDTO> applicantLinks = applicationDTO.getApplicantLinks();
+
+        if (null != applicantLinks && !applicantLinks.isEmpty()) {
+            return applicantLinks.stream()
+                    .filter(applicant -> applicant.getUnlinked() == null)
+                    .map(applicant -> applicant.getPartnerDTO().getId().intValue())
+                    .findFirst()
+                    .orElse(null);
+        }
+
+        return null;
+    }
+}

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/controller/PassportAssessmentController.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/controller/PassportAssessmentController.java
@@ -8,8 +8,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import uk.gov.justice.laa.crime.annotation.DefaultHTTPErrorResponse;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
@@ -20,6 +18,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -54,9 +54,7 @@ public class PassportAssessmentController {
             content =
                     @Content(
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = ApplicationDTO.class)
-                    )
-    )
+                            schema = @Schema(implementation = ApplicationDTO.class)))
     @DefaultHTTPErrorResponse
     public ResponseEntity<ApplicationDTO> create(@Valid @RequestBody WorkflowRequest workflowRequest) {
         log.info("Received request to create passport assessment");

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/controller/PassportAssessmentController.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/controller/PassportAssessmentController.java
@@ -5,9 +5,14 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import uk.gov.justice.laa.crime.annotation.DefaultHTTPErrorResponse;
+import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.PassportedDTO;
 import uk.gov.justice.laa.crime.orchestration.service.orchestration.PassportAssessmentOrchestrationService;
 
@@ -40,5 +45,21 @@ public class PassportAssessmentController {
         log.info("Received request to find Passport Assessment by ID - {}", id);
 
         return ResponseEntity.ok(orchestrationService.find(id));
+    }
+
+    @PostMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(description = "Create passport assessment")
+    @ApiResponse(
+            responseCode = "200",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApplicationDTO.class)
+                    )
+    )
+    @DefaultHTTPErrorResponse
+    public ResponseEntity<ApplicationDTO> create(@Valid @RequestBody WorkflowRequest workflowRequest) {
+        log.info("Received request to create passport assessment");
+        return ResponseEntity.ok(orchestrationService.create(workflowRequest));
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/enums/AssessmentSummaryType.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/enums/AssessmentSummaryType.java
@@ -11,7 +11,7 @@ public enum AssessmentSummaryType {
     HARDSHIP_REVIEW_MAGS_COURT("Hardship Review - Magistrate"),
     HARDSHIP_REVIEW_CROWN_COURT("Hardship Review - Crown Court"),
     IOJ_APPEAL("IoJ Appeal"),
-    PASSPORT_ASSESSMENT("Passported");
+    PASSPORTED_ASSESSMENT("Passported");
 
     private final String name;
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/enums/AssessmentSummaryType.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/enums/AssessmentSummaryType.java
@@ -10,7 +10,8 @@ public enum AssessmentSummaryType {
     FULL_MEANS_ASSESSMENT("Full Means Test"),
     HARDSHIP_REVIEW_MAGS_COURT("Hardship Review - Magistrate"),
     HARDSHIP_REVIEW_CROWN_COURT("Hardship Review - Crown Court"),
-    IOJ_APPEAL("IoJ Appeal");
+    IOJ_APPEAL("IoJ Appeal"),
+    PASSPORT_ASSESSMENT("Passported");
 
     private final String name;
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapper.java
@@ -89,9 +89,9 @@ public class PassportAssessmentMapper {
             return BenefitType.GSPC;
         } else if (Boolean.TRUE.equals(passportedDTO.getBenefitUniversalCredit())) {
             return BenefitType.UC;
-        } else {
-            return null;
         }
+
+        return null;
     }
 
     private DeclaredBenefit mapDeclaredBenefit(ApplicationDTO applicationDTO) {

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapper.java
@@ -7,6 +7,8 @@ import uk.gov.justice.laa.crime.enums.BenefitType;
 import uk.gov.justice.laa.crime.enums.NewWorkReason;
 import uk.gov.justice.laa.crime.enums.PassportAssessmentDecisionReason;
 import uk.gov.justice.laa.crime.enums.ReviewType;
+import uk.gov.justice.laa.crime.enums.orchestration.Action;
+import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.AssessmentStatusDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.JobSeekerDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.NewWorkReasonDTO;
@@ -15,6 +17,7 @@ import uk.gov.justice.laa.crime.orchestration.dto.maat.PassportConfirmationDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.PassportedDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.ReviewTypeDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.ApplicantDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.validation.UserActionDTO;
 import uk.gov.justice.laa.crime.util.DateUtil;
 
 import org.springframework.stereotype.Component;
@@ -24,6 +27,8 @@ import org.springframework.stereotype.Component;
 public class PassportAssessmentMapper {
 
     private static final String ASSESSMENT_STATUS_DESCRIPTION = "Complete";
+
+    private final UserMapper userMapper;
 
     private PartnerDTO applicantDTOToPartnerDTO(ApplicantDTO applicant) {
         return PartnerDTO.builder()
@@ -113,5 +118,15 @@ public class PassportAssessmentMapper {
         }
 
         return dto;
+    }
+
+    public UserActionDTO getUserActionDTO(WorkflowRequest workflowRequest) {
+        NewWorkReason newWorkReason = NewWorkReason.getFrom(workflowRequest
+            .getApplicationDTO()
+            .getPassportedDTO()
+            .getNewWorkReason()
+            .getCode());
+
+        return userMapper.getUserActionDTO(workflowRequest, Action.CREATE_PASSPORT_ASSESSMENT, newWorkReason);
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapper.java
@@ -78,16 +78,16 @@ public class PassportAssessmentMapper {
     }
 
     private BenefitType mapBenefitType(PassportedDTO passportedDTO) {
-        if (passportedDTO.getBenefitEmploymentSupport()) {
+        if (Boolean.TRUE.equals(passportedDTO.getBenefitEmploymentSupport())) {
             return BenefitType.ESA;
-        } else if (passportedDTO.getBenefitIncomeSupport()) {
+        } else if (Boolean.TRUE.equals(passportedDTO.getBenefitIncomeSupport())) {
             return BenefitType.INCOME_SUPPORT;
         } else if (passportedDTO.getBenefitJobSeeker() != null
                 && passportedDTO.getBenefitJobSeeker().getIsJobSeeker()) {
             return BenefitType.JSA;
-        } else if (passportedDTO.getBenefitGaurenteedStatePension()) {
+        } else if (Boolean.TRUE.equals(passportedDTO.getBenefitGaurenteedStatePension())) {
             return BenefitType.GSPC;
-        } else if (passportedDTO.getBenefitUniversalCredit()) {
+        } else if (Boolean.TRUE.equals(passportedDTO.getBenefitUniversalCredit())) {
             return BenefitType.UC;
         } else {
             return null;
@@ -97,7 +97,7 @@ public class PassportAssessmentMapper {
     private DeclaredBenefit mapDeclaredBenefit(ApplicationDTO applicationDTO) {
         PassportedDTO passportedDTO = applicationDTO.getPassportedDTO();
         BenefitType benefitType = mapBenefitType(passportedDTO);
-        BenefitRecipient benefitRecipient = applicationDTO.getPassportedDTO().getBenefitClaimedByPartner()
+        BenefitRecipient benefitRecipient = Boolean.TRUE.equals(applicationDTO.getPassportedDTO().getBenefitClaimedByPartner())
                 ? BenefitRecipient.PARTNER
                 : BenefitRecipient.APPLICANT;
 

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapper.java
@@ -97,9 +97,10 @@ public class PassportAssessmentMapper {
     private DeclaredBenefit mapDeclaredBenefit(ApplicationDTO applicationDTO) {
         PassportedDTO passportedDTO = applicationDTO.getPassportedDTO();
         BenefitType benefitType = mapBenefitType(passportedDTO);
-        BenefitRecipient benefitRecipient = Boolean.TRUE.equals(applicationDTO.getPassportedDTO().getBenefitClaimedByPartner())
-                ? BenefitRecipient.PARTNER
-                : BenefitRecipient.APPLICANT;
+        BenefitRecipient benefitRecipient =
+                Boolean.TRUE.equals(applicationDTO.getPassportedDTO().getBenefitClaimedByPartner())
+                        ? BenefitRecipient.PARTNER
+                        : BenefitRecipient.APPLICANT;
 
         return new DeclaredBenefit()
                 .withBenefitType(benefitType)

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapper.java
@@ -1,14 +1,20 @@
 package uk.gov.justice.laa.crime.orchestration.mapper;
 
 import lombok.RequiredArgsConstructor;
+import uk.gov.justice.laa.crime.common.model.passported.ApiCreatePassportedAssessmentRequest;
 import uk.gov.justice.laa.crime.common.model.passported.ApiGetPassportedAssessmentResponse;
 import uk.gov.justice.laa.crime.common.model.passported.DeclaredBenefit;
+import uk.gov.justice.laa.crime.common.model.passported.PassportedAssessment;
+import uk.gov.justice.laa.crime.common.model.passported.PassportedAssessmentMetadata;
+import uk.gov.justice.laa.crime.enums.BenefitRecipient;
 import uk.gov.justice.laa.crime.enums.BenefitType;
 import uk.gov.justice.laa.crime.enums.NewWorkReason;
+import uk.gov.justice.laa.crime.enums.PassportAssessmentDecision;
 import uk.gov.justice.laa.crime.enums.PassportAssessmentDecisionReason;
 import uk.gov.justice.laa.crime.enums.ReviewType;
 import uk.gov.justice.laa.crime.enums.orchestration.Action;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.AssessmentStatusDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.JobSeekerDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.NewWorkReasonDTO;
@@ -32,66 +38,132 @@ public class PassportAssessmentMapper {
 
     private PartnerDTO applicantDTOToPartnerDTO(ApplicantDTO applicant) {
         return PartnerDTO.builder()
-                .firstName(applicant.getFirstName())
-                .surname(applicant.getLastName())
-                .nationaInsuranceNumber(applicant.getNiNumber())
-                .dateOfBirth(DateUtil.asDate(applicant.getDob()))
-                .build();
+            .firstName(applicant.getFirstName())
+            .surname(applicant.getLastName())
+            .nationaInsuranceNumber(applicant.getNiNumber())
+            .dateOfBirth(DateUtil.asDate(applicant.getDob()))
+            .build();
     }
 
     private PassportConfirmationDTO passportAssessmentDecisionReasonToPassportConfirmationDTO(
-            PassportAssessmentDecisionReason decisionReason) {
+        PassportAssessmentDecisionReason decisionReason) {
         return PassportConfirmationDTO.builder()
-                .confirmation(decisionReason.getConfirmation())
-                .description(decisionReason.getDescription())
-                .build();
+            .confirmation(decisionReason.getConfirmation())
+            .description(decisionReason.getDescription())
+            .build();
     }
 
     private NewWorkReasonDTO newWorkReasonToNewWorkReasonDTO(NewWorkReason reason) {
         return NewWorkReasonDTO.builder()
-                .code(reason.getCode())
-                .description(reason.getDescription())
-                .type(reason.getType())
-                .build();
+            .code(reason.getCode())
+            .description(reason.getDescription())
+            .type(reason.getType())
+            .build();
     }
 
     private ReviewTypeDTO reviewTypeToReviewTypeDTO(ReviewType type) {
         return ReviewTypeDTO.builder()
-                .code(type.getCode())
-                .description(type.getDescription())
-                .build();
+            .code(type.getCode())
+            .description(type.getDescription())
+            .build();
     }
 
     private JobSeekerDTO declaredBenefitToJobSeekerDTO(DeclaredBenefit benefit) {
         return JobSeekerDTO.builder()
-                .isJobSeeker(BenefitType.JSA.equals(benefit.getBenefitType()))
-                .lastSignedOn(DateUtil.toDate(benefit.getLastSignOnDate()))
-                .build();
+            .isJobSeeker(BenefitType.JSA.equals(benefit.getBenefitType()))
+            .lastSignedOn(DateUtil.toDate(benefit.getLastSignOnDate()))
+            .build();
+    }
+
+    private BenefitType mapBenefitType(PassportedDTO passportedDTO) {
+        if (passportedDTO.getBenefitEmploymentSupport()) {
+            return BenefitType.ESA;
+        } else if (passportedDTO.getBenefitIncomeSupport()) {
+            return BenefitType.INCOME_SUPPORT;
+        } else if (passportedDTO.getBenefitJobSeeker() != null
+            && passportedDTO.getBenefitJobSeeker().getIsJobSeeker()) {
+            return BenefitType.JSA;
+        } else if (passportedDTO.getBenefitGaurenteedStatePension()) {
+            return BenefitType.GSPC;
+        } else if (passportedDTO.getBenefitUniversalCredit()) {
+            return BenefitType.UC;
+        } else {
+            return null;
+        }
+    }
+
+    private DeclaredBenefit mapDeclaredBenefit(ApplicationDTO applicationDTO) {
+        PassportedDTO passportedDTO = applicationDTO.getPassportedDTO();
+        BenefitType benefitType = mapBenefitType(passportedDTO);
+        BenefitRecipient benefitRecipient =
+            applicationDTO.getPassportedDTO().getBenefitClaimedByPartner()
+                ? BenefitRecipient.PARTNER
+                : BenefitRecipient.APPLICANT;
+
+        return new DeclaredBenefit()
+            .withBenefitType(benefitType)
+            .withLastSignOnDate(BenefitType.JSA.equals(benefitType) ? DateUtil.toLocalDateTime(
+                passportedDTO.getBenefitJobSeeker().getLastSignedOn()) : null)
+            .withBenefitRecipient(benefitRecipient)
+            .withLegacyPartnerId(BenefitRecipient.PARTNER.equals(benefitRecipient)
+                ? applicationDTO.getApplicantLinks().stream()
+                .filter(applicant -> applicant.getUnlinked() == null)
+                .map(applicant -> applicant.getPartnerDTO().getId().intValue()).findFirst()
+                .orElse(null) : null);
+    }
+
+    private PassportedAssessment applicationDTOToPassportedAssessment(
+        ApplicationDTO applicationDTO) {
+        PassportedDTO passportedDTO = applicationDTO.getPassportedDTO();
+
+        return new PassportedAssessment()
+            .withAssessmentDate(DateUtil.toLocalDateTime(passportedDTO.getDate()))
+            .withAssessmentReason(NewWorkReason.getFrom(passportedDTO.getNewWorkReason().getCode()))
+            .withReviewType(ReviewType.getFrom(passportedDTO.getReviewType().getCode()))
+            .withDeclaredUnder18(passportedDTO.getUnder18HeardMagsCourt()
+                || passportedDTO.getUnder18HeardYouthCourt())
+            .withDeclaredBenefit(mapDeclaredBenefit(applicationDTO))
+            .withAssessmentDecision(PassportAssessmentDecision.getFrom(passportedDTO.getResult()))
+            .withDecisionReason(PassportAssessmentDecisionReason.getFrom(passportedDTO.getPassportConfirmationDTO().getConfirmation()))
+            .withNotes(passportedDTO.getNotes());
+    }
+
+    private PassportedAssessmentMetadata workflowRequestToPassportedAssessmentMetadata(
+        WorkflowRequest workflowRequest) {
+        ApplicationDTO applicationDTO = workflowRequest.getApplicationDTO();
+        PassportedDTO passportedDTO = applicationDTO.getPassportedDTO();
+
+        return new PassportedAssessmentMetadata()
+            .withLegacyApplicationId(applicationDTO.getRepId().intValue())
+            .withUsn(passportedDTO.getUsn().intValue())
+            .withCaseManagementUnitId(passportedDTO.getCmuId().intValue())
+            .withUserSession(userMapper.userDtoToUserSession(workflowRequest.getUserDTO()));
     }
 
     public PassportedDTO apiGetPassportedAssessmentResponseToPassportedDTO(
-            ApiGetPassportedAssessmentResponse response, ApplicantDTO applicantDTO) {
+        ApiGetPassportedAssessmentResponse response, ApplicantDTO applicantDTO) {
 
         AssessmentStatusDTO assessmentStatusDTO = AssessmentStatusDTO.builder()
-                .status(AssessmentStatusDTO.COMPLETE)
-                .description(ASSESSMENT_STATUS_DESCRIPTION)
-                .build();
+            .status(AssessmentStatusDTO.COMPLETE)
+            .description(ASSESSMENT_STATUS_DESCRIPTION)
+            .build();
 
         // TODO: Need to populate passportSummaryEvidenceDTO following completion of LCAM-2002
         // TODO: Might need to amend mapping of legacy age related values following completion of LCAM-2016
         // Not setting dwpResult and dwpWhoChecked as these are no longer used in MAAT and so can left as null
         PassportedDTO dto = PassportedDTO.builder()
-                .passportedId(Long.valueOf(response.getLegacyAssessmentId()))
-                .cmuId(Long.valueOf(response.getCaseManagementUnitId()))
-                .date(DateUtil.toDate(response.getAssessmentDate()))
-                .assessementStatusDTO(assessmentStatusDTO)
-                .passportConfirmationDTO(
-                        passportAssessmentDecisionReasonToPassportConfirmationDTO(response.getDecisionReason()))
-                .newWorkReason(newWorkReasonToNewWorkReasonDTO(response.getAssessmentReason()))
-                .notes(response.getNotes())
-                .result(response.getAssessmentDecision().getCode())
-                .under18HeardYouthCourt(response.getDeclaredUnder18())
-                .build();
+            .passportedId(Long.valueOf(response.getLegacyAssessmentId()))
+            .cmuId(Long.valueOf(response.getCaseManagementUnitId()))
+            .date(DateUtil.toDate(response.getAssessmentDate()))
+            .assessementStatusDTO(assessmentStatusDTO)
+            .passportConfirmationDTO(
+                passportAssessmentDecisionReasonToPassportConfirmationDTO(
+                    response.getDecisionReason()))
+            .newWorkReason(newWorkReasonToNewWorkReasonDTO(response.getAssessmentReason()))
+            .notes(response.getNotes())
+            .result(response.getAssessmentDecision().getCode())
+            .under18HeardYouthCourt(response.getDeclaredUnder18())
+            .build();
 
         if (response.getUsn() != null) {
             dto.setUsn(Long.valueOf(response.getUsn()));
@@ -110,7 +182,8 @@ public class PassportAssessmentMapper {
 
             switch (declaredBenefit.getBenefitType()) {
                 case BenefitType.INCOME_SUPPORT -> dto.setBenefitIncomeSupport(true);
-                case BenefitType.JSA -> dto.setBenefitJobSeeker(declaredBenefitToJobSeekerDTO(declaredBenefit));
+                case BenefitType.JSA ->
+                    dto.setBenefitJobSeeker(declaredBenefitToJobSeekerDTO(declaredBenefit));
                 case BenefitType.GSPC -> dto.setBenefitGaurenteedStatePension(true);
                 case BenefitType.ESA -> dto.setBenefitEmploymentSupport(true);
                 case BenefitType.UC -> dto.setBenefitUniversalCredit(true);
@@ -127,6 +200,15 @@ public class PassportAssessmentMapper {
             .getNewWorkReason()
             .getCode());
 
-        return userMapper.getUserActionDTO(workflowRequest, Action.CREATE_PASSPORT_ASSESSMENT, newWorkReason);
+        return userMapper.getUserActionDTO(workflowRequest, Action.CREATE_PASSPORT_ASSESSMENT,
+            newWorkReason);
+    }
+
+    public ApiCreatePassportedAssessmentRequest workflowRequestToApiCreatePassportedAssessmentRequest(
+        WorkflowRequest workflowRequest) {
+        return new ApiCreatePassportedAssessmentRequest()
+            .withPassportedAssessment(applicationDTOToPassportedAssessment(workflowRequest.getApplicationDTO()))
+            .withPassportedAssessmentMetadata(
+                workflowRequestToPassportedAssessmentMetadata(workflowRequest));
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapper.java
@@ -38,41 +38,41 @@ public class PassportAssessmentMapper {
 
     private PartnerDTO applicantDTOToPartnerDTO(ApplicantDTO applicant) {
         return PartnerDTO.builder()
-            .firstName(applicant.getFirstName())
-            .surname(applicant.getLastName())
-            .nationaInsuranceNumber(applicant.getNiNumber())
-            .dateOfBirth(DateUtil.asDate(applicant.getDob()))
-            .build();
+                .firstName(applicant.getFirstName())
+                .surname(applicant.getLastName())
+                .nationaInsuranceNumber(applicant.getNiNumber())
+                .dateOfBirth(DateUtil.asDate(applicant.getDob()))
+                .build();
     }
 
     private PassportConfirmationDTO passportAssessmentDecisionReasonToPassportConfirmationDTO(
-        PassportAssessmentDecisionReason decisionReason) {
+            PassportAssessmentDecisionReason decisionReason) {
         return PassportConfirmationDTO.builder()
-            .confirmation(decisionReason.getConfirmation())
-            .description(decisionReason.getDescription())
-            .build();
+                .confirmation(decisionReason.getConfirmation())
+                .description(decisionReason.getDescription())
+                .build();
     }
 
     private NewWorkReasonDTO newWorkReasonToNewWorkReasonDTO(NewWorkReason reason) {
         return NewWorkReasonDTO.builder()
-            .code(reason.getCode())
-            .description(reason.getDescription())
-            .type(reason.getType())
-            .build();
+                .code(reason.getCode())
+                .description(reason.getDescription())
+                .type(reason.getType())
+                .build();
     }
 
     private ReviewTypeDTO reviewTypeToReviewTypeDTO(ReviewType type) {
         return ReviewTypeDTO.builder()
-            .code(type.getCode())
-            .description(type.getDescription())
-            .build();
+                .code(type.getCode())
+                .description(type.getDescription())
+                .build();
     }
 
     private JobSeekerDTO declaredBenefitToJobSeekerDTO(DeclaredBenefit benefit) {
         return JobSeekerDTO.builder()
-            .isJobSeeker(BenefitType.JSA.equals(benefit.getBenefitType()))
-            .lastSignedOn(DateUtil.toDate(benefit.getLastSignOnDate()))
-            .build();
+                .isJobSeeker(BenefitType.JSA.equals(benefit.getBenefitType()))
+                .lastSignedOn(DateUtil.toDate(benefit.getLastSignOnDate()))
+                .build();
     }
 
     private BenefitType mapBenefitType(PassportedDTO passportedDTO) {
@@ -81,7 +81,7 @@ public class PassportAssessmentMapper {
         } else if (passportedDTO.getBenefitIncomeSupport()) {
             return BenefitType.INCOME_SUPPORT;
         } else if (passportedDTO.getBenefitJobSeeker() != null
-            && passportedDTO.getBenefitJobSeeker().getIsJobSeeker()) {
+                && passportedDTO.getBenefitJobSeeker().getIsJobSeeker()) {
             return BenefitType.JSA;
         } else if (passportedDTO.getBenefitGaurenteedStatePension()) {
             return BenefitType.GSPC;
@@ -95,75 +95,83 @@ public class PassportAssessmentMapper {
     private DeclaredBenefit mapDeclaredBenefit(ApplicationDTO applicationDTO) {
         PassportedDTO passportedDTO = applicationDTO.getPassportedDTO();
         BenefitType benefitType = mapBenefitType(passportedDTO);
-        BenefitRecipient benefitRecipient =
-            applicationDTO.getPassportedDTO().getBenefitClaimedByPartner()
+        BenefitRecipient benefitRecipient = applicationDTO.getPassportedDTO().getBenefitClaimedByPartner()
                 ? BenefitRecipient.PARTNER
                 : BenefitRecipient.APPLICANT;
 
         return new DeclaredBenefit()
-            .withBenefitType(benefitType)
-            .withLastSignOnDate(BenefitType.JSA.equals(benefitType) ? DateUtil.toLocalDateTime(
-                passportedDTO.getBenefitJobSeeker().getLastSignedOn()) : null)
-            .withBenefitRecipient(benefitRecipient)
-            .withLegacyPartnerId(BenefitRecipient.PARTNER.equals(benefitRecipient)
-                ? applicationDTO.getApplicantLinks().stream()
-                .filter(applicant -> applicant.getUnlinked() == null)
-                .map(applicant -> applicant.getPartnerDTO().getId().intValue()).findFirst()
-                .orElse(null) : null);
+                .withBenefitType(benefitType)
+                .withLastSignOnDate(
+                        BenefitType.JSA.equals(benefitType)
+                                ? DateUtil.toLocalDateTime(
+                                        passportedDTO.getBenefitJobSeeker().getLastSignedOn())
+                                : null)
+                .withBenefitRecipient(benefitRecipient)
+                .withLegacyPartnerId(
+                        BenefitRecipient.PARTNER.equals(benefitRecipient)
+                                ? applicationDTO.getApplicantLinks().stream()
+                                        .filter(applicant -> applicant.getUnlinked() == null)
+                                        .map(applicant -> applicant
+                                                .getPartnerDTO()
+                                                .getId()
+                                                .intValue())
+                                        .findFirst()
+                                        .orElse(null)
+                                : null);
     }
 
-    private PassportedAssessment applicationDTOToPassportedAssessment(
-        ApplicationDTO applicationDTO) {
+    private PassportedAssessment applicationDTOToPassportedAssessment(ApplicationDTO applicationDTO) {
         PassportedDTO passportedDTO = applicationDTO.getPassportedDTO();
 
         return new PassportedAssessment()
-            .withAssessmentDate(DateUtil.toLocalDateTime(passportedDTO.getDate()))
-            .withAssessmentReason(NewWorkReason.getFrom(passportedDTO.getNewWorkReason().getCode()))
-            .withReviewType(ReviewType.getFrom(passportedDTO.getReviewType().getCode()))
-            .withDeclaredUnder18(passportedDTO.getUnder18HeardMagsCourt()
-                || passportedDTO.getUnder18HeardYouthCourt())
-            .withDeclaredBenefit(mapDeclaredBenefit(applicationDTO))
-            .withAssessmentDecision(PassportAssessmentDecision.getFrom(passportedDTO.getResult()))
-            .withDecisionReason(PassportAssessmentDecisionReason.getFrom(passportedDTO.getPassportConfirmationDTO().getConfirmation()))
-            .withNotes(passportedDTO.getNotes());
+                .withAssessmentDate(DateUtil.toLocalDateTime(passportedDTO.getDate()))
+                .withAssessmentReason(
+                        NewWorkReason.getFrom(passportedDTO.getNewWorkReason().getCode()))
+                .withReviewType(ReviewType.getFrom(passportedDTO.getReviewType().getCode()))
+                .withDeclaredUnder18(
+                        passportedDTO.getUnder18HeardMagsCourt() || passportedDTO.getUnder18HeardYouthCourt())
+                .withDeclaredBenefit(mapDeclaredBenefit(applicationDTO))
+                .withAssessmentDecision(PassportAssessmentDecision.getFrom(passportedDTO.getResult()))
+                .withDecisionReason(PassportAssessmentDecisionReason.getFrom(
+                        passportedDTO.getPassportConfirmationDTO().getConfirmation()))
+                .withNotes(passportedDTO.getNotes());
     }
 
     private PassportedAssessmentMetadata workflowRequestToPassportedAssessmentMetadata(
-        WorkflowRequest workflowRequest) {
+            WorkflowRequest workflowRequest) {
         ApplicationDTO applicationDTO = workflowRequest.getApplicationDTO();
         PassportedDTO passportedDTO = applicationDTO.getPassportedDTO();
 
         return new PassportedAssessmentMetadata()
-            .withLegacyApplicationId(applicationDTO.getRepId().intValue())
-            .withUsn(passportedDTO.getUsn().intValue())
-            .withCaseManagementUnitId(passportedDTO.getCmuId().intValue())
-            .withUserSession(userMapper.userDtoToUserSession(workflowRequest.getUserDTO()));
+                .withLegacyApplicationId(applicationDTO.getRepId().intValue())
+                .withUsn(passportedDTO.getUsn().intValue())
+                .withCaseManagementUnitId(passportedDTO.getCmuId().intValue())
+                .withUserSession(userMapper.userDtoToUserSession(workflowRequest.getUserDTO()));
     }
 
     public PassportedDTO apiGetPassportedAssessmentResponseToPassportedDTO(
-        ApiGetPassportedAssessmentResponse response, ApplicantDTO applicantDTO) {
+            ApiGetPassportedAssessmentResponse response, ApplicantDTO applicantDTO) {
 
         AssessmentStatusDTO assessmentStatusDTO = AssessmentStatusDTO.builder()
-            .status(AssessmentStatusDTO.COMPLETE)
-            .description(ASSESSMENT_STATUS_DESCRIPTION)
-            .build();
+                .status(AssessmentStatusDTO.COMPLETE)
+                .description(ASSESSMENT_STATUS_DESCRIPTION)
+                .build();
 
         // TODO: Need to populate passportSummaryEvidenceDTO following completion of LCAM-2002
         // TODO: Might need to amend mapping of legacy age related values following completion of LCAM-2016
         // Not setting dwpResult and dwpWhoChecked as these are no longer used in MAAT and so can left as null
         PassportedDTO dto = PassportedDTO.builder()
-            .passportedId(Long.valueOf(response.getLegacyAssessmentId()))
-            .cmuId(Long.valueOf(response.getCaseManagementUnitId()))
-            .date(DateUtil.toDate(response.getAssessmentDate()))
-            .assessementStatusDTO(assessmentStatusDTO)
-            .passportConfirmationDTO(
-                passportAssessmentDecisionReasonToPassportConfirmationDTO(
-                    response.getDecisionReason()))
-            .newWorkReason(newWorkReasonToNewWorkReasonDTO(response.getAssessmentReason()))
-            .notes(response.getNotes())
-            .result(response.getAssessmentDecision().getCode())
-            .under18HeardYouthCourt(response.getDeclaredUnder18())
-            .build();
+                .passportedId(Long.valueOf(response.getLegacyAssessmentId()))
+                .cmuId(Long.valueOf(response.getCaseManagementUnitId()))
+                .date(DateUtil.toDate(response.getAssessmentDate()))
+                .assessementStatusDTO(assessmentStatusDTO)
+                .passportConfirmationDTO(
+                        passportAssessmentDecisionReasonToPassportConfirmationDTO(response.getDecisionReason()))
+                .newWorkReason(newWorkReasonToNewWorkReasonDTO(response.getAssessmentReason()))
+                .notes(response.getNotes())
+                .result(response.getAssessmentDecision().getCode())
+                .under18HeardYouthCourt(response.getDeclaredUnder18())
+                .build();
 
         if (response.getUsn() != null) {
             dto.setUsn(Long.valueOf(response.getUsn()));
@@ -182,8 +190,7 @@ public class PassportAssessmentMapper {
 
             switch (declaredBenefit.getBenefitType()) {
                 case BenefitType.INCOME_SUPPORT -> dto.setBenefitIncomeSupport(true);
-                case BenefitType.JSA ->
-                    dto.setBenefitJobSeeker(declaredBenefitToJobSeekerDTO(declaredBenefit));
+                case BenefitType.JSA -> dto.setBenefitJobSeeker(declaredBenefitToJobSeekerDTO(declaredBenefit));
                 case BenefitType.GSPC -> dto.setBenefitGaurenteedStatePension(true);
                 case BenefitType.ESA -> dto.setBenefitEmploymentSupport(true);
                 case BenefitType.UC -> dto.setBenefitUniversalCredit(true);
@@ -195,20 +202,18 @@ public class PassportAssessmentMapper {
 
     public UserActionDTO getUserActionDTO(WorkflowRequest workflowRequest) {
         NewWorkReason newWorkReason = NewWorkReason.getFrom(workflowRequest
-            .getApplicationDTO()
-            .getPassportedDTO()
-            .getNewWorkReason()
-            .getCode());
+                .getApplicationDTO()
+                .getPassportedDTO()
+                .getNewWorkReason()
+                .getCode());
 
-        return userMapper.getUserActionDTO(workflowRequest, Action.CREATE_PASSPORT_ASSESSMENT,
-            newWorkReason);
+        return userMapper.getUserActionDTO(workflowRequest, Action.CREATE_PASSPORT_ASSESSMENT, newWorkReason);
     }
 
     public ApiCreatePassportedAssessmentRequest workflowRequestToApiCreatePassportedAssessmentRequest(
-        WorkflowRequest workflowRequest) {
+            WorkflowRequest workflowRequest) {
         return new ApiCreatePassportedAssessmentRequest()
-            .withPassportedAssessment(applicationDTOToPassportedAssessment(workflowRequest.getApplicationDTO()))
-            .withPassportedAssessmentMetadata(
-                workflowRequestToPassportedAssessmentMetadata(workflowRequest));
+                .withPassportedAssessment(applicationDTOToPassportedAssessment(workflowRequest.getApplicationDTO()))
+                .withPassportedAssessmentMetadata(workflowRequestToPassportedAssessmentMetadata(workflowRequest));
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapper.java
@@ -94,13 +94,9 @@ public class PassportAssessmentMapper {
         return null;
     }
 
-    private DeclaredBenefit mapDeclaredBenefit(ApplicationDTO applicationDTO) {
+    private DeclaredBenefit mapDeclaredBenefit(ApplicationDTO applicationDTO, Integer partnerId) {
         PassportedDTO passportedDTO = applicationDTO.getPassportedDTO();
         BenefitType benefitType = mapBenefitType(passportedDTO);
-        BenefitRecipient benefitRecipient =
-                Boolean.TRUE.equals(applicationDTO.getPassportedDTO().getBenefitClaimedByPartner())
-                        ? BenefitRecipient.PARTNER
-                        : BenefitRecipient.APPLICANT;
 
         return new DeclaredBenefit()
                 .withBenefitType(benefitType)
@@ -109,21 +105,12 @@ public class PassportAssessmentMapper {
                                 ? DateUtil.toLocalDateTime(
                                         passportedDTO.getBenefitJobSeeker().getLastSignedOn())
                                 : null)
-                .withBenefitRecipient(benefitRecipient)
-                .withLegacyPartnerId(
-                        BenefitRecipient.PARTNER.equals(benefitRecipient)
-                                ? applicationDTO.getApplicantLinks().stream()
-                                        .filter(applicant -> applicant.getUnlinked() == null)
-                                        .map(applicant -> applicant
-                                                .getPartnerDTO()
-                                                .getId()
-                                                .intValue())
-                                        .findFirst()
-                                        .orElse(null)
-                                : null);
+                .withBenefitRecipient(partnerId == null ? BenefitRecipient.APPLICANT : BenefitRecipient.PARTNER)
+                .withLegacyPartnerId(partnerId);
     }
 
-    private PassportedAssessment applicationDTOToPassportedAssessment(ApplicationDTO applicationDTO) {
+    private PassportedAssessment applicationDTOToPassportedAssessment(
+            ApplicationDTO applicationDTO, Integer partnerId) {
         PassportedDTO passportedDTO = applicationDTO.getPassportedDTO();
 
         return new PassportedAssessment()
@@ -133,7 +120,7 @@ public class PassportAssessmentMapper {
                 .withReviewType(ReviewType.getFrom(passportedDTO.getReviewType().getCode()))
                 .withDeclaredUnder18(
                         passportedDTO.getUnder18HeardMagsCourt() || passportedDTO.getUnder18HeardYouthCourt())
-                .withDeclaredBenefit(mapDeclaredBenefit(applicationDTO))
+                .withDeclaredBenefit(mapDeclaredBenefit(applicationDTO, partnerId))
                 .withAssessmentDecision(PassportAssessmentDecision.getFrom(passportedDTO.getResult()))
                 .withDecisionReason(PassportAssessmentDecisionReason.getFrom(
                         passportedDTO.getPassportConfirmationDTO().getConfirmation()))
@@ -219,9 +206,10 @@ public class PassportAssessmentMapper {
     }
 
     public ApiCreatePassportedAssessmentRequest workflowRequestToApiCreatePassportedAssessmentRequest(
-            WorkflowRequest workflowRequest) {
+            WorkflowRequest workflowRequest, Integer partnerId) {
         return new ApiCreatePassportedAssessmentRequest()
-                .withPassportedAssessment(applicationDTOToPassportedAssessment(workflowRequest.getApplicationDTO()))
+                .withPassportedAssessment(
+                        applicationDTOToPassportedAssessment(workflowRequest.getApplicationDTO(), partnerId))
                 .withPassportedAssessmentMetadata(workflowRequestToPassportedAssessmentMetadata(workflowRequest));
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/AssessmentSummaryService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/AssessmentSummaryService.java
@@ -8,6 +8,7 @@ import uk.gov.justice.laa.crime.orchestration.dto.maat.AssessmentSummaryDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.FinancialAssessmentDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.HardshipReviewDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.IOJAppealDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.PassportedDTO;
 import uk.gov.justice.laa.crime.orchestration.enums.AssessmentSummaryType;
 
 import java.util.Collection;
@@ -42,6 +43,17 @@ public class AssessmentSummaryService {
                 .result(iojAppealDTO.getAppealDecisionResult())
                 .assessmentDate(iojAppealDTO.getReceivedDate())
                 .build();
+    }
+
+    public AssessmentSummaryDTO getSummary(PassportedDTO passportedDTO) {
+        return AssessmentSummaryDTO.builder()
+            .id(passportedDTO.getPassportedId().intValue())
+            .assessmentDate(passportedDTO.getDate())
+            .type(AssessmentSummaryType.PASSPORT_ASSESSMENT.getName())
+            .reviewType(passportedDTO.getReviewType().getCode())
+            .status(CurrentStatus.getFrom(passportedDTO.getAssessementStatusDTO().getStatus()).getDescription())
+            .result(passportedDTO.getResult())
+            .build();
     }
 
     public void updateApplication(ApplicationDTO application, AssessmentSummaryDTO summaryDTO) {

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/AssessmentSummaryService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/AssessmentSummaryService.java
@@ -47,13 +47,15 @@ public class AssessmentSummaryService {
 
     public AssessmentSummaryDTO getSummary(PassportedDTO passportedDTO) {
         return AssessmentSummaryDTO.builder()
-            .id(passportedDTO.getPassportedId().intValue())
-            .assessmentDate(passportedDTO.getDate())
-            .type(AssessmentSummaryType.PASSPORT_ASSESSMENT.getName())
-            .reviewType(passportedDTO.getReviewType().getCode())
-            .status(CurrentStatus.getFrom(passportedDTO.getAssessementStatusDTO().getStatus()).getDescription())
-            .result(passportedDTO.getResult())
-            .build();
+                .id(passportedDTO.getPassportedId().intValue())
+                .assessmentDate(passportedDTO.getDate())
+                .type(AssessmentSummaryType.PASSPORTED_ASSESSMENT.getName())
+                .reviewType(passportedDTO.getReviewType().getCode())
+                .status(CurrentStatus.getFrom(
+                                passportedDTO.getAssessementStatusDTO().getStatus())
+                        .getDescription())
+                .result(passportedDTO.getResult())
+                .build();
     }
 
     public void updateApplication(ApplicationDTO application, AssessmentSummaryDTO summaryDTO) {

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/MaatCourtDataService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/MaatCourtDataService.java
@@ -46,7 +46,7 @@ public class MaatCourtDataService {
         return maatCourtDataApiService.getUserSummary(userName);
     }
 
-    public void updateRepOrderDateModified(Integer repId, Map<String, Object> fieldsToUpdate) {
+    public void updateRepOrder(Integer repId, Map<String, Object> fieldsToUpdate) {
         maatCourtDataApiService.patchRepOrder(repId, fieldsToUpdate);
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/PassportAssessmentService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/PassportAssessmentService.java
@@ -7,8 +7,8 @@ import uk.gov.justice.laa.crime.common.model.passported.ApiCreatePassportedAsses
 import uk.gov.justice.laa.crime.common.model.passported.ApiGetPassportedAssessmentResponse;
 import uk.gov.justice.laa.crime.common.model.passported.DeclaredBenefit;
 import uk.gov.justice.laa.crime.enums.BenefitRecipient;
+import uk.gov.justice.laa.crime.orchestration.common.ApplicationUtils;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
-import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.PassportedDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.ApplicantDTO;
 import uk.gov.justice.laa.crime.orchestration.mapper.PassportAssessmentMapper;
@@ -31,14 +31,6 @@ public class PassportAssessmentService {
         return declaredBenefit != null && BenefitRecipient.PARTNER.equals(declaredBenefit.getBenefitRecipient());
     }
 
-    private Integer getPartnerId(ApplicationDTO applicationDTO) {
-        return applicationDTO.getApplicantLinks().stream()
-                .filter(applicant -> applicant.getUnlinked() == null)
-                .map(applicant -> applicant.getPartnerDTO().getId().intValue())
-                .findFirst()
-                .orElse(null);
-    }
-
     public PassportedDTO find(int id) {
         ApiGetPassportedAssessmentResponse assessment = assessmentApiService.findPassportAssessment(id);
 
@@ -56,7 +48,7 @@ public class PassportAssessmentService {
     public Integer create(WorkflowRequest workflowRequest) {
         Integer partnerId = Boolean.TRUE.equals(
                         workflowRequest.getApplicationDTO().getPassportedDTO().getBenefitClaimedByPartner())
-                ? getPartnerId(workflowRequest.getApplicationDTO())
+                ? ApplicationUtils.getPartnerId(workflowRequest.getApplicationDTO())
                 : null;
 
         ApiCreatePassportedAssessmentRequest createPassportRequest =

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/PassportAssessmentService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/PassportAssessmentService.java
@@ -40,10 +40,9 @@ public class PassportAssessmentService {
 
     public String create(WorkflowRequest workflowRequest) {
         ApiCreatePassportedAssessmentRequest casRequest =
-            passportAssessmentMapper.workflowRequestToApiCreatePassportedAssessmentRequest(workflowRequest);
+                passportAssessmentMapper.workflowRequestToApiCreatePassportedAssessmentRequest(workflowRequest);
 
-        ApiCreatePassportedAssessmentResponse casResponse =
-            assessmentApiService.createPassportAssessment(casRequest);
+        ApiCreatePassportedAssessmentResponse casResponse = assessmentApiService.createPassportAssessment(casRequest);
 
         String assessmentId = casResponse.getAssessmentId();
         workflowRequest.getApplicationDTO().getPassportedDTO().setPassportedId(Long.valueOf(assessmentId));

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/PassportAssessmentService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/PassportAssessmentService.java
@@ -39,7 +39,14 @@ public class PassportAssessmentService {
     }
 
     public String create(WorkflowRequest workflowRequest) {
-        ApiCreatePassportedAssessmentRequest casRequest = passportAssessmentMapper.workflowRequestToApiCreatePassportedAssessmentRequest(workflowRequest);
-        ApiCreatePassportedAssessmentResponse response = assessmentApiService.createPassportAssessment(casRequest);
+        ApiCreatePassportedAssessmentRequest casRequest =
+            passportAssessmentMapper.workflowRequestToApiCreatePassportedAssessmentRequest(workflowRequest);
+
+        ApiCreatePassportedAssessmentResponse casResponse =
+            assessmentApiService.createPassportAssessment(casRequest);
+
+        String assessmentId = casResponse.getAssessmentId();
+        workflowRequest.getApplicationDTO().getPassportedDTO().setPassportedId(Long.valueOf(assessmentId));
+        return assessmentId;
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/PassportAssessmentService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/PassportAssessmentService.java
@@ -1,9 +1,12 @@
 package uk.gov.justice.laa.crime.orchestration.service;
 
 import lombok.RequiredArgsConstructor;
+import uk.gov.justice.laa.crime.common.model.passported.ApiCreatePassportedAssessmentRequest;
+import uk.gov.justice.laa.crime.common.model.passported.ApiCreatePassportedAssessmentResponse;
 import uk.gov.justice.laa.crime.common.model.passported.ApiGetPassportedAssessmentResponse;
 import uk.gov.justice.laa.crime.common.model.passported.DeclaredBenefit;
 import uk.gov.justice.laa.crime.enums.BenefitRecipient;
+import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.PassportedDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.ApplicantDTO;
 import uk.gov.justice.laa.crime.orchestration.mapper.PassportAssessmentMapper;
@@ -33,5 +36,10 @@ public class PassportAssessmentService {
                 : null;
 
         return passportAssessmentMapper.apiGetPassportedAssessmentResponseToPassportedDTO(response, applicantDTO);
+    }
+
+    public String create(WorkflowRequest workflowRequest) {
+        ApiCreatePassportedAssessmentRequest casRequest = passportAssessmentMapper.workflowRequestToApiCreatePassportedAssessmentRequest(workflowRequest);
+        ApiCreatePassportedAssessmentResponse response = assessmentApiService.createPassportAssessment(casRequest);
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/PassportAssessmentService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/PassportAssessmentService.java
@@ -38,13 +38,13 @@ public class PassportAssessmentService {
         return passportAssessmentMapper.apiGetPassportedAssessmentResponseToPassportedDTO(response, applicantDTO);
     }
 
-    public String create(WorkflowRequest workflowRequest) {
+    public Integer create(WorkflowRequest workflowRequest) {
         ApiCreatePassportedAssessmentRequest casRequest =
                 passportAssessmentMapper.workflowRequestToApiCreatePassportedAssessmentRequest(workflowRequest);
 
         ApiCreatePassportedAssessmentResponse casResponse = assessmentApiService.createPassportAssessment(casRequest);
 
-        String assessmentId = casResponse.getAssessmentId();
+        Integer assessmentId = casResponse.getLegacyAssessmentId();
         workflowRequest.getApplicationDTO().getPassportedDTO().setPassportedId(Long.valueOf(assessmentId));
         return assessmentId;
     }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/PassportAssessmentService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/PassportAssessmentService.java
@@ -7,7 +7,7 @@ import uk.gov.justice.laa.crime.common.model.passported.ApiCreatePassportedAsses
 import uk.gov.justice.laa.crime.common.model.passported.ApiGetPassportedAssessmentResponse;
 import uk.gov.justice.laa.crime.common.model.passported.DeclaredBenefit;
 import uk.gov.justice.laa.crime.enums.BenefitRecipient;
-import uk.gov.justice.laa.crime.orchestration.common.ApplicationUtils;
+import uk.gov.justice.laa.crime.orchestration.common.ApplicationDTOUtils;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.PassportedDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.ApplicantDTO;
@@ -48,7 +48,7 @@ public class PassportAssessmentService {
     public Integer create(WorkflowRequest workflowRequest) {
         Integer partnerId = Boolean.TRUE.equals(
                         workflowRequest.getApplicationDTO().getPassportedDTO().getBenefitClaimedByPartner())
-                ? ApplicationUtils.getPartnerId(workflowRequest.getApplicationDTO())
+                ? ApplicationDTOUtils.getPartnerId(workflowRequest.getApplicationDTO())
                 : null;
 
         ApiCreatePassportedAssessmentRequest createPassportRequest =

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/PassportAssessmentService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/PassportAssessmentService.java
@@ -45,12 +45,13 @@ public class PassportAssessmentService {
     }
 
     public Integer create(WorkflowRequest workflowRequest) {
-        ApiCreatePassportedAssessmentRequest casRequest =
+        ApiCreatePassportedAssessmentRequest createPassportRequest =
                 passportAssessmentMapper.workflowRequestToApiCreatePassportedAssessmentRequest(workflowRequest);
 
-        ApiCreatePassportedAssessmentResponse casResponse = assessmentApiService.createPassportAssessment(casRequest);
+        ApiCreatePassportedAssessmentResponse createPassportResponse =
+                assessmentApiService.createPassportAssessment(createPassportRequest);
 
-        Integer assessmentId = casResponse.getLegacyAssessmentId();
+        Integer assessmentId = createPassportResponse.getLegacyAssessmentId();
         workflowRequest.getApplicationDTO().getPassportedDTO().setPassportedId(Long.valueOf(assessmentId));
         return assessmentId;
     }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/PassportAssessmentService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/PassportAssessmentService.java
@@ -8,6 +8,7 @@ import uk.gov.justice.laa.crime.common.model.passported.ApiGetPassportedAssessme
 import uk.gov.justice.laa.crime.common.model.passported.DeclaredBenefit;
 import uk.gov.justice.laa.crime.enums.BenefitRecipient;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.PassportedDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.ApplicantDTO;
 import uk.gov.justice.laa.crime.orchestration.mapper.PassportAssessmentMapper;
@@ -30,6 +31,14 @@ public class PassportAssessmentService {
         return declaredBenefit != null && BenefitRecipient.PARTNER.equals(declaredBenefit.getBenefitRecipient());
     }
 
+    private Integer getPartnerId(ApplicationDTO applicationDTO) {
+        return applicationDTO.getApplicantLinks().stream()
+                .filter(applicant -> applicant.getUnlinked() == null)
+                .map(applicant -> applicant.getPartnerDTO().getId().intValue())
+                .findFirst()
+                .orElse(null);
+    }
+
     public PassportedDTO find(int id) {
         ApiGetPassportedAssessmentResponse assessment = assessmentApiService.findPassportAssessment(id);
 
@@ -45,8 +54,14 @@ public class PassportAssessmentService {
     }
 
     public Integer create(WorkflowRequest workflowRequest) {
+        Integer partnerId = Boolean.TRUE.equals(
+                        workflowRequest.getApplicationDTO().getPassportedDTO().getBenefitClaimedByPartner())
+                ? getPartnerId(workflowRequest.getApplicationDTO())
+                : null;
+
         ApiCreatePassportedAssessmentRequest createPassportRequest =
-                passportAssessmentMapper.workflowRequestToApiCreatePassportedAssessmentRequest(workflowRequest);
+                passportAssessmentMapper.workflowRequestToApiCreatePassportedAssessmentRequest(
+                        workflowRequest, partnerId);
 
         ApiCreatePassportedAssessmentResponse createPassportResponse =
                 assessmentApiService.createPassportAssessment(createPassportRequest);

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/RepOrderService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/RepOrderService.java
@@ -1,6 +1,5 @@
 package uk.gov.justice.laa.crime.orchestration.service;
 
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import uk.gov.justice.laa.crime.enums.CaseType;
@@ -35,14 +34,20 @@ public class RepOrderService {
         return getRepOrder(workflowRequest);
     }
 
-    public RepOrderDTO updateRepOrderAssessmentDateCompleted(WorkflowRequest workflowRequest, RepOrderDTO repOrderDTO, LocalDateTime dateCompleted) {
+    public RepOrderDTO updateRepOrderAssessmentDateCompleted(
+            WorkflowRequest workflowRequest, RepOrderDTO repOrderDTO, LocalDateTime dateCompleted) {
         ApplicationDTO applicationDTO = workflowRequest.getApplicationDTO();
         CaseType caseType = CaseType.getFrom(applicationDTO.getCaseDetailsDTO().getCaseType());
-        CurrentStatus fullAssessmentStatus = CurrentStatus.getFrom(applicationDTO.getAssessmentDTO()
-            .getFinancialAssessmentDTO().getFull().getAssessmnentStatusDTO().getStatus());
+        CurrentStatus fullAssessmentStatus = CurrentStatus.getFrom(applicationDTO
+                .getAssessmentDTO()
+                .getFinancialAssessmentDTO()
+                .getFull()
+                .getAssessmnentStatusDTO()
+                .getStatus());
 
         if (!CaseType.EITHER_WAY.equals(caseType)
-            || repOrderDTO.getAssessmentDateCompleted() == null && CurrentStatus.COMPLETE.equals(fullAssessmentStatus)) {
+                || repOrderDTO.getAssessmentDateCompleted() == null
+                        && CurrentStatus.COMPLETE.equals(fullAssessmentStatus)) {
             int repId = applicationDTO.getRepId().intValue();
             Map<String, Object> fieldsToUpdate = Map.of("assessmentDateCompleted", dateCompleted);
 

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/RepOrderService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/RepOrderService.java
@@ -1,8 +1,12 @@
 package uk.gov.justice.laa.crime.orchestration.service;
 
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import uk.gov.justice.laa.crime.enums.CaseType;
+import uk.gov.justice.laa.crime.enums.CurrentStatus;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
 
 import java.time.LocalDateTime;
@@ -14,6 +18,7 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class RepOrderService {
+
     private final MaatCourtDataService maatCourtDataService;
 
     public RepOrderDTO getRepOrder(WorkflowRequest workflowRequest) {
@@ -25,8 +30,26 @@ public class RepOrderService {
         int repId = workflowRequest.getApplicationDTO().getRepId().intValue();
         Map<String, Object> fieldsToUpdate = Map.of("dateModified", dateModified);
 
-        maatCourtDataService.updateRepOrderDateModified(repId, fieldsToUpdate);
+        maatCourtDataService.updateRepOrder(repId, fieldsToUpdate);
 
         return getRepOrder(workflowRequest);
+    }
+
+    public RepOrderDTO updateRepOrderAssessmentDateCompleted(WorkflowRequest workflowRequest, RepOrderDTO repOrderDTO, LocalDateTime dateCompleted) {
+        ApplicationDTO applicationDTO = workflowRequest.getApplicationDTO();
+        CaseType caseType = CaseType.getFrom(applicationDTO.getCaseDetailsDTO().getCaseType());
+        CurrentStatus fullAssessmentStatus = CurrentStatus.getFrom(applicationDTO.getAssessmentDTO()
+            .getFinancialAssessmentDTO().getFull().getAssessmnentStatusDTO().getStatus());
+
+        if (!CaseType.EITHER_WAY.equals(caseType)
+            || repOrderDTO.getAssessmentDateCompleted() == null && CurrentStatus.COMPLETE.equals(fullAssessmentStatus)) {
+            int repId = applicationDTO.getRepId().intValue();
+            Map<String, Object> fieldsToUpdate = Map.of("assessmentDateCompleted", dateCompleted);
+
+            maatCourtDataService.updateRepOrder(repId, fieldsToUpdate);
+            return getRepOrder(workflowRequest);
+        }
+
+        return repOrderDTO;
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/WorkflowPreProcessorService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/WorkflowPreProcessorService.java
@@ -67,7 +67,7 @@ public class WorkflowPreProcessorService {
         }
     }
 
-    public void preProcessPassportRequest(
+    public void validatePassportRequest(
             WorkflowRequest workflowRequest, RepOrderDTO repOrderDTO, UserActionDTO userActionDTO) {
         validationService.validate(workflowRequest, repOrderDTO);
 

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/WorkflowPreProcessorService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/WorkflowPreProcessorService.java
@@ -66,4 +66,13 @@ public class WorkflowPreProcessorService {
             validationService.checkUpliftFieldPermissions(userSummaryDTO);
         }
     }
+
+    public void preProcessPassportRequest(WorkflowRequest workflowRequest, RepOrderDTO repOrderDTO, UserActionDTO userActionDTO) {
+        validationService.validate(workflowRequest, repOrderDTO);
+
+        UserSummaryDTO userSummaryDTO = Optional.ofNullable(userActionDTO.getUsername())
+            .map(maatCourtDataService::getUserSummary)
+            .orElse(null);
+        validationService.isUserActionValid(userActionDTO, userSummaryDTO);
+    }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/WorkflowPreProcessorService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/WorkflowPreProcessorService.java
@@ -67,12 +67,13 @@ public class WorkflowPreProcessorService {
         }
     }
 
-    public void preProcessPassportRequest(WorkflowRequest workflowRequest, RepOrderDTO repOrderDTO, UserActionDTO userActionDTO) {
+    public void preProcessPassportRequest(
+            WorkflowRequest workflowRequest, RepOrderDTO repOrderDTO, UserActionDTO userActionDTO) {
         validationService.validate(workflowRequest, repOrderDTO);
 
         UserSummaryDTO userSummaryDTO = Optional.ofNullable(userActionDTO.getUsername())
-            .map(maatCourtDataService::getUserSummary)
-            .orElse(null);
+                .map(maatCourtDataService::getUserSummary)
+                .orElse(null);
         validationService.isUserActionValid(userActionDTO, userSummaryDTO);
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/api/AssessmentApiService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/api/AssessmentApiService.java
@@ -60,7 +60,8 @@ public class AssessmentApiService {
         return response;
     }
 
-    public ApiCreatePassportedAssessmentResponse createPassportAssessment(ApiCreatePassportedAssessmentRequest request) {
+    public ApiCreatePassportedAssessmentResponse createPassportAssessment(
+            ApiCreatePassportedAssessmentRequest request) {
         log.debug(REQUEST_STRING, request);
         ApiCreatePassportedAssessmentResponse response = assessmentApiClient.createPassportAssessment(request);
         log.debug(RESPONSE_STRING, response);

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/api/AssessmentApiService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/api/AssessmentApiService.java
@@ -6,6 +6,8 @@ import uk.gov.justice.laa.crime.common.model.ioj.ApiCreateIojAppealRequest;
 import uk.gov.justice.laa.crime.common.model.ioj.ApiCreateIojAppealResponse;
 import uk.gov.justice.laa.crime.common.model.ioj.ApiGetIojAppealResponse;
 import uk.gov.justice.laa.crime.common.model.ioj.ApiRollbackIojAppealResponse;
+import uk.gov.justice.laa.crime.common.model.passported.ApiCreatePassportedAssessmentRequest;
+import uk.gov.justice.laa.crime.common.model.passported.ApiCreatePassportedAssessmentResponse;
 import uk.gov.justice.laa.crime.common.model.passported.ApiGetPassportedAssessmentResponse;
 import uk.gov.justice.laa.crime.orchestration.client.CrimeAssessmentApiClient;
 
@@ -55,6 +57,13 @@ public class AssessmentApiService {
 
         log.debug(REQUEST_STRING, response);
 
+        return response;
+    }
+
+    public ApiCreatePassportedAssessmentResponse createPassportAssessment(ApiCreatePassportedAssessmentRequest request) {
+        log.debug(REQUEST_STRING, request);
+        ApiCreatePassportedAssessmentResponse response = assessmentApiClient.createPassportAssessment(request);
+        log.debug(RESPONSE_STRING, response);
         return response;
     }
 

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationService.java
@@ -82,8 +82,8 @@ public class PassportAssessmentOrchestrationService {
                         StoredProcedure.PROCESS_ACTIVITY_AND_GET_CORRESPONDENCE));
             }
 
-            AssessmentSummaryDTO assessmentSummaryDTO = assessmentSummaryService.getSummary(
-                    applicationDTO.getPassportedDTO());
+            AssessmentSummaryDTO assessmentSummaryDTO =
+                    assessmentSummaryService.getSummary(applicationDTO.getPassportedDTO());
             assessmentSummaryService.updateApplication(applicationDTO, assessmentSummaryDTO);
 
             applicationService.updateDateModified(workflowRequest, applicationDTO);

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationService.java
@@ -3,6 +3,10 @@ package uk.gov.justice.laa.crime.orchestration.service.orchestration;
 import io.sentry.Sentry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult;
+import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult.AssessmentType;
+import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult.RequestSource;
+import uk.gov.justice.laa.crime.enums.NewWorkReason;
 import uk.gov.justice.laa.crime.enums.orchestration.StoredProcedure;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
@@ -11,7 +15,10 @@ import uk.gov.justice.laa.crime.orchestration.dto.maat.PassportedDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.validation.UserActionDTO;
 import uk.gov.justice.laa.crime.orchestration.exception.MaatOrchestrationException;
+import uk.gov.justice.laa.crime.orchestration.mapper.ApplicationTrackingMapper;
 import uk.gov.justice.laa.crime.orchestration.mapper.PassportAssessmentMapper;
+import uk.gov.justice.laa.crime.orchestration.service.ApplicationService;
+import uk.gov.justice.laa.crime.orchestration.service.ApplicationTrackingDataService;
 import uk.gov.justice.laa.crime.orchestration.service.AssessmentSummaryService;
 import uk.gov.justice.laa.crime.orchestration.service.ContributionService;
 import uk.gov.justice.laa.crime.orchestration.service.MaatCourtDataService;
@@ -35,6 +42,9 @@ public class PassportAssessmentOrchestrationService {
     private final ContributionService contributionService;
     private final MaatCourtDataService maatCourtDataService;
     private final AssessmentSummaryService assessmentSummaryService;
+    private final ApplicationService applicationService;
+    private final ApplicationTrackingMapper applicationTrackingMapper;
+    private final ApplicationTrackingDataService applicationTrackingDataService;
 
 
     public PassportedDTO find(int id) {
@@ -42,10 +52,11 @@ public class PassportAssessmentOrchestrationService {
     }
 
     public ApplicationDTO create(WorkflowRequest workflowRequest) {
+        ApplicationDTO applicationDTO = workflowRequest.getApplicationDTO();
         RepOrderDTO repOrderDTO = repOrderService.getRepOrder(workflowRequest);
         if (repOrderDTO == null) {
             log.error("Could not find rep order for request {}", workflowRequest);
-            throw new MaatOrchestrationException(workflowRequest.getApplicationDTO());
+            throw new MaatOrchestrationException(applicationDTO);
         }
         UserActionDTO userActionDTO = passportAssessmentMapper.getUserActionDTO(workflowRequest);
 
@@ -54,36 +65,40 @@ public class PassportAssessmentOrchestrationService {
         String assessmentId = passportAssessmentService.create(workflowRequest);
 
         try {
-            // TODO: Check what is being done about manage passport evidence, no ticket on backlog and evidence endpoint geared towards income???
-
+            workflowRequest.setApplicationDTO(maatCourtDataService.invokeStoredProcedure(
+                applicationDTO, workflowRequest.getUserDTO(),
+                StoredProcedure.MANAGE_PASSPORT_EVIDENCE));
             proceedingsService.determineMagsRepDecision(workflowRequest);
-
-            // TODO: Check crown repord called in stored procedure, should use CCP process rep order which looks very similar or CCP update application???
-
-            contributionService.calculate(workflowRequest);
-
+            workflowRequest.setApplicationDTO(contributionService.calculate(workflowRequest));
             proceedingsService.updateApplication(workflowRequest, repOrderDTO);
 
-            // TODO: Do we need to do this only if work reason isn't FMA as it is in the stored procedure???
-            workflowRequest.setApplicationDTO(maatCourtDataService.invokeStoredProcedure(
-                workflowRequest.getApplicationDTO(),
-                workflowRequest.getUserDTO(),
-                StoredProcedure.PROCESS_ACTIVITY_AND_GET_CORRESPONDENCE));
+            if (!NewWorkReason.FMA.equals(NewWorkReason.getFrom(applicationDTO.getPassportedDTO().getNewWorkReason().getCode()))) {
+                workflowRequest.setApplicationDTO(maatCourtDataService.invokeStoredProcedure(
+                    applicationDTO, workflowRequest.getUserDTO(),
+                    StoredProcedure.PROCESS_ACTIVITY_AND_GET_CORRESPONDENCE));
+            }
 
             AssessmentSummaryDTO assessmentSummaryDTO = assessmentSummaryService.getSummary(
-                workflowRequest.getApplicationDTO().getAssessmentDTO().getIojAppeal());
-            assessmentSummaryService.updateApplication(workflowRequest.getApplicationDTO(), assessmentSummaryDTO);
+                applicationDTO.getAssessmentDTO().getIojAppeal());
+            assessmentSummaryService.updateApplication(applicationDTO, assessmentSummaryDTO);
 
-            // TODO: Do we need to update date modified (app date completed in SP) and call ATS here similar to the IOJ flow???
+            // TODO: Need to update the ass date completed by calling patch rep order endpoint (use fin ass data from appDTO)
+            applicationService.updateDateModified(workflowRequest, applicationDTO);
+
+            ApplicationTrackingOutputResult applicationTrackingOutputResult = applicationTrackingMapper.build(
+                workflowRequest, repOrderDTO, AssessmentType.PASSPORT, RequestSource.PASSPORT_IOJ);
+            if (null != applicationTrackingOutputResult.getUsn()) {
+                applicationTrackingDataService.sendTrackingOutputResult(applicationTrackingOutputResult);
+            }
         } catch (Exception exception) {
             log.error("Create passport assessment post processing failed, rolling back...", exception);
             Sentry.captureException(exception);
 
             // TODO: Need to call rollback passport assessment and handle failure when ticket LCAM-1987 and follow on has been completed.
 
-            throw new MaatOrchestrationException(workflowRequest.getApplicationDTO());
+            throw new MaatOrchestrationException(applicationDTO);
         }
 
-        return workflowRequest.getApplicationDTO();
+        return applicationDTO;
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationService.java
@@ -1,14 +1,20 @@
 package uk.gov.justice.laa.crime.orchestration.service.orchestration;
 
+import io.sentry.Sentry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import uk.gov.justice.laa.crime.enums.orchestration.StoredProcedure;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.AssessmentSummaryDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.PassportedDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.validation.UserActionDTO;
 import uk.gov.justice.laa.crime.orchestration.exception.MaatOrchestrationException;
 import uk.gov.justice.laa.crime.orchestration.mapper.PassportAssessmentMapper;
+import uk.gov.justice.laa.crime.orchestration.service.AssessmentSummaryService;
+import uk.gov.justice.laa.crime.orchestration.service.ContributionService;
+import uk.gov.justice.laa.crime.orchestration.service.MaatCourtDataService;
 import uk.gov.justice.laa.crime.orchestration.service.PassportAssessmentService;
 
 import org.springframework.stereotype.Service;
@@ -21,11 +27,15 @@ import uk.gov.justice.laa.crime.orchestration.service.WorkflowPreProcessorServic
 @RequiredArgsConstructor
 public class PassportAssessmentOrchestrationService {
 
-    private final PassportAssessmentService passportAssessmentService;
-    private final PassportAssessmentMapper passportAssessmentMapper;
     private final RepOrderService repOrderService;
-    private final ProceedingsService proceedingsService;
+    private final PassportAssessmentMapper passportAssessmentMapper;
     private final WorkflowPreProcessorService workflowPreProcessorService;
+    private final PassportAssessmentService passportAssessmentService;
+    private final ProceedingsService proceedingsService;
+    private final ContributionService contributionService;
+    private final MaatCourtDataService maatCourtDataService;
+    private final AssessmentSummaryService assessmentSummaryService;
+
 
     public PassportedDTO find(int id) {
         return passportAssessmentService.find(id);
@@ -41,17 +51,39 @@ public class PassportAssessmentOrchestrationService {
 
         workflowPreProcessorService.preProcessPassportRequest(workflowRequest, repOrderDTO, userActionDTO);
 
-        passportAssessmentService.create(workflowRequest);
+        String assessmentId = passportAssessmentService.create(workflowRequest);
 
-        // IF APP STATUS COMPLETE BUT WE CAN SAFELY ASSUME ALWAYS SUCH I BELIEVE
-        // manage passport evidence - this doable??? no tickets for it and current create evidence seems geared for income evidence
-        // check income evidence available - this is done in MAAT using PP flag for means assessment, do the same for passported???
-        // determine mags rep decision
-        proceedingsService.determineMagsRepDecision(workflowRequest);
-        // check crown court actions - check crown repord - cap eq check - calc contribs - cc avail
-        // update cc application
-        // matrix process activity
-        // get application correspondence
-        // get assessments summary
+        try {
+            // TODO: Check what is being done about manage passport evidence, no ticket on backlog and evidence endpoint geared towards income???
+
+            proceedingsService.determineMagsRepDecision(workflowRequest);
+
+            // TODO: Check crown repord called in stored procedure, should use CCP process rep order which looks very similar or CCP update application???
+
+            contributionService.calculate(workflowRequest);
+
+            proceedingsService.updateApplication(workflowRequest, repOrderDTO);
+
+            // TODO: Do we need to do this only if work reason isn't FMA as it is in the stored procedure???
+            workflowRequest.setApplicationDTO(maatCourtDataService.invokeStoredProcedure(
+                workflowRequest.getApplicationDTO(),
+                workflowRequest.getUserDTO(),
+                StoredProcedure.PROCESS_ACTIVITY_AND_GET_CORRESPONDENCE));
+
+            AssessmentSummaryDTO assessmentSummaryDTO = assessmentSummaryService.getSummary(
+                workflowRequest.getApplicationDTO().getAssessmentDTO().getIojAppeal());
+            assessmentSummaryService.updateApplication(workflowRequest.getApplicationDTO(), assessmentSummaryDTO);
+
+            // TODO: Do we need to update date modified (app date completed in SP) and call ATS here similar to the IOJ flow???
+        } catch (Exception exception) {
+            log.error("Create passport assessment post processing failed, rolling back...", exception);
+            Sentry.captureException(exception);
+
+            // TODO: Need to call rollback passport assessment and handle failure when ticket LCAM-1987 and follow on has been completed.
+
+            throw new MaatOrchestrationException(workflowRequest.getApplicationDTO());
+        }
+
+        return workflowRequest.getApplicationDTO();
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationService.java
@@ -1,11 +1,15 @@
 package uk.gov.justice.laa.crime.orchestration.service.orchestration;
 
 import io.sentry.Sentry;
+import java.time.LocalDateTime;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult;
 import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult.AssessmentType;
 import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult.RequestSource;
+import uk.gov.justice.laa.crime.enums.CaseType;
+import uk.gov.justice.laa.crime.enums.CurrentStatus;
 import uk.gov.justice.laa.crime.enums.NewWorkReason;
 import uk.gov.justice.laa.crime.enums.orchestration.StoredProcedure;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
@@ -63,6 +67,7 @@ public class PassportAssessmentOrchestrationService {
         workflowPreProcessorService.preProcessPassportRequest(workflowRequest, repOrderDTO, userActionDTO);
 
         String assessmentId = passportAssessmentService.create(workflowRequest);
+        repOrderDTO = repOrderService.updateRepOrderAssessmentDateCompleted(workflowRequest, repOrderDTO, LocalDateTime.now());
 
         try {
             workflowRequest.setApplicationDTO(maatCourtDataService.invokeStoredProcedure(
@@ -82,7 +87,6 @@ public class PassportAssessmentOrchestrationService {
                 applicationDTO.getAssessmentDTO().getIojAppeal());
             assessmentSummaryService.updateApplication(applicationDTO, assessmentSummaryDTO);
 
-            // TODO: Need to update the ass date completed by calling patch rep order endpoint (use fin ass data from appDTO)
             applicationService.updateDateModified(workflowRequest, applicationDTO);
 
             ApplicationTrackingOutputResult applicationTrackingOutputResult = applicationTrackingMapper.build(

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationService.java
@@ -38,5 +38,7 @@ public class PassportAssessmentOrchestrationService {
         UserActionDTO userActionDTO = passportAssessmentMapper.getUserActionDTO(workflowRequest);
 
         workflowPreProcessorService.preProcessPassportRequest(workflowRequest, repOrderDTO, userActionDTO);
+
+        passportAssessmentService.create(workflowRequest);
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationService.java
@@ -83,7 +83,7 @@ public class PassportAssessmentOrchestrationService {
             }
 
             AssessmentSummaryDTO assessmentSummaryDTO = assessmentSummaryService.getSummary(
-                    applicationDTO.getAssessmentDTO().getIojAppeal());
+                    applicationDTO.getPassportedDTO());
             assessmentSummaryService.updateApplication(applicationDTO, assessmentSummaryDTO);
 
             applicationService.updateDateModified(workflowRequest, applicationDTO);

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationService.java
@@ -1,18 +1,42 @@
 package uk.gov.justice.laa.crime.orchestration.service.orchestration;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.PassportedDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.validation.UserActionDTO;
+import uk.gov.justice.laa.crime.orchestration.exception.MaatOrchestrationException;
+import uk.gov.justice.laa.crime.orchestration.mapper.PassportAssessmentMapper;
 import uk.gov.justice.laa.crime.orchestration.service.PassportAssessmentService;
 
 import org.springframework.stereotype.Service;
+import uk.gov.justice.laa.crime.orchestration.service.RepOrderService;
+import uk.gov.justice.laa.crime.orchestration.service.WorkflowPreProcessorService;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PassportAssessmentOrchestrationService {
 
     private final PassportAssessmentService passportAssessmentService;
+    private final PassportAssessmentMapper passportAssessmentMapper;
+    private final RepOrderService repOrderService;
+    private final WorkflowPreProcessorService workflowPreProcessorService;
 
     public PassportedDTO find(int id) {
         return passportAssessmentService.find(id);
+    }
+
+    public ApplicationDTO create(WorkflowRequest workflowRequest) {
+        RepOrderDTO repOrderDTO = repOrderService.getRepOrder(workflowRequest);
+        if (repOrderDTO == null) {
+            log.error("Could not find rep order for request {}", workflowRequest);
+            throw new MaatOrchestrationException(workflowRequest.getApplicationDTO());
+        }
+        UserActionDTO userActionDTO = passportAssessmentMapper.getUserActionDTO(workflowRequest);
+
+        workflowPreProcessorService.preProcessPassportRequest(workflowRequest, repOrderDTO, userActionDTO);
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationService.java
@@ -61,7 +61,7 @@ public class PassportAssessmentOrchestrationService {
         }
         UserActionDTO userActionDTO = passportAssessmentMapper.getUserActionDTO(workflowRequest);
 
-        workflowPreProcessorService.preProcessPassportRequest(workflowRequest, repOrderDTO, userActionDTO);
+        workflowPreProcessorService.validatePassportRequest(workflowRequest, repOrderDTO, userActionDTO);
 
         Integer assessmentId = passportAssessmentService.create(workflowRequest);
         repOrderDTO = repOrderService.updateRepOrderAssessmentDateCompleted(

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationService.java
@@ -1,15 +1,11 @@
 package uk.gov.justice.laa.crime.orchestration.service.orchestration;
 
 import io.sentry.Sentry;
-import java.time.LocalDateTime;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult;
 import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult.AssessmentType;
 import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult.RequestSource;
-import uk.gov.justice.laa.crime.enums.CaseType;
-import uk.gov.justice.laa.crime.enums.CurrentStatus;
 import uk.gov.justice.laa.crime.enums.NewWorkReason;
 import uk.gov.justice.laa.crime.enums.orchestration.StoredProcedure;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
@@ -27,11 +23,13 @@ import uk.gov.justice.laa.crime.orchestration.service.AssessmentSummaryService;
 import uk.gov.justice.laa.crime.orchestration.service.ContributionService;
 import uk.gov.justice.laa.crime.orchestration.service.MaatCourtDataService;
 import uk.gov.justice.laa.crime.orchestration.service.PassportAssessmentService;
-
-import org.springframework.stereotype.Service;
 import uk.gov.justice.laa.crime.orchestration.service.ProceedingsService;
 import uk.gov.justice.laa.crime.orchestration.service.RepOrderService;
 import uk.gov.justice.laa.crime.orchestration.service.WorkflowPreProcessorService;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
@@ -50,7 +48,6 @@ public class PassportAssessmentOrchestrationService {
     private final ApplicationTrackingMapper applicationTrackingMapper;
     private final ApplicationTrackingDataService applicationTrackingDataService;
 
-
     public PassportedDTO find(int id) {
         return passportAssessmentService.find(id);
     }
@@ -67,30 +64,32 @@ public class PassportAssessmentOrchestrationService {
         workflowPreProcessorService.preProcessPassportRequest(workflowRequest, repOrderDTO, userActionDTO);
 
         String assessmentId = passportAssessmentService.create(workflowRequest);
-        repOrderDTO = repOrderService.updateRepOrderAssessmentDateCompleted(workflowRequest, repOrderDTO, LocalDateTime.now());
+        repOrderDTO = repOrderService.updateRepOrderAssessmentDateCompleted(
+                workflowRequest, repOrderDTO, LocalDateTime.now());
 
         try {
             workflowRequest.setApplicationDTO(maatCourtDataService.invokeStoredProcedure(
-                applicationDTO, workflowRequest.getUserDTO(),
-                StoredProcedure.MANAGE_PASSPORT_EVIDENCE));
+                    applicationDTO, workflowRequest.getUserDTO(), StoredProcedure.MANAGE_PASSPORT_EVIDENCE));
             proceedingsService.determineMagsRepDecision(workflowRequest);
             workflowRequest.setApplicationDTO(contributionService.calculate(workflowRequest));
             proceedingsService.updateApplication(workflowRequest, repOrderDTO);
 
-            if (!NewWorkReason.FMA.equals(NewWorkReason.getFrom(applicationDTO.getPassportedDTO().getNewWorkReason().getCode()))) {
+            if (!NewWorkReason.FMA.equals(NewWorkReason.getFrom(
+                    applicationDTO.getPassportedDTO().getNewWorkReason().getCode()))) {
                 workflowRequest.setApplicationDTO(maatCourtDataService.invokeStoredProcedure(
-                    applicationDTO, workflowRequest.getUserDTO(),
-                    StoredProcedure.PROCESS_ACTIVITY_AND_GET_CORRESPONDENCE));
+                        applicationDTO,
+                        workflowRequest.getUserDTO(),
+                        StoredProcedure.PROCESS_ACTIVITY_AND_GET_CORRESPONDENCE));
             }
 
             AssessmentSummaryDTO assessmentSummaryDTO = assessmentSummaryService.getSummary(
-                applicationDTO.getAssessmentDTO().getIojAppeal());
+                    applicationDTO.getAssessmentDTO().getIojAppeal());
             assessmentSummaryService.updateApplication(applicationDTO, assessmentSummaryDTO);
 
             applicationService.updateDateModified(workflowRequest, applicationDTO);
 
             ApplicationTrackingOutputResult applicationTrackingOutputResult = applicationTrackingMapper.build(
-                workflowRequest, repOrderDTO, AssessmentType.PASSPORT, RequestSource.PASSPORT_IOJ);
+                    workflowRequest, repOrderDTO, AssessmentType.PASSPORT, RequestSource.PASSPORT_IOJ);
             if (null != applicationTrackingOutputResult.getUsn()) {
                 applicationTrackingDataService.sendTrackingOutputResult(applicationTrackingOutputResult);
             }
@@ -98,7 +97,8 @@ public class PassportAssessmentOrchestrationService {
             log.error("Create passport assessment post processing failed, rolling back...", exception);
             Sentry.captureException(exception);
 
-            // TODO: Need to call rollback passport assessment and handle failure when ticket LCAM-1987 and follow on has been completed.
+            // TODO: Need to call rollback passport assessment and handle failure when ticket LCAM-1987 and follow on
+            // has been completed.
 
             throw new MaatOrchestrationException(applicationDTO);
         }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationService.java
@@ -48,57 +48,81 @@ public class PassportAssessmentOrchestrationService {
     private final ApplicationTrackingMapper applicationTrackingMapper;
     private final ApplicationTrackingDataService applicationTrackingDataService;
 
+    private RepOrderDTO getLatestRepOrder(WorkflowRequest workflowRequest) {
+        RepOrderDTO repOrderDTO = repOrderService.getRepOrder(workflowRequest);
+
+        if (repOrderDTO == null) {
+            log.error("Could not find rep order for request {}", workflowRequest);
+            throw new MaatOrchestrationException(workflowRequest.getApplicationDTO());
+        }
+
+        return repOrderDTO;
+    }
+
+    private void validatePassportRequest(WorkflowRequest workflowRequest, RepOrderDTO repOrderDTO) {
+        UserActionDTO userActionDTO = passportAssessmentMapper.getUserActionDTO(workflowRequest);
+
+        workflowPreProcessorService.validatePassportRequest(workflowRequest, repOrderDTO, userActionDTO);
+    }
+
+    private void updateAssessmentSummary(ApplicationDTO applicationDTO) {
+        AssessmentSummaryDTO assessmentSummaryDTO =
+                assessmentSummaryService.getSummary(applicationDTO.getPassportedDTO());
+
+        assessmentSummaryService.updateApplication(applicationDTO, assessmentSummaryDTO);
+    }
+
+    private void updateApplicationTracking(WorkflowRequest workflowRequest, RepOrderDTO repOrderDTO) {
+        ApplicationTrackingOutputResult applicationTrackingOutputResult = applicationTrackingMapper.build(
+                workflowRequest, repOrderDTO, AssessmentType.PASSPORT, RequestSource.PASSPORT_IOJ);
+
+        if (null != applicationTrackingOutputResult.getUsn()) {
+            applicationTrackingDataService.sendTrackingOutputResult(applicationTrackingOutputResult);
+        }
+    }
+
+    private void performPostProcessing(
+            WorkflowRequest workflowRequest, ApplicationDTO applicationDTO, RepOrderDTO repOrderDTO) {
+        workflowRequest.setApplicationDTO(maatCourtDataService.invokeStoredProcedure(
+                applicationDTO, workflowRequest.getUserDTO(), StoredProcedure.MANAGE_PASSPORT_EVIDENCE));
+        proceedingsService.determineMagsRepDecision(workflowRequest);
+        workflowRequest.setApplicationDTO(contributionService.calculate(workflowRequest));
+        proceedingsService.updateApplication(workflowRequest, repOrderDTO);
+
+        if (!NewWorkReason.FMA.equals(NewWorkReason.getFrom(
+                applicationDTO.getPassportedDTO().getNewWorkReason().getCode()))) {
+            workflowRequest.setApplicationDTO(maatCourtDataService.invokeStoredProcedure(
+                    applicationDTO,
+                    workflowRequest.getUserDTO(),
+                    StoredProcedure.PROCESS_ACTIVITY_AND_GET_CORRESPONDENCE));
+        }
+
+        updateAssessmentSummary(applicationDTO);
+        applicationService.updateDateModified(workflowRequest, applicationDTO);
+        updateApplicationTracking(workflowRequest, repOrderDTO);
+    }
+
     public PassportedDTO find(int id) {
         return passportAssessmentService.find(id);
     }
 
     public ApplicationDTO create(WorkflowRequest workflowRequest) {
         ApplicationDTO applicationDTO = workflowRequest.getApplicationDTO();
-        RepOrderDTO repOrderDTO = repOrderService.getRepOrder(workflowRequest);
-        if (repOrderDTO == null) {
-            log.error("Could not find rep order for request {}", workflowRequest);
-            throw new MaatOrchestrationException(applicationDTO);
-        }
-        UserActionDTO userActionDTO = passportAssessmentMapper.getUserActionDTO(workflowRequest);
+        RepOrderDTO repOrderDTO = getLatestRepOrder(workflowRequest);
 
-        workflowPreProcessorService.validatePassportRequest(workflowRequest, repOrderDTO, userActionDTO);
+        validatePassportRequest(workflowRequest, repOrderDTO);
 
         Integer assessmentId = passportAssessmentService.create(workflowRequest);
         repOrderDTO = repOrderService.updateRepOrderAssessmentDateCompleted(
                 workflowRequest, repOrderDTO, LocalDateTime.now());
 
         try {
-            workflowRequest.setApplicationDTO(maatCourtDataService.invokeStoredProcedure(
-                    applicationDTO, workflowRequest.getUserDTO(), StoredProcedure.MANAGE_PASSPORT_EVIDENCE));
-            proceedingsService.determineMagsRepDecision(workflowRequest);
-            workflowRequest.setApplicationDTO(contributionService.calculate(workflowRequest));
-            proceedingsService.updateApplication(workflowRequest, repOrderDTO);
-
-            if (!NewWorkReason.FMA.equals(NewWorkReason.getFrom(
-                    applicationDTO.getPassportedDTO().getNewWorkReason().getCode()))) {
-                workflowRequest.setApplicationDTO(maatCourtDataService.invokeStoredProcedure(
-                        applicationDTO,
-                        workflowRequest.getUserDTO(),
-                        StoredProcedure.PROCESS_ACTIVITY_AND_GET_CORRESPONDENCE));
-            }
-
-            AssessmentSummaryDTO assessmentSummaryDTO =
-                    assessmentSummaryService.getSummary(applicationDTO.getPassportedDTO());
-            assessmentSummaryService.updateApplication(applicationDTO, assessmentSummaryDTO);
-
-            applicationService.updateDateModified(workflowRequest, applicationDTO);
-
-            ApplicationTrackingOutputResult applicationTrackingOutputResult = applicationTrackingMapper.build(
-                    workflowRequest, repOrderDTO, AssessmentType.PASSPORT, RequestSource.PASSPORT_IOJ);
-            if (null != applicationTrackingOutputResult.getUsn()) {
-                applicationTrackingDataService.sendTrackingOutputResult(applicationTrackingOutputResult);
-            }
+            performPostProcessing(workflowRequest, applicationDTO, repOrderDTO);
         } catch (Exception exception) {
             log.error("Create passport assessment post processing failed, rolling back...", exception);
             Sentry.captureException(exception);
 
-            // TODO: Need to call rollback passport assessment and handle failure when ticket LCAM-1987 and follow on
-            // has been completed.
+            // TODO: Need to call rollback passport assessment and handle failure when ticket LCAM-1987 completed
 
             throw new MaatOrchestrationException(applicationDTO);
         }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationService.java
@@ -12,6 +12,7 @@ import uk.gov.justice.laa.crime.orchestration.mapper.PassportAssessmentMapper;
 import uk.gov.justice.laa.crime.orchestration.service.PassportAssessmentService;
 
 import org.springframework.stereotype.Service;
+import uk.gov.justice.laa.crime.orchestration.service.ProceedingsService;
 import uk.gov.justice.laa.crime.orchestration.service.RepOrderService;
 import uk.gov.justice.laa.crime.orchestration.service.WorkflowPreProcessorService;
 
@@ -23,6 +24,7 @@ public class PassportAssessmentOrchestrationService {
     private final PassportAssessmentService passportAssessmentService;
     private final PassportAssessmentMapper passportAssessmentMapper;
     private final RepOrderService repOrderService;
+    private final ProceedingsService proceedingsService;
     private final WorkflowPreProcessorService workflowPreProcessorService;
 
     public PassportedDTO find(int id) {
@@ -40,5 +42,16 @@ public class PassportAssessmentOrchestrationService {
         workflowPreProcessorService.preProcessPassportRequest(workflowRequest, repOrderDTO, userActionDTO);
 
         passportAssessmentService.create(workflowRequest);
+
+        // IF APP STATUS COMPLETE BUT WE CAN SAFELY ASSUME ALWAYS SUCH I BELIEVE
+        // manage passport evidence - this doable??? no tickets for it and current create evidence seems geared for income evidence
+        // check income evidence available - this is done in MAAT using PP flag for means assessment, do the same for passported???
+        // determine mags rep decision
+        proceedingsService.determineMagsRepDecision(workflowRequest);
+        // check crown court actions - check crown repord - cap eq check - calc contribs - cc avail
+        // update cc application
+        // matrix process activity
+        // get application correspondence
+        // get assessments summary
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationService.java
@@ -63,7 +63,7 @@ public class PassportAssessmentOrchestrationService {
 
         workflowPreProcessorService.preProcessPassportRequest(workflowRequest, repOrderDTO, userActionDTO);
 
-        String assessmentId = passportAssessmentService.create(workflowRequest);
+        Integer assessmentId = passportAssessmentService.create(workflowRequest);
         repOrderDTO = repOrderService.updateRepOrderAssessmentDateCompleted(
                 workflowRequest, repOrderDTO, LocalDateTime.now());
 

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/commmon/ApplicationDTOUtilsTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/commmon/ApplicationDTOUtilsTest.java
@@ -3,20 +3,20 @@ package uk.gov.justice.laa.crime.orchestration.commmon;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import uk.gov.justice.laa.crime.enums.CourtType;
-import uk.gov.justice.laa.crime.orchestration.common.ApplicationUtils;
+import uk.gov.justice.laa.crime.orchestration.common.ApplicationDTOUtils;
 import uk.gov.justice.laa.crime.orchestration.data.Constants;
 import uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
 
 import org.junit.jupiter.api.Test;
 
-class ApplicationUtilsTest {
+class ApplicationDTOUtilsTest {
 
     @Test
     void givenApplicationWithPartner_whenGetPartnerIdIsInvoked_thenPartnerIdReturned() {
         WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
 
-        Integer partnerId = ApplicationUtils.getPartnerId(workflowRequest.getApplicationDTO());
+        Integer partnerId = ApplicationDTOUtils.getPartnerId(workflowRequest.getApplicationDTO());
 
         assertThat(partnerId).isEqualTo(Constants.PARTNER_ID);
     }
@@ -25,7 +25,7 @@ class ApplicationUtilsTest {
     void givenApplicationWithoutPartner_whenGetPartnerIdIsInvoked_thenNullIsReturned() {
         WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest(CourtType.CROWN_COURT);
 
-        Integer partnerId = ApplicationUtils.getPartnerId(workflowRequest.getApplicationDTO());
+        Integer partnerId = ApplicationDTOUtils.getPartnerId(workflowRequest.getApplicationDTO());
 
         assertThat(partnerId).isNull();
     }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/commmon/ApplicationUtilsTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/commmon/ApplicationUtilsTest.java
@@ -1,0 +1,32 @@
+package uk.gov.justice.laa.crime.orchestration.commmon;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import uk.gov.justice.laa.crime.enums.CourtType;
+import uk.gov.justice.laa.crime.orchestration.common.ApplicationUtils;
+import uk.gov.justice.laa.crime.orchestration.data.Constants;
+import uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder;
+import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
+
+import org.junit.jupiter.api.Test;
+
+class ApplicationUtilsTest {
+
+    @Test
+    void givenApplicationWithPartner_whenGetPartnerIdIsInvoked_thenPartnerIdReturned() {
+        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
+
+        Integer partnerId = ApplicationUtils.getPartnerId(workflowRequest.getApplicationDTO());
+
+        assertThat(partnerId).isEqualTo(Constants.PARTNER_ID);
+    }
+
+    @Test
+    void givenApplicationWithoutPartner_whenGetPartnerIdIsInvoked_thenNullIsReturned() {
+        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest(CourtType.CROWN_COURT);
+
+        Integer partnerId = ApplicationUtils.getPartnerId(workflowRequest.getApplicationDTO());
+
+        assertThat(partnerId).isNull();
+    }
+}

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/controller/PassportAssessmentControllerTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/controller/PassportAssessmentControllerTest.java
@@ -1,13 +1,18 @@
 package uk.gov.justice.laa.crime.orchestration.controller;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.justice.laa.crime.util.RequestBuilderUtils.buildRequestWithTransactionId;
+import static uk.gov.justice.laa.crime.util.RequestBuilderUtils.buildRequestWithTransactionIdGivenContent;
 
 import uk.gov.justice.laa.crime.orchestration.config.OrchestrationTestConfiguration;
 import uk.gov.justice.laa.crime.orchestration.data.Constants;
 import uk.gov.justice.laa.crime.orchestration.data.builder.PassportAssessmentDataBuilder;
+import uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder;
+import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.PassportedDTO;
 import uk.gov.justice.laa.crime.orchestration.service.orchestration.PassportAssessmentOrchestrationService;
 import uk.gov.justice.laa.crime.orchestration.tracing.TraceIdHandler;
@@ -22,6 +27,8 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 @WebMvcTest(PassportAssessmentController.class)
 @Import(OrchestrationTestConfiguration.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -31,6 +38,9 @@ class PassportAssessmentControllerTest {
 
     @Autowired
     private MockMvc mvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @MockitoBean
     private PassportAssessmentOrchestrationService passportAssessmentOrchestrationService;
@@ -46,14 +56,39 @@ class PassportAssessmentControllerTest {
                 .thenReturn(dto);
 
         mvc.perform(buildRequestWithTransactionId(
-                        HttpMethod.GET, ENDPOINT_URL + "/" + Constants.PASSPORT_ASSESSMENT_ID, Constants.WITHOUT_AUTH))
+                        HttpMethod.GET, ENDPOINT_URL + "/" + Constants.PASSPORT_ASSESSMENT_ID, Constants.WITH_AUTH))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
     }
 
     @Test
     void givenInvalidId_whenFindIsInvoked_thenBadRequestResponseIsReturned() throws Exception {
-        mvc.perform(buildRequestWithTransactionId(HttpMethod.GET, ENDPOINT_URL + "/inv4l1d1d", Constants.WITHOUT_AUTH))
+        mvc.perform(buildRequestWithTransactionId(HttpMethod.GET, ENDPOINT_URL + "/inv4l1d1d", Constants.WITH_AUTH))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void givenValidRequest_whenCreateIsInvoked_thenOkResponseIsReturned() throws Exception {
+        ApplicationDTO applicationDTO = TestModelDataBuilder.getApplicationDTO();
+
+        when(passportAssessmentOrchestrationService.create(any(WorkflowRequest.class)))
+                .thenReturn(applicationDTO);
+
+        String requestBody = objectMapper.writeValueAsString(TestModelDataBuilder.buildWorkFlowRequest());
+        mvc.perform(buildRequestWithTransactionIdGivenContent(
+                        HttpMethod.POST, requestBody, ENDPOINT_URL, Constants.WITH_AUTH))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    void givenInvalidRequest_whenCreateIsInvoked_thenBadRequestResponseIsReturned() throws Exception {
+        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
+        workflowRequest.setUserDTO(null);
+
+        String requestBody = objectMapper.writeValueAsString(workflowRequest);
+        mvc.perform(buildRequestWithTransactionIdGivenContent(
+                        HttpMethod.POST, requestBody, ENDPOINT_URL, Constants.WITH_AUTH))
                 .andExpect(status().isBadRequest());
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/Constants.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/Constants.java
@@ -25,7 +25,7 @@ public class Constants {
             Date.from(Instant.ofEpochSecond(ASSESSMENT_SUMMARY_DATETIME.toEpochSecond(ZoneOffset.UTC)));
     public static final Integer CONTRIBUTIONS_ID = 43;
     public static final Integer APPLICANT_ID = 999;
-    public static final Integer PARTNER_ID = 666;
+    public static final Integer PARTNER_ID = 1234;
     public static final String FIRST_NAME = "Edward";
     public static final String LAST_NAME = "Munson";
     public static final String NI_NUMBER = "JR679802A";
@@ -44,6 +44,7 @@ public class Constants {
     public static final boolean WITH_AUTH = true;
     public static final LocalDateTime DATE_RECEIVED = LocalDateTime.of(2022, 10, 13, 0, 0, 0);
     public static final LocalDateTime DATE_MODIFIED = DATE_RECEIVED.plusHours(7);
+    public static final int REP_ID = 200;
 
     // Passport
     public static final int PASSPORT_ASSESSMENT_ID = 123;

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/Constants.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/Constants.java
@@ -34,6 +34,7 @@ public class Constants {
     public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     public static final Integer USN = 123456789;
     public static final LocalDateTime ASSESSMENT_DATETIME = LocalDateTime.of(2022, 9, 3, 0, 0, 0);
+    public static final LocalDateTime ASSESSMENT_COMPLETED_DATETIME = ASSESSMENT_DATETIME.plusDays(2);
     public static final String NOTES = "This is a test note.";
     public static final int PASSPORT_ASSESSMENT_ID = 123;
     public static final int CASE_MANAGEMENT_UNIT_ID = 50;

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/Constants.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/Constants.java
@@ -42,4 +42,5 @@ public class Constants {
     public static final boolean WITH_PARTNER = true;
     public static final boolean WITHOUT_PARTNER = false;
     public static final boolean WITHOUT_AUTH = false;
+    public static final boolean WITH_AUTH = true;
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/PassportAssessmentDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/PassportAssessmentDataBuilder.java
@@ -1,7 +1,11 @@
 package uk.gov.justice.laa.crime.orchestration.data.builder;
 
+import uk.gov.justice.laa.crime.common.model.passported.ApiCreatePassportedAssessmentRequest;
+import uk.gov.justice.laa.crime.common.model.passported.ApiCreatePassportedAssessmentResponse;
 import uk.gov.justice.laa.crime.common.model.passported.ApiGetPassportedAssessmentResponse;
 import uk.gov.justice.laa.crime.common.model.passported.DeclaredBenefit;
+import uk.gov.justice.laa.crime.common.model.passported.PassportedAssessment;
+import uk.gov.justice.laa.crime.common.model.passported.PassportedAssessmentMetadata;
 import uk.gov.justice.laa.crime.enums.BenefitRecipient;
 import uk.gov.justice.laa.crime.enums.BenefitType;
 import uk.gov.justice.laa.crime.enums.CurrentStatus;
@@ -63,6 +67,25 @@ public class PassportAssessmentDataBuilder {
                 .build();
     }
 
+    private static PassportedAssessment getPassportedAssessment(boolean hasPartner) {
+        return new PassportedAssessment()
+                .withAssessmentDate(Constants.ASSESSMENT_DATETIME)
+                .withAssessmentReason(NewWorkReason.FMA)
+                .withReviewType(ReviewType.ER)
+                .withDeclaredUnder18(false)
+                .withDeclaredBenefit(hasPartner ? getDeclaredPartnerBenefit() : getDeclaredBenefit())
+                .withAssessmentDecision(PassportAssessmentDecision.PASS)
+                .withDecisionReason(PassportAssessmentDecisionReason.DWP_CHECK)
+                .withNotes(Constants.NOTES);
+    }
+
+    private static PassportedAssessmentMetadata getPassportedAssessmentMetadata() {
+        return new PassportedAssessmentMetadata()
+                .withUsn(Constants.USN)
+                .withCaseManagementUnitId(Constants.CASE_MANAGEMENT_UNIT_ID)
+                .withUserSession(TestModelDataBuilder.getApiUserSession());
+    }
+
     public static ApiGetPassportedAssessmentResponse getApiGetPassportedAssessmentResponse(boolean hasPartner) {
         return new ApiGetPassportedAssessmentResponse()
                 .withAssessmentId("deb7a9a4-2ad3-4ac8-95a4-ef0746c52ed0")
@@ -77,6 +100,16 @@ public class PassportAssessmentDataBuilder {
                 .withAssessmentDecision(PassportAssessmentDecision.PASS)
                 .withDecisionReason(PassportAssessmentDecisionReason.DWP_CHECK)
                 .withNotes(Constants.NOTES);
+    }
+
+    public static ApiCreatePassportedAssessmentRequest getApiCreatePassportedAssessmentRequest() {
+        return new ApiCreatePassportedAssessmentRequest()
+                .withPassportedAssessment(getPassportedAssessment(Constants.WITHOUT_PARTNER))
+                .withPassportedAssessmentMetadata(getPassportedAssessmentMetadata());
+    }
+
+    public static ApiCreatePassportedAssessmentResponse getApiCreatePassportedAssessmentResponse() {
+        return new ApiCreatePassportedAssessmentResponse().withLegacyAssessmentId(Constants.PASSPORT_ASSESSMENT_ID);
     }
 
     public static ApplicantDTO getApplicantDTO() {

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/PassportAssessmentDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/PassportAssessmentDataBuilder.java
@@ -102,9 +102,9 @@ public class PassportAssessmentDataBuilder {
                 .withNotes(Constants.NOTES);
     }
 
-    public static ApiCreatePassportedAssessmentRequest getApiCreatePassportedAssessmentRequest() {
+    public static ApiCreatePassportedAssessmentRequest getApiCreatePassportedAssessmentRequest(boolean hasPartner) {
         return new ApiCreatePassportedAssessmentRequest()
-                .withPassportedAssessment(getPassportedAssessment(Constants.WITHOUT_PARTNER))
+                .withPassportedAssessment(getPassportedAssessment(hasPartner))
                 .withPassportedAssessmentMetadata(getPassportedAssessmentMetadata());
     }
 

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/PassportAssessmentDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/PassportAssessmentDataBuilder.java
@@ -30,7 +30,6 @@ public class PassportAssessmentDataBuilder {
     private static DeclaredBenefit getDeclaredBenefit() {
         return new DeclaredBenefit()
                 .withBenefitType(BenefitType.INCOME_SUPPORT)
-                .withLastSignOnDate(Constants.LAST_SIGNON_DATETIME)
                 .withBenefitRecipient(BenefitRecipient.APPLICANT)
                 .withLegacyPartnerId(null);
     }
@@ -38,7 +37,6 @@ public class PassportAssessmentDataBuilder {
     private static DeclaredBenefit getDeclaredPartnerBenefit() {
         return new DeclaredBenefit()
                 .withBenefitType(BenefitType.INCOME_SUPPORT)
-                .withLastSignOnDate(Constants.LAST_SIGNON_DATETIME)
                 .withBenefitRecipient(BenefitRecipient.PARTNER)
                 .withLegacyPartnerId(Constants.PARTNER_ID);
     }
@@ -81,6 +79,7 @@ public class PassportAssessmentDataBuilder {
 
     private static PassportedAssessmentMetadata getPassportedAssessmentMetadata() {
         return new PassportedAssessmentMetadata()
+                .withLegacyApplicationId(Constants.REP_ID)
                 .withUsn(Constants.USN)
                 .withCaseManagementUnitId(Constants.CASE_MANAGEMENT_UNIT_ID)
                 .withUserSession(TestModelDataBuilder.getApiUserSession());
@@ -146,5 +145,13 @@ public class PassportAssessmentDataBuilder {
                 .under18HeardYouthCourt(false)
                 .passportSummaryEvidenceDTO(EvidenceDataBuilder.getIncomeEvidenceSummaryDTO(hasPartner))
                 .build();
+    }
+
+    public static DeclaredBenefit getDeclaredBenefitJobSeeker() {
+        return new DeclaredBenefit()
+                .withBenefitType(BenefitType.JSA)
+                .withLastSignOnDate(Constants.LAST_SIGNON_DATETIME)
+                .withBenefitRecipient(BenefitRecipient.APPLICANT)
+                .withLegacyPartnerId(null);
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/PassportAssessmentDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/PassportAssessmentDataBuilder.java
@@ -27,17 +27,19 @@ import org.springframework.stereotype.Component;
 @Component
 public class PassportAssessmentDataBuilder {
 
-    private static DeclaredBenefit getDeclaredBenefit() {
+    public static DeclaredBenefit getDeclaredBenefit(BenefitType benefitType) {
         return new DeclaredBenefit()
-                .withBenefitType(BenefitType.INCOME_SUPPORT)
+                .withBenefitType(benefitType)
                 .withBenefitRecipient(BenefitRecipient.APPLICANT)
+                .withLastSignOnDate(BenefitType.JSA.equals(benefitType) ? Constants.LAST_SIGNON_DATETIME : null)
                 .withLegacyPartnerId(null);
     }
 
-    private static DeclaredBenefit getDeclaredPartnerBenefit() {
+    private static DeclaredBenefit getDeclaredPartnerBenefit(BenefitType benefitType) {
         return new DeclaredBenefit()
-                .withBenefitType(BenefitType.INCOME_SUPPORT)
+                .withBenefitType(benefitType)
                 .withBenefitRecipient(BenefitRecipient.PARTNER)
+                .withLastSignOnDate(BenefitType.JSA.equals(benefitType) ? Constants.LAST_SIGNON_DATETIME : null)
                 .withLegacyPartnerId(Constants.PARTNER_ID);
     }
 
@@ -71,7 +73,10 @@ public class PassportAssessmentDataBuilder {
                 .withAssessmentReason(NewWorkReason.FMA)
                 .withReviewType(ReviewType.ER)
                 .withDeclaredUnder18(false)
-                .withDeclaredBenefit(hasPartner ? getDeclaredPartnerBenefit() : getDeclaredBenefit())
+                .withDeclaredBenefit(
+                        hasPartner
+                                ? getDeclaredPartnerBenefit(BenefitType.INCOME_SUPPORT)
+                                : getDeclaredBenefit(BenefitType.INCOME_SUPPORT))
                 .withAssessmentDecision(PassportAssessmentDecision.PASS)
                 .withDecisionReason(PassportAssessmentDecisionReason.DWP_CHECK)
                 .withNotes(Constants.NOTES);
@@ -95,7 +100,10 @@ public class PassportAssessmentDataBuilder {
                 .withAssessmentReason(NewWorkReason.FMA)
                 .withReviewType(ReviewType.ER)
                 .withDeclaredUnder18(false)
-                .withDeclaredBenefit(hasPartner ? getDeclaredPartnerBenefit() : getDeclaredBenefit())
+                .withDeclaredBenefit(
+                        hasPartner
+                                ? getDeclaredPartnerBenefit(BenefitType.INCOME_SUPPORT)
+                                : getDeclaredBenefit(BenefitType.INCOME_SUPPORT))
                 .withAssessmentDecision(PassportAssessmentDecision.PASS)
                 .withDecisionReason(PassportAssessmentDecisionReason.DWP_CHECK)
                 .withNotes(Constants.NOTES);
@@ -145,13 +153,5 @@ public class PassportAssessmentDataBuilder {
                 .under18HeardYouthCourt(false)
                 .passportSummaryEvidenceDTO(EvidenceDataBuilder.getIncomeEvidenceSummaryDTO(hasPartner))
                 .build();
-    }
-
-    public static DeclaredBenefit getDeclaredBenefitJobSeeker() {
-        return new DeclaredBenefit()
-                .withBenefitType(BenefitType.JSA)
-                .withLastSignOnDate(Constants.LAST_SIGNON_DATETIME)
-                .withBenefitRecipient(BenefitRecipient.APPLICANT)
-                .withLegacyPartnerId(null);
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/TestModelDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/TestModelDataBuilder.java
@@ -140,6 +140,7 @@ import uk.gov.justice.laa.crime.orchestration.dto.validation.UserActionDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.validation.UserSummaryDTO;
 import uk.gov.justice.laa.crime.orchestration.enums.AssessmentSummaryType;
 import uk.gov.justice.laa.crime.proceeding.MagsDecisionResult;
+import uk.gov.justice.laa.crime.util.DateUtil;
 import uk.gov.justice.laa.crime.util.NumberUtils;
 
 import java.math.BigDecimal;
@@ -856,6 +857,16 @@ public class TestModelDataBuilder {
                 .type(AssessmentSummaryType.IOJ_APPEAL.getName())
                 .result(RESULT_PASS)
                 .assessmentDate(receivedDate)
+                .build();
+    }
+
+    public static AssessmentSummaryDTO getAssessmentSummaryDTOFromPassportedDTO() {
+        return AssessmentSummaryDTO.builder()
+                .id(Constants.PASSPORT_ASSESSMENT_ID)
+                .status(CurrentStatus.COMPLETE.getDescription())
+                .type(AssessmentSummaryType.PASSPORTED_ASSESSMENT.getName())
+                .result(RESULT_PASS)
+                .assessmentDate(DateUtil.toDate(Constants.ASSESSMENT_DATETIME))
                 .build();
     }
 

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/integration/PassportAssessmentIntegrationTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/integration/PassportAssessmentIntegrationTest.java
@@ -1,21 +1,42 @@
 package uk.gov.justice.laa.crime.orchestration.integration;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.justice.laa.crime.orchestration.data.Constants.PASSPORT_ASSESSMENT_ID;
+import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.stubForCalculateContributions;
+import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.stubForCreatePassportAssessment;
+import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.stubForDetermineMagsRepDecision;
 import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.stubForFindPassportAssessment;
 import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.stubForFindPassportEvidence;
+import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.stubForFindRepOrder;
 import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.stubForGetApplicant;
+import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.stubForGetUserSummary;
+import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.stubForInvokeStoredProcedure;
+import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.stubForSendApplicationTrackingResult;
+import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.stubForUpdateCrownCourtApplication;
 import static uk.gov.justice.laa.crime.util.RequestBuilderUtils.buildRequest;
+import static uk.gov.justice.laa.crime.util.RequestBuilderUtils.buildRequestGivenContent;
 
+import uk.gov.justice.laa.crime.enums.NewWorkReason;
+import uk.gov.justice.laa.crime.enums.orchestration.Action;
 import uk.gov.justice.laa.crime.orchestration.data.Constants;
 import uk.gov.justice.laa.crime.orchestration.data.builder.EvidenceDataBuilder;
+import uk.gov.justice.laa.crime.orchestration.data.builder.MeansAssessmentDataBuilder;
 import uk.gov.justice.laa.crime.orchestration.data.builder.PassportAssessmentDataBuilder;
+import uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder;
+import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.PassportedDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
 import uk.gov.justice.laa.crime.orchestration.utils.TestUtils;
+
+import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,6 +51,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
 
 class PassportAssessmentIntegrationTest extends WiremockIntegrationTest {
 
@@ -142,5 +164,105 @@ class PassportAssessmentIntegrationTest extends WiremockIntegrationTest {
 
         mvc.perform(buildRequest(HttpMethod.GET, ENDPOINT_URL + "/" + PASSPORT_ASSESSMENT_ID))
                 .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void givenValidRequest_whenCreateIsInvoked_thenShouldReturnSuccessResponse() throws Exception {
+        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
+        PassportedDTO expected = PassportAssessmentDataBuilder.getPassportedDTO(Constants.WITHOUT_PARTNER);
+        workflowRequest.getApplicationDTO().setPassportedDTO(expected);
+        RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTOWithAssessorName();
+        String requestBody = objectMapper.writeValueAsString(workflowRequest);
+
+        stubForOAuth();
+        stubForFindRepOrder(objectMapper.writeValueAsString(repOrderDTO));
+        stubForGetUserSummary(objectMapper.writeValueAsString(TestModelDataBuilder.getUserSummaryDTO(
+                List.of(Action.CREATE_PASSPORT_ASSESSMENT.getCode()), NewWorkReason.FMA)));
+        stubForCreatePassportAssessment(objectMapper.writeValueAsString(
+                PassportAssessmentDataBuilder.getApiGetPassportedAssessmentResponse(Constants.WITHOUT_PARTNER)));
+        stubForInvokeStoredProcedure(
+                Scenario.STARTED,
+                "MANAGE_PASSPORT_EVIDENCE",
+                objectMapper.writeValueAsString(TestModelDataBuilder.getApplicationDTO()));
+        stubForDetermineMagsRepDecision(
+                objectMapper.writeValueAsString(TestModelDataBuilder.getDetermineMagsRepDecisionResponse()));
+        stubForCalculateContributions(
+                objectMapper.writeValueAsString(TestModelDataBuilder.getApiMaatCalculateContributionResponse()));
+        stubForInvokeStoredProcedure(
+                "MANAGE_PASSPORT_EVIDENCE",
+                "PROCESS_ACTIVITY_AND_GET_CORRESPONDENCE",
+                objectMapper.writeValueAsString(TestModelDataBuilder.getApplicationDTO()));
+        stubForUpdateCrownCourtApplication(
+                objectMapper.writeValueAsString(MeansAssessmentDataBuilder.getApiUpdateApplicationResponse()));
+        stubForSendApplicationTrackingResult();
+
+        mvc.perform(buildRequestGivenContent(HttpMethod.POST, requestBody, ENDPOINT_URL))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.passportedDTO.passportedId").value(expected.getPassportedId()))
+                .andExpect(jsonPath("$.passportedDTO.cmuId").value(expected.getCmuId()))
+                .andExpect(jsonPath("$.passportedDTO.usn").value(expected.getUsn()))
+                .andExpect(jsonPath("$.passportedDTO.date").value(TestUtils.formatDate(expected.getDate())))
+                .andExpect(jsonPath("$.passportedDTO.assessementStatusDTO.status")
+                        .value(expected.getAssessementStatusDTO().getStatus()))
+                .andExpect(jsonPath("$.passportedDTO.passportConfirmationDTO.confirmation")
+                        .value(expected.getPassportConfirmationDTO().getConfirmation()))
+                .andExpect(jsonPath("$.passportedDTO.newWorkReason.code")
+                        .value(expected.getNewWorkReason().getCode()))
+                .andExpect(jsonPath("$.passportedDTO.reviewType.code")
+                        .value(expected.getReviewType().getCode()))
+                .andExpect(jsonPath("$.passportedDTO.dwpResult").value(expected.getDwpResult()))
+                .andExpect(jsonPath("$.passportedDTO.benefitIncomeSupport").value(expected.getBenefitIncomeSupport()))
+                .andExpect(jsonPath("$.passportedDTO.benefitJobSeeker").value(expected.getBenefitJobSeeker()))
+                .andExpect(jsonPath("$.passportedDTO.benefitGaurenteedStatePension")
+                        .value(expected.getBenefitGaurenteedStatePension()))
+                .andExpect(jsonPath("$.passportedDTO.benefitClaimedByPartner")
+                        .value(expected.getBenefitClaimedByPartner()))
+                .andExpect(jsonPath("$.passportedDTO.benefitEmploymentSupport")
+                        .value(expected.getBenefitEmploymentSupport()))
+                .andExpect(
+                        jsonPath("$.passportedDTO.benefitUniversalCredit").value(expected.getBenefitUniversalCredit()))
+                .andExpect(jsonPath("$.passportedDTO.partnerDetails").value(expected.getPartnerDetails()))
+                .andExpect(jsonPath("$.passportedDTO.notes").value(expected.getNotes()))
+                .andExpect(jsonPath("$.passportedDTO.result").value(expected.getResult()))
+                .andExpect(
+                        jsonPath("$.passportedDTO.under18HeardYouthCourt").value(expected.getUnder18HeardYouthCourt()))
+                .andExpect(jsonPath("$.passportedDTO.under18HeardMagsCourt").value(expected.getUnder18HeardMagsCourt()))
+                .andExpect(jsonPath("$.passportedDTO.under18FullEducation").value(expected.getUnder18FullEducation()))
+                .andExpect(jsonPath("$.passportedDTO.under16").value(expected.getUnder16()))
+                .andExpect(jsonPath("$.passportedDTO.between1617").value(expected.getBetween1617()))
+                .andExpect(jsonPath("$.passportedDTO.passportSummaryEvidenceDTO.evidenceDueDate")
+                        .value(TestUtils.formatDate(
+                                expected.getPassportSummaryEvidenceDTO().getEvidenceDueDate())))
+                .andExpect(jsonPath("$.passportedDTO.passportSummaryEvidenceDTO.evidenceReceivedDate")
+                        .value(TestUtils.formatDate(
+                                expected.getPassportSummaryEvidenceDTO().getEvidenceReceivedDate())))
+                .andExpect(jsonPath("$.passportedDTO.passportSummaryEvidenceDTO.upliftAppliedDate")
+                        .value(TestUtils.formatDate(
+                                expected.getPassportSummaryEvidenceDTO().getUpliftAppliedDate())))
+                .andExpect(jsonPath("$.passportedDTO.passportSummaryEvidenceDTO.upliftRemovedDate")
+                        .value(TestUtils.formatDate(
+                                expected.getPassportSummaryEvidenceDTO().getUpliftRemovedDate())))
+                .andExpect(jsonPath("$.passportedDTO.passportSummaryEvidenceDTO.incomeEvidenceNotes")
+                        .value(expected.getPassportSummaryEvidenceDTO().getIncomeEvidenceNotes()))
+                .andExpect(jsonPath("$.passportedDTO.passportSummaryEvidenceDTO.firstReminderDate")
+                        .value(TestUtils.formatDate(
+                                expected.getPassportSummaryEvidenceDTO().getFirstReminderDate())))
+                .andExpect(jsonPath("$.passportedDTO.passportSummaryEvidenceDTO.secondReminderDate")
+                        .value(TestUtils.formatDate(
+                                expected.getPassportSummaryEvidenceDTO().getSecondReminderDate())))
+                .andExpect(jsonPath("$.passportedDTO.passportSummaryEvidenceDTO.applicantIncomeEvidenceList[0].id")
+                        .value(Constants.APPLICANT_EVIDENCE_ID))
+                .andExpect(jsonPath("$.passportedDTO.passportSummaryEvidenceDTO.extraEvidenceList[0].otherText")
+                        .value(Constants.OTHER_DESCRIPTION))
+                .andExpect(jsonPath("$.passportedDTO.whoDwpChecked").value(expected.getWhoDwpChecked()));
+
+        verify(exactly(1), postRequestedFor(urlPathMatching("/api/internal/v1/passport")));
+    }
+
+    @Test
+    void givenEmptyOAuthToken_whenCreateIsInvoked_thenFailsUnauthorisedAccess() throws Exception {
+        mvc.perform(buildRequest(HttpMethod.POST, ENDPOINT_URL, Constants.WITHOUT_AUTH))
+                .andExpect(status().isUnauthorized());
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/integration/PassportAssessmentIntegrationTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/integration/PassportAssessmentIntegrationTest.java
@@ -261,7 +261,7 @@ class PassportAssessmentIntegrationTest extends WiremockIntegrationTest {
     }
 
     @Test
-    void givenEmptyOAuthToken_whenCreateIsInvoked_thenFailsUnauthorisedAccess() throws Exception {
+    void givenEmptyOAuthToken_whenCreateIsInvoked_thenFailsWithUnauthorisedAccess() throws Exception {
         mvc.perform(buildRequest(HttpMethod.POST, ENDPOINT_URL, Constants.WITHOUT_AUTH))
                 .andExpect(status().isUnauthorized());
     }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapperTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapperTest.java
@@ -14,6 +14,7 @@ import uk.gov.justice.laa.crime.orchestration.data.builder.EvidenceDataBuilder;
 import uk.gov.justice.laa.crime.orchestration.data.builder.PassportAssessmentDataBuilder;
 import uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.PassportedDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.ApplicantDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.validation.UserActionDTO;
@@ -82,7 +83,7 @@ class PassportAssessmentMapperTest {
             case BenefitType.INCOME_SUPPORT -> expected.setBenefitIncomeSupport(true);
             case BenefitType.JSA -> {
                 expected.setBenefitJobSeeker(PassportAssessmentDataBuilder.getJobSeekerDTO());
-                response.setDeclaredBenefit(PassportAssessmentDataBuilder.getDeclaredBenefitJobSeeker());
+                response.setDeclaredBenefit(PassportAssessmentDataBuilder.getDeclaredBenefit(BenefitType.JSA));
             }
             case BenefitType.GSPC -> expected.setBenefitGaurenteedStatePension(true);
             case BenefitType.ESA -> expected.setBenefitEmploymentSupport(true);
@@ -139,21 +140,27 @@ class PassportAssessmentMapperTest {
         softly.assertAll();
     }
 
-    @Test
-    void
-            givenValidWorkflowRequestWithJobSeeker_whenWorkflowRequestToPassportedAssessmentRequestIsInvoked_thenRequestIsReturned() {
+    @ParameterizedTest
+    @EnumSource(BenefitType.class)
+    void givenRequestWithDifferentBenefits_whenWorkflowRequestToPassportedRequestIsInvoked_thenRequestIsReturned(
+            BenefitType benefit) {
         WorkflowRequest request = TestModelDataBuilder.buildWorkFlowRequest();
-        request.getApplicationDTO()
-                .setPassportedDTO(PassportAssessmentDataBuilder.getPassportedDTO(Constants.WITHOUT_PARTNER));
-        request.getApplicationDTO().getPassportedDTO().setBenefitIncomeSupport(false);
-        request.getApplicationDTO()
-                .getPassportedDTO()
-                .setBenefitJobSeeker(PassportAssessmentDataBuilder.getJobSeekerDTO());
+        ApplicationDTO applicationDTO = request.getApplicationDTO();
+        applicationDTO.setPassportedDTO(PassportAssessmentDataBuilder.getPassportedDTO(Constants.WITHOUT_PARTNER));
+        applicationDTO.getPassportedDTO().setBenefitIncomeSupport(false);
         ApiUserSession userSession = TestModelDataBuilder.getApiUserSession();
         ApiCreatePassportedAssessmentRequest expected =
                 PassportAssessmentDataBuilder.getApiCreatePassportedAssessmentRequest(Constants.WITHOUT_PARTNER);
         expected.getPassportedAssessment()
-                .setDeclaredBenefit(PassportAssessmentDataBuilder.getDeclaredBenefitJobSeeker());
+                .setDeclaredBenefit(PassportAssessmentDataBuilder.getDeclaredBenefit(benefit));
+        switch (benefit) {
+            case BenefitType.INCOME_SUPPORT -> applicationDTO.getPassportedDTO().setBenefitIncomeSupport(true);
+            case BenefitType.JSA ->
+                applicationDTO.getPassportedDTO().setBenefitJobSeeker(PassportAssessmentDataBuilder.getJobSeekerDTO());
+            case BenefitType.GSPC -> applicationDTO.getPassportedDTO().setBenefitGaurenteedStatePension(true);
+            case BenefitType.ESA -> applicationDTO.getPassportedDTO().setBenefitEmploymentSupport(true);
+            case BenefitType.UC -> applicationDTO.getPassportedDTO().setBenefitUniversalCredit(true);
+        }
 
         when(userMapper.userDtoToUserSession(request.getUserDTO())).thenReturn(userSession);
 

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapperTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapperTest.java
@@ -128,13 +128,14 @@ class PassportAssessmentMapperTest {
         WorkflowRequest request = TestModelDataBuilder.buildWorkFlowRequest();
         request.getApplicationDTO().setPassportedDTO(PassportAssessmentDataBuilder.getPassportedDTO(hasPartner));
         ApiUserSession userSession = TestModelDataBuilder.getApiUserSession();
+        Integer partnerId = hasPartner ? Constants.PARTNER_ID : null;
         ApiCreatePassportedAssessmentRequest expected =
                 PassportAssessmentDataBuilder.getApiCreatePassportedAssessmentRequest(hasPartner);
 
         when(userMapper.userDtoToUserSession(request.getUserDTO())).thenReturn(userSession);
 
         ApiCreatePassportedAssessmentRequest actual =
-                passportAssessmentMapper.workflowRequestToApiCreatePassportedAssessmentRequest(request);
+                passportAssessmentMapper.workflowRequestToApiCreatePassportedAssessmentRequest(request, partnerId);
 
         softly.assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
         softly.assertAll();
@@ -165,7 +166,7 @@ class PassportAssessmentMapperTest {
         when(userMapper.userDtoToUserSession(request.getUserDTO())).thenReturn(userSession);
 
         ApiCreatePassportedAssessmentRequest actual =
-                passportAssessmentMapper.workflowRequestToApiCreatePassportedAssessmentRequest(request);
+                passportAssessmentMapper.workflowRequestToApiCreatePassportedAssessmentRequest(request, null);
 
         softly.assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
         softly.assertAll();

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapperTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapperTest.java
@@ -17,7 +17,8 @@ import org.junit.jupiter.params.provider.EnumSource;
 @ExtendWith(SoftAssertionsExtension.class)
 class PassportAssessmentMapperTest {
 
-    PassportAssessmentMapper passportAssessmentMapper = new PassportAssessmentMapper();
+    UserMapper userMapper = new UserMapper();
+    PassportAssessmentMapper passportAssessmentMapper = new PassportAssessmentMapper(userMapper);
 
     @InjectSoftAssertions
     private SoftAssertions softly;

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapperTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapperTest.java
@@ -2,18 +2,26 @@ package uk.gov.justice.laa.crime.orchestration.mapper;
 
 import static org.mockito.Mockito.when;
 
+import uk.gov.justice.laa.crime.common.model.common.ApiUserSession;
 import uk.gov.justice.laa.crime.common.model.evidence.ApiGetPassportEvidenceResponse;
+import uk.gov.justice.laa.crime.common.model.passported.ApiCreatePassportedAssessmentRequest;
 import uk.gov.justice.laa.crime.common.model.passported.ApiGetPassportedAssessmentResponse;
 import uk.gov.justice.laa.crime.enums.BenefitType;
+import uk.gov.justice.laa.crime.enums.NewWorkReason;
+import uk.gov.justice.laa.crime.enums.orchestration.Action;
 import uk.gov.justice.laa.crime.orchestration.data.Constants;
 import uk.gov.justice.laa.crime.orchestration.data.builder.EvidenceDataBuilder;
 import uk.gov.justice.laa.crime.orchestration.data.builder.PassportAssessmentDataBuilder;
+import uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder;
+import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.PassportedDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.ApplicantDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.validation.UserActionDTO;
 
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -44,9 +52,11 @@ class PassportAssessmentMapperTest {
             boolean withPartner) {
         PassportedDTO expected = PassportAssessmentDataBuilder.getPassportedDTO(withPartner);
         ApiGetPassportEvidenceResponse evidence = EvidenceDataBuilder.getApiGetPassportEvidenceResponse(withPartner);
+        ApplicantDTO applicant = withPartner ? PassportAssessmentDataBuilder.getApplicantDTO() : null;
+
         when(passportEvidenceMapper.apiGetPassportEvidenceResponseToIncomeEvidenceSummaryDTO(evidence))
                 .thenReturn(EvidenceDataBuilder.getIncomeEvidenceSummaryDTO(withPartner));
-        ApplicantDTO applicant = withPartner ? PassportAssessmentDataBuilder.getApplicantDTO() : null;
+
         PassportedDTO actual = passportAssessmentMapper.apiGetPassportedAssessmentResponseToPassportedDTO(
                 PassportAssessmentDataBuilder.getApiGetPassportedAssessmentResponse(withPartner), evidence, applicant);
 
@@ -63,20 +73,25 @@ class PassportAssessmentMapperTest {
             BenefitType benefit) {
         PassportedDTO expected = PassportAssessmentDataBuilder.getPassportedDTO(Constants.WITHOUT_PARTNER);
         expected.setBenefitIncomeSupport(false);
-        switch (benefit) {
-            case BenefitType.INCOME_SUPPORT -> expected.setBenefitIncomeSupport(true);
-            case BenefitType.JSA -> expected.setBenefitJobSeeker(PassportAssessmentDataBuilder.getJobSeekerDTO());
-            case BenefitType.GSPC -> expected.setBenefitGaurenteedStatePension(true);
-            case BenefitType.ESA -> expected.setBenefitEmploymentSupport(true);
-            case BenefitType.UC -> expected.setBenefitUniversalCredit(true);
-        }
         ApiGetPassportedAssessmentResponse response =
                 PassportAssessmentDataBuilder.getApiGetPassportedAssessmentResponse(Constants.WITHOUT_PARTNER);
         response.getDeclaredBenefit().setBenefitType(benefit);
         ApiGetPassportEvidenceResponse evidence =
                 EvidenceDataBuilder.getApiGetPassportEvidenceResponse(Constants.WITHOUT_PARTNER);
+        switch (benefit) {
+            case BenefitType.INCOME_SUPPORT -> expected.setBenefitIncomeSupport(true);
+            case BenefitType.JSA -> {
+                expected.setBenefitJobSeeker(PassportAssessmentDataBuilder.getJobSeekerDTO());
+                response.setDeclaredBenefit(PassportAssessmentDataBuilder.getDeclaredBenefitJobSeeker());
+            }
+            case BenefitType.GSPC -> expected.setBenefitGaurenteedStatePension(true);
+            case BenefitType.ESA -> expected.setBenefitEmploymentSupport(true);
+            case BenefitType.UC -> expected.setBenefitUniversalCredit(true);
+        }
+
         when(passportEvidenceMapper.apiGetPassportEvidenceResponseToIncomeEvidenceSummaryDTO(evidence))
                 .thenReturn(EvidenceDataBuilder.getIncomeEvidenceSummaryDTO(Constants.WITHOUT_PARTNER));
+
         PassportedDTO actual =
                 passportAssessmentMapper.apiGetPassportedAssessmentResponseToPassportedDTO(response, evidence, null);
 
@@ -84,6 +99,68 @@ class PassportAssessmentMapperTest {
                 .usingRecursiveComparison()
                 .ignoringCollectionOrder()
                 .isEqualTo(expected);
+        softly.assertAll();
+    }
+
+    @Test
+    void givenValidWorkflowRequest_whenGetUserActionDTOIsInvoked_thenUserActionDTOIsReturned() {
+        WorkflowRequest request = TestModelDataBuilder.buildWorkFlowRequest();
+        NewWorkReason newWorkReason = NewWorkReason.getFrom(request.getApplicationDTO()
+                .getPassportedDTO()
+                .getNewWorkReason()
+                .getCode());
+        UserActionDTO expected = TestModelDataBuilder.getUserActionDTO();
+
+        when(userMapper.getUserActionDTO(request, Action.CREATE_PASSPORT_ASSESSMENT, newWorkReason))
+                .thenReturn(expected);
+
+        UserActionDTO actual = passportAssessmentMapper.getUserActionDTO(request);
+
+        softly.assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+        softly.assertAll();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void givenValidWorkflowRequest_whenWorkflowRequestToPassportedAssessmentRequestIsInvoked_thenRequestIsReturned(
+            boolean hasPartner) {
+        WorkflowRequest request = TestModelDataBuilder.buildWorkFlowRequest();
+        request.getApplicationDTO().setPassportedDTO(PassportAssessmentDataBuilder.getPassportedDTO(hasPartner));
+        ApiUserSession userSession = TestModelDataBuilder.getApiUserSession();
+        ApiCreatePassportedAssessmentRequest expected =
+                PassportAssessmentDataBuilder.getApiCreatePassportedAssessmentRequest(hasPartner);
+
+        when(userMapper.userDtoToUserSession(request.getUserDTO())).thenReturn(userSession);
+
+        ApiCreatePassportedAssessmentRequest actual =
+                passportAssessmentMapper.workflowRequestToApiCreatePassportedAssessmentRequest(request);
+
+        softly.assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+        softly.assertAll();
+    }
+
+    @Test
+    void
+            givenValidWorkflowRequestWithJobSeeker_whenWorkflowRequestToPassportedAssessmentRequestIsInvoked_thenRequestIsReturned() {
+        WorkflowRequest request = TestModelDataBuilder.buildWorkFlowRequest();
+        request.getApplicationDTO()
+                .setPassportedDTO(PassportAssessmentDataBuilder.getPassportedDTO(Constants.WITHOUT_PARTNER));
+        request.getApplicationDTO().getPassportedDTO().setBenefitIncomeSupport(false);
+        request.getApplicationDTO()
+                .getPassportedDTO()
+                .setBenefitJobSeeker(PassportAssessmentDataBuilder.getJobSeekerDTO());
+        ApiUserSession userSession = TestModelDataBuilder.getApiUserSession();
+        ApiCreatePassportedAssessmentRequest expected =
+                PassportAssessmentDataBuilder.getApiCreatePassportedAssessmentRequest(Constants.WITHOUT_PARTNER);
+        expected.getPassportedAssessment()
+                .setDeclaredBenefit(PassportAssessmentDataBuilder.getDeclaredBenefitJobSeeker());
+
+        when(userMapper.userDtoToUserSession(request.getUserDTO())).thenReturn(userSession);
+
+        ApiCreatePassportedAssessmentRequest actual =
+                passportAssessmentMapper.workflowRequestToApiCreatePassportedAssessmentRequest(request);
+
+        softly.assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
         softly.assertAll();
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/MaatCourtDataServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/MaatCourtDataServiceTest.java
@@ -67,10 +67,10 @@ class MaatCourtDataServiceTest {
     }
 
     @Test
-    void givenValidReqest_whenUpdateRepOrderDateModifiedIsInvoked_thenApiServiceIsCalled() {
+    void givenValidReqest_whenUpdateRepOrderIsInvoked_thenApiServiceIsCalled() {
         Map<String, Object> fieldsToUpdate = Map.of("dateModified", LocalDateTime.now());
 
-        maatCourtDataService.updateRepOrderDateModified(1234, fieldsToUpdate);
+        maatCourtDataService.updateRepOrder(1234, fieldsToUpdate);
         verify(maatCourtDataApiService).patchRepOrder(1234, fieldsToUpdate);
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/MaatCourtDataServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/MaatCourtDataServiceTest.java
@@ -67,7 +67,7 @@ class MaatCourtDataServiceTest {
     }
 
     @Test
-    void givenValidReqest_whenUpdateRepOrderIsInvoked_thenApiServiceIsCalled() {
+    void givenValidRequest_whenUpdateRepOrderIsInvoked_thenApiServiceIsCalled() {
         Map<String, Object> fieldsToUpdate = Map.of("dateModified", LocalDateTime.now());
 
         maatCourtDataService.updateRepOrder(1234, fieldsToUpdate);

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/PassportAssessmentServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/PassportAssessmentServiceTest.java
@@ -4,9 +4,13 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import uk.gov.justice.laa.crime.common.model.passported.ApiCreatePassportedAssessmentRequest;
+import uk.gov.justice.laa.crime.common.model.passported.ApiCreatePassportedAssessmentResponse;
 import uk.gov.justice.laa.crime.common.model.passported.ApiGetPassportedAssessmentResponse;
 import uk.gov.justice.laa.crime.orchestration.data.Constants;
 import uk.gov.justice.laa.crime.orchestration.data.builder.PassportAssessmentDataBuilder;
+import uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder;
+import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.PassportedDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.ApplicantDTO;
 import uk.gov.justice.laa.crime.orchestration.mapper.PassportAssessmentMapper;
@@ -65,5 +69,24 @@ class PassportAssessmentServiceTest {
         verifyNoInteractions(maatCourtDataApiService);
         assertThat(passportAssessmentService.find(Constants.PASSPORT_ASSESSMENT_ID))
                 .isEqualTo(passportedDTO);
+    }
+
+    @Test
+    void givenValidRequest_whenCreateIsInvoked_thenPassportAssessmentIdIsReturned() {
+        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
+        ApiCreatePassportedAssessmentRequest casRequest =
+                PassportAssessmentDataBuilder.getApiCreatePassportedAssessmentRequest(Constants.WITHOUT_PARTNER);
+        ApiCreatePassportedAssessmentResponse response =
+                PassportAssessmentDataBuilder.getApiCreatePassportedAssessmentResponse();
+
+        when(passportAssessmentMapper.workflowRequestToApiCreatePassportedAssessmentRequest(workflowRequest))
+                .thenReturn(casRequest);
+        when(assessmentApiService.createPassportAssessment(casRequest)).thenReturn(response);
+
+        Integer assessmentId = passportAssessmentService.create(workflowRequest);
+
+        assertThat(workflowRequest.getApplicationDTO().getPassportedDTO().getPassportedId())
+                .isEqualTo(Long.valueOf(Constants.PASSPORT_ASSESSMENT_ID));
+        assertThat(assessmentId).isEqualTo(Constants.PASSPORT_ASSESSMENT_ID);
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/PassportAssessmentServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/PassportAssessmentServiceTest.java
@@ -94,7 +94,7 @@ class PassportAssessmentServiceTest {
         ApiCreatePassportedAssessmentResponse response =
                 PassportAssessmentDataBuilder.getApiCreatePassportedAssessmentResponse();
 
-        when(passportAssessmentMapper.workflowRequestToApiCreatePassportedAssessmentRequest(workflowRequest))
+        when(passportAssessmentMapper.workflowRequestToApiCreatePassportedAssessmentRequest(workflowRequest, null))
                 .thenReturn(casRequest);
         when(assessmentApiService.createPassportAssessment(casRequest)).thenReturn(response);
 

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/RepOrderServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/RepOrderServiceTest.java
@@ -3,11 +3,17 @@ package uk.gov.justice.laa.crime.orchestration.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import uk.gov.justice.laa.crime.enums.CaseType;
+import uk.gov.justice.laa.crime.enums.CurrentStatus;
+import uk.gov.justice.laa.crime.enums.RepOrderStatus;
+import uk.gov.justice.laa.crime.orchestration.data.Constants;
 import uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
+import uk.gov.justice.laa.crime.util.DateUtil;
 
 import java.time.LocalDateTime;
 
@@ -54,5 +60,40 @@ class RepOrderServiceTest {
 
         repOrderService.updateRepOrderDateModified(workflowRequest, LocalDateTime.now());
         verify(maatCourtDataService).updateRepOrder(any(), any());
+    }
+
+    @Test
+    void givenIndictableCase_whenUpdateAssessmentDateCompletedIsCalled_thenDateIsUpdated() {
+        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
+        workflowRequest.getApplicationDTO().getCaseDetailsDTO().setCaseType(CaseType.INDICTABLE.getCaseType());
+        RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTO(RepOrderStatus.CURR.getCode());
+        LocalDateTime dateCompleted = Constants.ASSESSMENT_COMPLETED_DATETIME;
+        RepOrderDTO updatedRepOrderDTO = TestModelDataBuilder.buildRepOrderDTO(RepOrderStatus.CURR.getCode());
+        updatedRepOrderDTO.setAssessmentDateCompleted(DateUtil.parseLocalDate(dateCompleted));
+
+        when(maatCourtDataService.findRepOrder(
+                        workflowRequest.getApplicationDTO().getRepId().intValue()))
+                .thenReturn(updatedRepOrderDTO);
+
+        assertThat(repOrderService.updateRepOrderAssessmentDateCompleted(workflowRequest, repOrderDTO, dateCompleted))
+                .isEqualTo(updatedRepOrderDTO);
+    }
+
+    @Test
+    void givenInProgressEitherWayCase_whenUpdateAssessmentDateCompletedIsCalled_thenDateIsNotUpdated() {
+        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
+        workflowRequest
+                .getApplicationDTO()
+                .getAssessmentDTO()
+                .getFinancialAssessmentDTO()
+                .getFull()
+                .getAssessmnentStatusDTO()
+                .setStatus(CurrentStatus.IN_PROGRESS.getStatus());
+        RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTO(RepOrderStatus.CURR.getCode());
+        LocalDateTime dateCompleted = Constants.ASSESSMENT_COMPLETED_DATETIME;
+
+        verifyNoInteractions(maatCourtDataService);
+        assertThat(repOrderService.updateRepOrderAssessmentDateCompleted(workflowRequest, repOrderDTO, dateCompleted))
+                .isEqualTo(repOrderDTO);
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/RepOrderServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/RepOrderServiceTest.java
@@ -53,6 +53,6 @@ class RepOrderServiceTest {
         WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
 
         repOrderService.updateRepOrderDateModified(workflowRequest, LocalDateTime.now());
-        verify(maatCourtDataService).updateRepOrderDateModified(any(), any());
+        verify(maatCourtDataService).updateRepOrder(any(), any());
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/WorkflowPreProcessorServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/WorkflowPreProcessorServiceTest.java
@@ -2,6 +2,7 @@ package uk.gov.justice.laa.crime.orchestration.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -166,5 +167,39 @@ class WorkflowPreProcessorServiceTest {
 
         assertThatThrownBy(() -> workflowPreProcessorService.preProcessEvidenceRequest(userActionDTO, true))
                 .isInstanceOf(ValidationException.class);
+    }
+
+    @Test
+    void givenRequestValidationFails_whenPreProcessPassportRequestIsInvoked_thenExceptionIsThrown() {
+        WorkflowRequest workflowRequest = getWorkflowRequestWithCaseType(INDICTABLE.getCaseType());
+        RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTO(RepOrderStatus.CURR.getCode());
+        UserActionDTO userActionDTO = TestModelDataBuilder.getUserActionDTO();
+
+        doThrow(new ValidationException(ValidationService.CANNOT_MODIFY_APPLICATION_ERROR))
+                .when(validationService)
+                .validate(workflowRequest, repOrderDTO);
+
+        assertThatThrownBy(() -> workflowPreProcessorService.preProcessPassportRequest(
+                        workflowRequest, repOrderDTO, userActionDTO))
+                .isInstanceOf(ValidationException.class);
+    }
+
+    @Test
+    void givenUserActionValidationFails_whenPreProcessPassportRequestIsInvoked_thenExceptionIsThrown() {
+        WorkflowRequest workflowRequest = getWorkflowRequestWithCaseType(INDICTABLE.getCaseType());
+        RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTO(RepOrderStatus.CURR.getCode());
+        UserActionDTO userActionDTO = TestModelDataBuilder.getUserActionDTO();
+        UserSummaryDTO userSummaryDTO = TestModelDataBuilder.getUserSummaryDTO();
+
+        doNothing().when(validationService).validate(workflowRequest, repOrderDTO);
+        when(maatCourtDataService.getUserSummary(userActionDTO.getUsername())).thenReturn(userSummaryDTO);
+        doThrow(new CrimeValidationException(
+                        List.of(ValidationService.USER_HAVE_AN_EXISTING_RESERVATION_RESERVATION_NOT_ALLOWED)))
+                .when(validationService)
+                .isUserActionValid(userActionDTO, userSummaryDTO);
+
+        assertThatThrownBy(() -> workflowPreProcessorService.preProcessPassportRequest(
+                        workflowRequest, repOrderDTO, userActionDTO))
+                .isInstanceOf(CrimeValidationException.class);
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/WorkflowPreProcessorServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/WorkflowPreProcessorServiceTest.java
@@ -170,7 +170,7 @@ class WorkflowPreProcessorServiceTest {
     }
 
     @Test
-    void givenRequestValidationFails_whenPreProcessPassportRequestIsInvoked_thenExceptionIsThrown() {
+    void givenRequestValidationFails_whenValidatePassportRequestIsInvoked_thenExceptionIsThrown() {
         WorkflowRequest workflowRequest = getWorkflowRequestWithCaseType(INDICTABLE.getCaseType());
         RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTO(RepOrderStatus.CURR.getCode());
         UserActionDTO userActionDTO = TestModelDataBuilder.getUserActionDTO();
@@ -179,13 +179,13 @@ class WorkflowPreProcessorServiceTest {
                 .when(validationService)
                 .validate(workflowRequest, repOrderDTO);
 
-        assertThatThrownBy(() -> workflowPreProcessorService.preProcessPassportRequest(
+        assertThatThrownBy(() -> workflowPreProcessorService.validatePassportRequest(
                         workflowRequest, repOrderDTO, userActionDTO))
                 .isInstanceOf(ValidationException.class);
     }
 
     @Test
-    void givenUserActionValidationFails_whenPreProcessPassportRequestIsInvoked_thenExceptionIsThrown() {
+    void givenUserActionValidationFails_whenValidatePassportRequestIsInvoked_thenExceptionIsThrown() {
         WorkflowRequest workflowRequest = getWorkflowRequestWithCaseType(INDICTABLE.getCaseType());
         RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTO(RepOrderStatus.CURR.getCode());
         UserActionDTO userActionDTO = TestModelDataBuilder.getUserActionDTO();
@@ -198,7 +198,7 @@ class WorkflowPreProcessorServiceTest {
                 .when(validationService)
                 .isUserActionValid(userActionDTO, userSummaryDTO);
 
-        assertThatThrownBy(() -> workflowPreProcessorService.preProcessPassportRequest(
+        assertThatThrownBy(() -> workflowPreProcessorService.validatePassportRequest(
                         workflowRequest, repOrderDTO, userActionDTO))
                 .isInstanceOf(CrimeValidationException.class);
     }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/api/AssessmentApiServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/api/AssessmentApiServiceTest.java
@@ -90,7 +90,7 @@ class AssessmentApiServiceTest {
     @Test
     void givenValidRequest_whenCreatePassportAssessmentIsInvoked_thenResponseIsReturned() {
         ApiCreatePassportedAssessmentRequest request =
-                PassportAssessmentDataBuilder.getApiCreatePassportedAssessmentRequest();
+                PassportAssessmentDataBuilder.getApiCreatePassportedAssessmentRequest(Constants.WITHOUT_PARTNER);
         ApiCreatePassportedAssessmentResponse response =
                 PassportAssessmentDataBuilder.getApiCreatePassportedAssessmentResponse();
 

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/api/AssessmentApiServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/api/AssessmentApiServiceTest.java
@@ -8,6 +8,8 @@ import static org.mockito.Mockito.when;
 import uk.gov.justice.laa.crime.common.model.ioj.ApiCreateIojAppealRequest;
 import uk.gov.justice.laa.crime.common.model.ioj.ApiCreateIojAppealResponse;
 import uk.gov.justice.laa.crime.common.model.ioj.ApiGetIojAppealResponse;
+import uk.gov.justice.laa.crime.common.model.passported.ApiCreatePassportedAssessmentRequest;
+import uk.gov.justice.laa.crime.common.model.passported.ApiCreatePassportedAssessmentResponse;
 import uk.gov.justice.laa.crime.common.model.passported.ApiGetPassportedAssessmentResponse;
 import uk.gov.justice.laa.crime.orchestration.client.CrimeAssessmentApiClient;
 import uk.gov.justice.laa.crime.orchestration.data.Constants;
@@ -83,5 +85,17 @@ class AssessmentApiServiceTest {
 
         assertThatThrownBy(() -> assessmentApiService.findPassportAssessment(Constants.PASSPORT_ASSESSMENT_ID))
                 .isInstanceOf(WebClientResponseException.class);
+    }
+
+    @Test
+    void givenValidRequest_whenCreatePassportAssessmentIsInvoked_thenResponseIsReturned() {
+        ApiCreatePassportedAssessmentRequest request =
+                PassportAssessmentDataBuilder.getApiCreatePassportedAssessmentRequest();
+        ApiCreatePassportedAssessmentResponse response =
+                PassportAssessmentDataBuilder.getApiCreatePassportedAssessmentResponse();
+
+        when(assessmentApiClient.createPassportAssessment(request)).thenReturn(response);
+
+        assertThat(assessmentApiService.createPassportAssessment(request)).isEqualTo(response);
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationServiceTest.java
@@ -1,12 +1,42 @@
 package uk.gov.justice.laa.crime.orchestration.service.orchestration;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult;
+import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult.AssessmentType;
+import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult.RequestSource;
+import uk.gov.justice.laa.crime.enums.orchestration.StoredProcedure;
 import uk.gov.justice.laa.crime.orchestration.data.Constants;
 import uk.gov.justice.laa.crime.orchestration.data.builder.PassportAssessmentDataBuilder;
+import uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder;
+import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.AssessmentSummaryDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.PassportedDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.validation.UserActionDTO;
+import uk.gov.justice.laa.crime.orchestration.exception.MaatOrchestrationException;
+import uk.gov.justice.laa.crime.orchestration.mapper.ApplicationTrackingMapper;
+import uk.gov.justice.laa.crime.orchestration.mapper.PassportAssessmentMapper;
+import uk.gov.justice.laa.crime.orchestration.service.ApplicationService;
+import uk.gov.justice.laa.crime.orchestration.service.ApplicationTrackingDataService;
+import uk.gov.justice.laa.crime.orchestration.service.AssessmentSummaryService;
+import uk.gov.justice.laa.crime.orchestration.service.ContributionService;
+import uk.gov.justice.laa.crime.orchestration.service.MaatCourtDataService;
 import uk.gov.justice.laa.crime.orchestration.service.PassportAssessmentService;
+import uk.gov.justice.laa.crime.orchestration.service.ProceedingsService;
+import uk.gov.justice.laa.crime.orchestration.service.RepOrderService;
+import uk.gov.justice.laa.crime.orchestration.service.WorkflowPreProcessorService;
+import uk.gov.justice.laa.crime.util.DateUtil;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,6 +50,36 @@ class PassportAssessmentOrchestrationServiceTest {
     @Mock
     private PassportAssessmentService passportAssessmentService;
 
+    @Mock
+    private RepOrderService repOrderService;
+
+    @Mock
+    private PassportAssessmentMapper passportAssessmentMapper;
+
+    @Mock
+    private WorkflowPreProcessorService workflowPreProcessorService;
+
+    @Mock
+    private MaatCourtDataService maatCourtDataService;
+
+    @Mock
+    private ProceedingsService proceedingsService;
+
+    @Mock
+    private ContributionService contributionService;
+
+    @Mock
+    private AssessmentSummaryService assessmentSummaryService;
+
+    @Mock
+    private ApplicationService applicationService;
+
+    @Mock
+    private ApplicationTrackingMapper applicationTrackingMapper;
+
+    @Mock
+    private ApplicationTrackingDataService applicationTrackingDataService;
+
     @InjectMocks
     private PassportAssessmentOrchestrationService passportAssessmentOrchestrationService;
 
@@ -31,5 +91,188 @@ class PassportAssessmentOrchestrationServiceTest {
 
         assertThat(passportAssessmentOrchestrationService.find(Constants.PASSPORT_ASSESSMENT_ID))
                 .isEqualTo(dto);
+    }
+
+    @Test
+    void givenValidWorkflowRequest_whenCreateIsInvoked_thenApplicationDTOIsUpdated() {
+        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
+        workflowRequest
+                .getApplicationDTO()
+                .setPassportedDTO(PassportAssessmentDataBuilder.getPassportedDTO(Constants.WITHOUT_PARTNER));
+        RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTO("CURR");
+        LocalDateTime dateCompleted = Constants.ASSESSMENT_COMPLETED_DATETIME;
+        RepOrderDTO updatedRepOrderDTO = TestModelDataBuilder.buildRepOrderDTO("CURR");
+        updatedRepOrderDTO.setAssessmentDateCompleted(DateUtil.parseLocalDate(dateCompleted));
+        ApplicationDTO updatedApplicationDTO = workflowRequest.getApplicationDTO();
+        updatedApplicationDTO.getPassportedDTO().setTimestamp(dateCompleted.atZone(ZoneId.systemDefault()));
+        ApplicationDTO furtherUpdatedApplicationDTO = workflowRequest.getApplicationDTO();
+        furtherUpdatedApplicationDTO
+                .getCrownCourtOverviewDTO()
+                .setContribution(TestModelDataBuilder.getContributionsDTO());
+
+        when(repOrderService.getRepOrder(workflowRequest)).thenReturn(repOrderDTO);
+        when(passportAssessmentMapper.getUserActionDTO(workflowRequest))
+                .thenReturn(TestModelDataBuilder.getUserActionDTO());
+        when(passportAssessmentService.create(workflowRequest)).thenReturn(Constants.PASSPORT_ASSESSMENT_ID);
+        when(repOrderService.updateRepOrderAssessmentDateCompleted(
+                        eq(workflowRequest), eq(repOrderDTO), any(LocalDateTime.class)))
+                .thenReturn(updatedRepOrderDTO);
+        when(maatCourtDataService.invokeStoredProcedure(
+                        workflowRequest.getApplicationDTO(),
+                        workflowRequest.getUserDTO(),
+                        StoredProcedure.MANAGE_PASSPORT_EVIDENCE))
+                .thenReturn(updatedApplicationDTO);
+        when(contributionService.calculate(workflowRequest)).thenReturn(furtherUpdatedApplicationDTO);
+        when(assessmentSummaryService.getSummary(
+                        workflowRequest.getApplicationDTO().getPassportedDTO()))
+                .thenReturn(TestModelDataBuilder.getAssessmentSummaryDTOFromPassportedDTO());
+        when(applicationTrackingMapper.build(
+                        workflowRequest, updatedRepOrderDTO, AssessmentType.PASSPORT, RequestSource.PASSPORT_IOJ))
+                .thenReturn(TestModelDataBuilder.getApplicationTrackingOutputResult());
+
+        ApplicationDTO returnedApplicationDTO = passportAssessmentOrchestrationService.create(workflowRequest);
+
+        verify(workflowPreProcessorService)
+                .preProcessPassportRequest(
+                        any(WorkflowRequest.class), any(RepOrderDTO.class), any(UserActionDTO.class));
+        verify(proceedingsService).determineMagsRepDecision(any(WorkflowRequest.class));
+        verify(proceedingsService).updateApplication(any(WorkflowRequest.class), any(RepOrderDTO.class));
+        verify(assessmentSummaryService).updateApplication(any(ApplicationDTO.class), any(AssessmentSummaryDTO.class));
+        verify(applicationService).updateDateModified(any(WorkflowRequest.class), any(ApplicationDTO.class));
+        verify(applicationTrackingDataService).sendTrackingOutputResult(any(ApplicationTrackingOutputResult.class));
+
+        assertThat(returnedApplicationDTO.getPassportedDTO().getTimestamp())
+                .isEqualTo(dateCompleted.atZone(ZoneId.systemDefault()));
+        assertThat(returnedApplicationDTO
+                        .getCrownCourtOverviewDTO()
+                        .getContribution()
+                        .getId())
+                .isEqualTo(Long.valueOf(Constants.CONTRIBUTIONS_ID));
+    }
+
+    @Test
+    void givenNoRepOrderRetrieved_whenCreateIsInvoked_thenExceptionIsThrown() {
+        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
+
+        when(repOrderService.getRepOrder(workflowRequest)).thenReturn(null);
+
+        assertThatThrownBy(() -> passportAssessmentOrchestrationService.create(workflowRequest))
+                .isInstanceOf(MaatOrchestrationException.class);
+    }
+
+    @Test
+    void givenWorkReasonNotFMA_whenCreateIsInvoked_thenMatrixAndCorrespondenceStoredProcedureIsCalled() {
+        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
+        RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTO("CURR");
+        LocalDateTime dateCompleted = Constants.ASSESSMENT_COMPLETED_DATETIME;
+        RepOrderDTO updatedRepOrderDTO = TestModelDataBuilder.buildRepOrderDTO("CURR");
+        updatedRepOrderDTO.setAssessmentDateCompleted(DateUtil.parseLocalDate(dateCompleted));
+        ApplicationDTO updatedApplicationDTO = workflowRequest.getApplicationDTO();
+        updatedApplicationDTO.getPassportedDTO().setTimestamp(dateCompleted.atZone(ZoneId.systemDefault()));
+        ApplicationDTO furtherUpdatedApplicationDTO = workflowRequest.getApplicationDTO();
+        furtherUpdatedApplicationDTO
+                .getCrownCourtOverviewDTO()
+                .setContribution(TestModelDataBuilder.getContributionsDTO());
+
+        when(repOrderService.getRepOrder(workflowRequest)).thenReturn(repOrderDTO);
+        when(passportAssessmentMapper.getUserActionDTO(workflowRequest))
+                .thenReturn(TestModelDataBuilder.getUserActionDTO());
+        when(passportAssessmentService.create(workflowRequest)).thenReturn(Constants.PASSPORT_ASSESSMENT_ID);
+        when(repOrderService.updateRepOrderAssessmentDateCompleted(
+                        eq(workflowRequest), eq(repOrderDTO), any(LocalDateTime.class)))
+                .thenReturn(updatedRepOrderDTO);
+        when(maatCourtDataService.invokeStoredProcedure(
+                        workflowRequest.getApplicationDTO(),
+                        workflowRequest.getUserDTO(),
+                        StoredProcedure.MANAGE_PASSPORT_EVIDENCE))
+                .thenReturn(updatedApplicationDTO);
+        when(contributionService.calculate(workflowRequest)).thenReturn(furtherUpdatedApplicationDTO);
+        when(maatCourtDataService.invokeStoredProcedure(
+                        workflowRequest.getApplicationDTO(),
+                        workflowRequest.getUserDTO(),
+                        StoredProcedure.PROCESS_ACTIVITY_AND_GET_CORRESPONDENCE))
+                .thenReturn(furtherUpdatedApplicationDTO);
+        when(assessmentSummaryService.getSummary(
+                        workflowRequest.getApplicationDTO().getPassportedDTO()))
+                .thenReturn(TestModelDataBuilder.getAssessmentSummaryDTOFromPassportedDTO());
+        when(applicationTrackingMapper.build(
+                        workflowRequest, updatedRepOrderDTO, AssessmentType.PASSPORT, RequestSource.PASSPORT_IOJ))
+                .thenReturn(TestModelDataBuilder.getApplicationTrackingOutputResult());
+
+        ApplicationDTO returnedApplicationDTO = passportAssessmentOrchestrationService.create(workflowRequest);
+
+        verify(workflowPreProcessorService)
+                .preProcessPassportRequest(
+                        any(WorkflowRequest.class), any(RepOrderDTO.class), any(UserActionDTO.class));
+        verify(proceedingsService).determineMagsRepDecision(any(WorkflowRequest.class));
+        verify(proceedingsService).updateApplication(any(WorkflowRequest.class), any(RepOrderDTO.class));
+        verify(assessmentSummaryService).updateApplication(any(ApplicationDTO.class), any(AssessmentSummaryDTO.class));
+        verify(applicationService).updateDateModified(any(WorkflowRequest.class), any(ApplicationDTO.class));
+        verify(applicationTrackingDataService).sendTrackingOutputResult(any(ApplicationTrackingOutputResult.class));
+
+        assertThat(returnedApplicationDTO.getPassportedDTO().getTimestamp())
+                .isEqualTo(dateCompleted.atZone(ZoneId.systemDefault()));
+        assertThat(returnedApplicationDTO
+                        .getCrownCourtOverviewDTO()
+                        .getContribution()
+                        .getId())
+                .isEqualTo(Long.valueOf(Constants.CONTRIBUTIONS_ID));
+    }
+
+    @Test
+    void givenNoApplicationTrackingLink_whenCreateIsInvoked_thenApplicationTrackingNotUpdated() {
+        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
+        workflowRequest
+                .getApplicationDTO()
+                .setPassportedDTO(PassportAssessmentDataBuilder.getPassportedDTO(Constants.WITHOUT_PARTNER));
+        RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTO("CURR");
+        LocalDateTime dateCompleted = Constants.ASSESSMENT_COMPLETED_DATETIME;
+        RepOrderDTO updatedRepOrderDTO = TestModelDataBuilder.buildRepOrderDTO("CURR");
+        updatedRepOrderDTO.setAssessmentDateCompleted(DateUtil.parseLocalDate(dateCompleted));
+        ApplicationDTO updatedApplicationDTO = workflowRequest.getApplicationDTO();
+        updatedApplicationDTO.getPassportedDTO().setTimestamp(dateCompleted.atZone(ZoneId.systemDefault()));
+        ApplicationDTO furtherUpdatedApplicationDTO = workflowRequest.getApplicationDTO();
+        furtherUpdatedApplicationDTO
+                .getCrownCourtOverviewDTO()
+                .setContribution(TestModelDataBuilder.getContributionsDTO());
+
+        when(repOrderService.getRepOrder(workflowRequest)).thenReturn(repOrderDTO);
+        when(passportAssessmentMapper.getUserActionDTO(workflowRequest))
+                .thenReturn(TestModelDataBuilder.getUserActionDTO());
+        when(passportAssessmentService.create(workflowRequest)).thenReturn(Constants.PASSPORT_ASSESSMENT_ID);
+        when(repOrderService.updateRepOrderAssessmentDateCompleted(
+                        eq(workflowRequest), eq(repOrderDTO), any(LocalDateTime.class)))
+                .thenReturn(updatedRepOrderDTO);
+        when(maatCourtDataService.invokeStoredProcedure(
+                        workflowRequest.getApplicationDTO(),
+                        workflowRequest.getUserDTO(),
+                        StoredProcedure.MANAGE_PASSPORT_EVIDENCE))
+                .thenReturn(updatedApplicationDTO);
+        when(contributionService.calculate(workflowRequest)).thenReturn(furtherUpdatedApplicationDTO);
+        when(assessmentSummaryService.getSummary(
+                        workflowRequest.getApplicationDTO().getPassportedDTO()))
+                .thenReturn(TestModelDataBuilder.getAssessmentSummaryDTOFromPassportedDTO());
+        when(applicationTrackingMapper.build(
+                        workflowRequest, updatedRepOrderDTO, AssessmentType.PASSPORT, RequestSource.PASSPORT_IOJ))
+                .thenReturn(new ApplicationTrackingOutputResult());
+
+        ApplicationDTO returnedApplicationDTO = passportAssessmentOrchestrationService.create(workflowRequest);
+
+        verify(workflowPreProcessorService)
+                .preProcessPassportRequest(
+                        any(WorkflowRequest.class), any(RepOrderDTO.class), any(UserActionDTO.class));
+        verify(proceedingsService).determineMagsRepDecision(any(WorkflowRequest.class));
+        verify(proceedingsService).updateApplication(any(WorkflowRequest.class), any(RepOrderDTO.class));
+        verify(assessmentSummaryService).updateApplication(any(ApplicationDTO.class), any(AssessmentSummaryDTO.class));
+        verify(applicationService).updateDateModified(any(WorkflowRequest.class), any(ApplicationDTO.class));
+        verifyNoInteractions(applicationTrackingDataService);
+
+        assertThat(returnedApplicationDTO.getPassportedDTO().getTimestamp())
+                .isEqualTo(dateCompleted.atZone(ZoneId.systemDefault()));
+        assertThat(returnedApplicationDTO
+                        .getCrownCourtOverviewDTO()
+                        .getContribution()
+                        .getId())
+                .isEqualTo(Long.valueOf(Constants.CONTRIBUTIONS_ID));
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult;
 import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult.AssessmentType;
 import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult.RequestSource;
+import uk.gov.justice.laa.crime.enums.RepOrderStatus;
 import uk.gov.justice.laa.crime.enums.orchestration.StoredProcedure;
 import uk.gov.justice.laa.crime.orchestration.data.Constants;
 import uk.gov.justice.laa.crime.orchestration.data.builder.PassportAssessmentDataBuilder;
@@ -99,14 +100,14 @@ class PassportAssessmentOrchestrationServiceTest {
         workflowRequest
                 .getApplicationDTO()
                 .setPassportedDTO(PassportAssessmentDataBuilder.getPassportedDTO(Constants.WITHOUT_PARTNER));
-        RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTO("CURR");
+        RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTO(RepOrderStatus.CURR.getCode());
         LocalDateTime dateCompleted = Constants.ASSESSMENT_COMPLETED_DATETIME;
-        RepOrderDTO updatedRepOrderDTO = TestModelDataBuilder.buildRepOrderDTO("CURR");
+        RepOrderDTO updatedRepOrderDTO = TestModelDataBuilder.buildRepOrderDTO(RepOrderStatus.CURR.getCode());
         updatedRepOrderDTO.setAssessmentDateCompleted(DateUtil.parseLocalDate(dateCompleted));
-        ApplicationDTO updatedApplicationDTO = workflowRequest.getApplicationDTO();
-        updatedApplicationDTO.getPassportedDTO().setTimestamp(dateCompleted.atZone(ZoneId.systemDefault()));
-        ApplicationDTO furtherUpdatedApplicationDTO = workflowRequest.getApplicationDTO();
-        furtherUpdatedApplicationDTO
+        ApplicationDTO applicationDTOManagedEvidence = workflowRequest.getApplicationDTO();
+        applicationDTOManagedEvidence.getPassportedDTO().setTimestamp(dateCompleted.atZone(ZoneId.systemDefault()));
+        ApplicationDTO applicationDTOWithContributions = workflowRequest.getApplicationDTO();
+        applicationDTOWithContributions
                 .getCrownCourtOverviewDTO()
                 .setContribution(TestModelDataBuilder.getContributionsDTO());
 
@@ -121,8 +122,8 @@ class PassportAssessmentOrchestrationServiceTest {
                         workflowRequest.getApplicationDTO(),
                         workflowRequest.getUserDTO(),
                         StoredProcedure.MANAGE_PASSPORT_EVIDENCE))
-                .thenReturn(updatedApplicationDTO);
-        when(contributionService.calculate(workflowRequest)).thenReturn(furtherUpdatedApplicationDTO);
+                .thenReturn(applicationDTOManagedEvidence);
+        when(contributionService.calculate(workflowRequest)).thenReturn(applicationDTOWithContributions);
         when(assessmentSummaryService.getSummary(
                         workflowRequest.getApplicationDTO().getPassportedDTO()))
                 .thenReturn(TestModelDataBuilder.getAssessmentSummaryDTOFromPassportedDTO());
@@ -133,8 +134,7 @@ class PassportAssessmentOrchestrationServiceTest {
         ApplicationDTO returnedApplicationDTO = passportAssessmentOrchestrationService.create(workflowRequest);
 
         verify(workflowPreProcessorService)
-                .preProcessPassportRequest(
-                        any(WorkflowRequest.class), any(RepOrderDTO.class), any(UserActionDTO.class));
+                .validatePassportRequest(any(WorkflowRequest.class), any(RepOrderDTO.class), any(UserActionDTO.class));
         verify(proceedingsService).determineMagsRepDecision(any(WorkflowRequest.class));
         verify(proceedingsService).updateApplication(any(WorkflowRequest.class), any(RepOrderDTO.class));
         verify(assessmentSummaryService).updateApplication(any(ApplicationDTO.class), any(AssessmentSummaryDTO.class));
@@ -163,14 +163,14 @@ class PassportAssessmentOrchestrationServiceTest {
     @Test
     void givenWorkReasonNotFMA_whenCreateIsInvoked_thenMatrixAndCorrespondenceStoredProcedureIsCalled() {
         WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
-        RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTO("CURR");
+        RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTO(RepOrderStatus.CURR.getCode());
         LocalDateTime dateCompleted = Constants.ASSESSMENT_COMPLETED_DATETIME;
-        RepOrderDTO updatedRepOrderDTO = TestModelDataBuilder.buildRepOrderDTO("CURR");
+        RepOrderDTO updatedRepOrderDTO = TestModelDataBuilder.buildRepOrderDTO(RepOrderStatus.CURR.getCode());
         updatedRepOrderDTO.setAssessmentDateCompleted(DateUtil.parseLocalDate(dateCompleted));
-        ApplicationDTO updatedApplicationDTO = workflowRequest.getApplicationDTO();
-        updatedApplicationDTO.getPassportedDTO().setTimestamp(dateCompleted.atZone(ZoneId.systemDefault()));
-        ApplicationDTO furtherUpdatedApplicationDTO = workflowRequest.getApplicationDTO();
-        furtherUpdatedApplicationDTO
+        ApplicationDTO applicationDTOManagedEvidence = workflowRequest.getApplicationDTO();
+        applicationDTOManagedEvidence.getPassportedDTO().setTimestamp(dateCompleted.atZone(ZoneId.systemDefault()));
+        ApplicationDTO applicationDTOWithContributions = workflowRequest.getApplicationDTO();
+        applicationDTOWithContributions
                 .getCrownCourtOverviewDTO()
                 .setContribution(TestModelDataBuilder.getContributionsDTO());
 
@@ -185,13 +185,13 @@ class PassportAssessmentOrchestrationServiceTest {
                         workflowRequest.getApplicationDTO(),
                         workflowRequest.getUserDTO(),
                         StoredProcedure.MANAGE_PASSPORT_EVIDENCE))
-                .thenReturn(updatedApplicationDTO);
-        when(contributionService.calculate(workflowRequest)).thenReturn(furtherUpdatedApplicationDTO);
+                .thenReturn(applicationDTOManagedEvidence);
+        when(contributionService.calculate(workflowRequest)).thenReturn(applicationDTOWithContributions);
         when(maatCourtDataService.invokeStoredProcedure(
                         workflowRequest.getApplicationDTO(),
                         workflowRequest.getUserDTO(),
                         StoredProcedure.PROCESS_ACTIVITY_AND_GET_CORRESPONDENCE))
-                .thenReturn(furtherUpdatedApplicationDTO);
+                .thenReturn(applicationDTOWithContributions);
         when(assessmentSummaryService.getSummary(
                         workflowRequest.getApplicationDTO().getPassportedDTO()))
                 .thenReturn(TestModelDataBuilder.getAssessmentSummaryDTOFromPassportedDTO());
@@ -202,8 +202,7 @@ class PassportAssessmentOrchestrationServiceTest {
         ApplicationDTO returnedApplicationDTO = passportAssessmentOrchestrationService.create(workflowRequest);
 
         verify(workflowPreProcessorService)
-                .preProcessPassportRequest(
-                        any(WorkflowRequest.class), any(RepOrderDTO.class), any(UserActionDTO.class));
+                .validatePassportRequest(any(WorkflowRequest.class), any(RepOrderDTO.class), any(UserActionDTO.class));
         verify(proceedingsService).determineMagsRepDecision(any(WorkflowRequest.class));
         verify(proceedingsService).updateApplication(any(WorkflowRequest.class), any(RepOrderDTO.class));
         verify(assessmentSummaryService).updateApplication(any(ApplicationDTO.class), any(AssessmentSummaryDTO.class));
@@ -225,14 +224,14 @@ class PassportAssessmentOrchestrationServiceTest {
         workflowRequest
                 .getApplicationDTO()
                 .setPassportedDTO(PassportAssessmentDataBuilder.getPassportedDTO(Constants.WITHOUT_PARTNER));
-        RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTO("CURR");
+        RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTO(RepOrderStatus.CURR.getCode());
         LocalDateTime dateCompleted = Constants.ASSESSMENT_COMPLETED_DATETIME;
-        RepOrderDTO updatedRepOrderDTO = TestModelDataBuilder.buildRepOrderDTO("CURR");
+        RepOrderDTO updatedRepOrderDTO = TestModelDataBuilder.buildRepOrderDTO(RepOrderStatus.CURR.getCode());
         updatedRepOrderDTO.setAssessmentDateCompleted(DateUtil.parseLocalDate(dateCompleted));
-        ApplicationDTO updatedApplicationDTO = workflowRequest.getApplicationDTO();
-        updatedApplicationDTO.getPassportedDTO().setTimestamp(dateCompleted.atZone(ZoneId.systemDefault()));
-        ApplicationDTO furtherUpdatedApplicationDTO = workflowRequest.getApplicationDTO();
-        furtherUpdatedApplicationDTO
+        ApplicationDTO applicationDTOManagedEvidence = workflowRequest.getApplicationDTO();
+        applicationDTOManagedEvidence.getPassportedDTO().setTimestamp(dateCompleted.atZone(ZoneId.systemDefault()));
+        ApplicationDTO applicationDTOWithContributions = workflowRequest.getApplicationDTO();
+        applicationDTOWithContributions
                 .getCrownCourtOverviewDTO()
                 .setContribution(TestModelDataBuilder.getContributionsDTO());
 
@@ -247,8 +246,8 @@ class PassportAssessmentOrchestrationServiceTest {
                         workflowRequest.getApplicationDTO(),
                         workflowRequest.getUserDTO(),
                         StoredProcedure.MANAGE_PASSPORT_EVIDENCE))
-                .thenReturn(updatedApplicationDTO);
-        when(contributionService.calculate(workflowRequest)).thenReturn(furtherUpdatedApplicationDTO);
+                .thenReturn(applicationDTOManagedEvidence);
+        when(contributionService.calculate(workflowRequest)).thenReturn(applicationDTOWithContributions);
         when(assessmentSummaryService.getSummary(
                         workflowRequest.getApplicationDTO().getPassportedDTO()))
                 .thenReturn(TestModelDataBuilder.getAssessmentSummaryDTOFromPassportedDTO());
@@ -259,8 +258,7 @@ class PassportAssessmentOrchestrationServiceTest {
         ApplicationDTO returnedApplicationDTO = passportAssessmentOrchestrationService.create(workflowRequest);
 
         verify(workflowPreProcessorService)
-                .preProcessPassportRequest(
-                        any(WorkflowRequest.class), any(RepOrderDTO.class), any(UserActionDTO.class));
+                .validatePassportRequest(any(WorkflowRequest.class), any(RepOrderDTO.class), any(UserActionDTO.class));
         verify(proceedingsService).determineMagsRepDecision(any(WorkflowRequest.class));
         verify(proceedingsService).updateApplication(any(WorkflowRequest.class), any(RepOrderDTO.class));
         verify(assessmentSummaryService).updateApplication(any(ApplicationDTO.class), any(AssessmentSummaryDTO.class));

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/utils/WiremockStubs.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/utils/WiremockStubs.java
@@ -195,6 +195,13 @@ public class WiremockStubs {
                         .withBody(response)));
     }
 
+    public static void stubForCreatePassportAssessment(String response) {
+        stubFor(post(urlMatching(PASSPORT_URL))
+                .willReturn(WireMock.ok()
+                        .withHeader("Content-Type", String.valueOf(MediaType.APPLICATION_JSON))
+                        .withBody(response)));
+    }
+
     public static void stubForFindPassportEvidence(String response) {
         stubFor(get(urlMatching(EVIDENCE_URL + "/passport/" + Constants.PASSPORT_ASSESSMENT_ID))
                 .willReturn(WireMock.ok()


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/projects/LCAM/boards/881?selectedIssue=LCAM-1982)

Added a new endpoint to orchestrate the creation of passport assessments through calling the Crime Assessment Service and then handling all post processing via calls to other services and legacy stored procedures.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.