### PR TITLE
[LCAM-1734] Replace determine_mags_rep_decision stored procedure call

### DIFF
--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/PassportAssessmentMapper.java
@@ -72,8 +72,6 @@ public class PassportAssessmentMapper {
                 .description(ASSESSMENT_STATUS_DESCRIPTION)
                 .build();
 
-        // TODO: Need to populate passportSummaryEvidenceDTO following completion of LCAM-2002
-        // TODO: Might need to amend mapping of legacy age related values following completion of LCAM-2016
         // Not setting dwpResult and dwpWhoChecked as these are no longer used in MAAT and so can left as null
         PassportedDTO dto = PassportedDTO.builder()
                 .passportedId(Long.valueOf(response.getLegacyAssessmentId()))

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/ProceedingsMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/ProceedingsMapper.java
@@ -69,8 +69,7 @@ public class ProceedingsMapper extends CrownCourtMapper {
                         CaseType.getFrom(applicationDTO.getCaseDetailsDTO().getCaseType()))
                 .withPassportAssessment(applicationDtoToPassportAssessment(applicationDTO))
                 .withIojAppeal(new ApiIOJSummary()
-                        .withDecisionResult(
-                                applicationDTO.getAssessmentDTO().getIojAppeal().getAppealDecisionResult())
+                        .withDecisionResult(getIojDecisionResult(applicationDTO))
                         .withIojResult(applicationDTO.getIojResult()))
                 .withFinancialAssessment(applicationDtoToFinancialAssessment(applicationDTO, CourtType.MAGISTRATE))
                 .withUserSession(userMapper.userDtoToUserSession(request.getUserDTO()));
@@ -195,7 +194,7 @@ public class ProceedingsMapper extends CrownCourtMapper {
     private ApiPassportAssessment applicationDtoToPassportAssessment(ApplicationDTO application) {
         PassportedDTO passported = application.getPassportedDTO();
 
-        if (passported.getPassportedId() != null) {
+        if (passported != null && passported.getPassportedId() != null) {
             return new ApiPassportAssessment()
                     .withResult(passported.getResult())
                     .withStatus(CurrentStatus.getFrom(
@@ -340,5 +339,18 @@ public class ProceedingsMapper extends CrownCourtMapper {
 
     CurrentStatus getCurrentStatus(String status) {
         return StringUtils.isNotBlank(status) ? CurrentStatus.getFrom(status) : null;
+    }
+
+    private String getIojDecisionResult(ApplicationDTO applicationDTO) {
+        if (applicationDTO.getAssessmentDTO().getIojAppeal().getAppealDecisionResult() != null
+                && !applicationDTO
+                        .getAssessmentDTO()
+                        .getIojAppeal()
+                        .getAppealDecisionResult()
+                        .isBlank()) {
+            return applicationDTO.getAssessmentDTO().getIojAppeal().getAppealDecisionResult();
+        }
+
+        return null;
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/ProceedingsMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/ProceedingsMapper.java
@@ -35,6 +35,7 @@ import uk.gov.justice.laa.crime.orchestration.dto.maat.FinancialAssessmentDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.FullAssessmentDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.HardshipOverviewDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.HardshipReviewDTO;
+import uk.gov.justice.laa.crime.orchestration.dto.maat.IOJAppealDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.IncomeEvidenceSummaryDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.InitialAssessmentDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.OutcomeDTO;
@@ -69,7 +70,8 @@ public class ProceedingsMapper extends CrownCourtMapper {
                         CaseType.getFrom(applicationDTO.getCaseDetailsDTO().getCaseType()))
                 .withPassportAssessment(applicationDtoToPassportAssessment(applicationDTO))
                 .withIojAppeal(new ApiIOJSummary()
-                        .withDecisionResult(getIojDecisionResult(applicationDTO))
+                        .withDecisionResult(getIojDecisionResult(
+                                applicationDTO.getAssessmentDTO().getIojAppeal()))
                         .withIojResult(applicationDTO.getIojResult()))
                 .withFinancialAssessment(applicationDtoToFinancialAssessment(applicationDTO, CourtType.MAGISTRATE))
                 .withUserSession(userMapper.userDtoToUserSession(request.getUserDTO()));
@@ -341,16 +343,8 @@ public class ProceedingsMapper extends CrownCourtMapper {
         return StringUtils.isNotBlank(status) ? CurrentStatus.getFrom(status) : null;
     }
 
-    private String getIojDecisionResult(ApplicationDTO applicationDTO) {
-        if (applicationDTO.getAssessmentDTO().getIojAppeal().getAppealDecisionResult() != null
-                && !applicationDTO
-                        .getAssessmentDTO()
-                        .getIojAppeal()
-                        .getAppealDecisionResult()
-                        .isBlank()) {
-            return applicationDTO.getAssessmentDTO().getIojAppeal().getAppealDecisionResult();
-        }
-
-        return null;
+    private String getIojDecisionResult(IOJAppealDTO iojAppeal) {
+        String result = iojAppeal.getAppealDecisionResult();
+        return (result == null || result.isBlank()) ? null : result;
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/HardshipOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/HardshipOrchestrationService.java
@@ -93,6 +93,7 @@ public class HardshipOrchestrationService implements AssessmentOrchestrator<Hard
                 }
             }
 
+            applicationService.updateDateModified(request, application);
             // Update assessment summary view - displayed on the application tab
             AssessmentSummaryDTO hardshipSummary = assessmentSummaryService.getSummary(newHardship, courtType);
             assessmentSummaryService.updateApplication(application, hardshipSummary);
@@ -135,6 +136,7 @@ public class HardshipOrchestrationService implements AssessmentOrchestrator<Hard
                 }
             }
 
+            applicationService.updateDateModified(request, request.getApplicationDTO());
             // Update assessment summary view - displayed on the application tab
             AssessmentSummaryDTO hardshipSummary = assessmentSummaryService.getSummary(hardshipReviewDTO, courtType);
             assessmentSummaryService.updateApplication(request.getApplicationDTO(), hardshipSummary);
@@ -155,9 +157,7 @@ public class HardshipOrchestrationService implements AssessmentOrchestrator<Hard
     }
 
     private ApplicationDTO processMagCourtHardshipRules(WorkflowRequest request) {
-        // call assessments.determine_mags_rep_decision stored procedure
-        request.setApplicationDTO(maatCourtDataService.invokeStoredProcedure(
-                request.getApplicationDTO(), request.getUserDTO(), StoredProcedure.DETERMINE_MAGS_REP_DECISION));
+        request.setApplicationDTO(proceedingsService.determineMagsRepDecision(request));
         if (contributionService.isVariationRequired(request.getApplicationDTO())) {
             return contributionService.calculate(request);
         }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/HardshipOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/HardshipOrchestrationService.java
@@ -68,7 +68,7 @@ public class HardshipOrchestrationService implements AssessmentOrchestrator<Hard
         ApplicationDTO application = request.getApplicationDTO();
 
         ApiPerformHardshipResponse performHardshipResponse = hardshipService.create(request);
-        applicationService.updateDateModified(request, application);
+
         try {
             // Need to refresh from DB as HardshipDetail ids may have changed
             HardshipReviewDTO newHardship = hardshipService.find(performHardshipResponse.getHardshipReviewId());
@@ -93,7 +93,6 @@ public class HardshipOrchestrationService implements AssessmentOrchestrator<Hard
                 }
             }
 
-            applicationService.updateDateModified(request, application);
             // Update assessment summary view - displayed on the application tab
             AssessmentSummaryDTO hardshipSummary = assessmentSummaryService.getSummary(newHardship, courtType);
             assessmentSummaryService.updateApplication(application, hardshipSummary);
@@ -102,6 +101,8 @@ public class HardshipOrchestrationService implements AssessmentOrchestrator<Hard
             hardshipService.rollback(request);
             Sentry.captureException(ex);
             throw new MaatOrchestrationException(request.getApplicationDTO());
+        } finally {
+            applicationService.updateDateModified(request, application);
         }
 
         return application;
@@ -118,7 +119,7 @@ public class HardshipOrchestrationService implements AssessmentOrchestrator<Hard
         validate(request, action, repOrderDTO);
 
         hardshipService.update(request);
-        applicationService.updateDateModified(request, request.getApplicationDTO());
+
         try {
             HardshipOverviewDTO hardshipOverviewDTO = request.getApplicationDTO()
                     .getAssessmentDTO()
@@ -136,7 +137,6 @@ public class HardshipOrchestrationService implements AssessmentOrchestrator<Hard
                 }
             }
 
-            applicationService.updateDateModified(request, request.getApplicationDTO());
             // Update assessment summary view - displayed on the application tab
             AssessmentSummaryDTO hardshipSummary = assessmentSummaryService.getSummary(hardshipReviewDTO, courtType);
             assessmentSummaryService.updateApplication(request.getApplicationDTO(), hardshipSummary);
@@ -145,6 +145,8 @@ public class HardshipOrchestrationService implements AssessmentOrchestrator<Hard
             hardshipService.rollback(request);
             Sentry.captureException(ex);
             throw new MaatOrchestrationException(request.getApplicationDTO());
+        } finally {
+            applicationService.updateDateModified(request, request.getApplicationDTO());
         }
 
         return request.getApplicationDTO();

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/TestModelDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/TestModelDataBuilder.java
@@ -946,10 +946,13 @@ public class TestModelDataBuilder {
                 .offenceDTO(getOffenceDTO())
                 .magsOutcomeDTO(getOutcomeDTO(courtType))
                 .statusDTO(getRepStatusDTO())
+                .repOrderDecision(getRepOrderDecisionDTO())
                 .timestamp(APPLICATION_TIMESTAMP)
                 .assessmentDTO(AssessmentDTO.builder()
                         .financialAssessmentDTO(getFinancialAssessmentDTO(courtType))
+                        .iojAppeal(getIOJAppealDTO())
                         .build())
+                .caseDetailsDTO(getCaseDetailDTO())
                 .build();
     }
 

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/integration/HardshipIntegrationTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/integration/HardshipIntegrationTest.java
@@ -335,8 +335,6 @@ class HardshipIntegrationTest extends WiremockIntegrationTest {
         assertStubForCalculateContributions(1);
         assertStubForGetContributionsSummary(1, repId);
         if (CourtType.CROWN_COURT.equals(courtType)) {
-            // TODO: Uncomment this assertion for application tracking before activating hardship orchestration
-            // assertStubForHandleEformSerivce(1);
             assertStubForInvokeStoredProcedure(4);
         } else {
             assertStubForCheckContributionsRule(1);
@@ -350,9 +348,5 @@ class HardshipIntegrationTest extends WiremockIntegrationTest {
         assertStubForCheckContributionsRule(1);
         assertStubForCalculateContributions(1);
         assertStubForGetContributionsSummary(1, repId);
-        if (CourtType.CROWN_COURT.equals(courtType)) {
-            // TODO: Uncomment this assertion for application tracking before activating hardship orchestration
-            // assertStubForHandleEformSerivce(1);
-        }
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/integration/HardshipIntegrationTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/integration/HardshipIntegrationTest.java
@@ -212,7 +212,7 @@ class HardshipIntegrationTest extends WiremockIntegrationTest {
                 .andExpect(jsonPath("$.crownCourtOverviewDTO.contribution.monthlyContribs")
                         .value(150.0));
 
-        verifyStubForUpdateHardship(CourtType.MAGISTRATE, TestModelDataBuilder.REP_ID);
+        verifyStubForUpdateHardship(TestModelDataBuilder.REP_ID);
     }
 
     @Test
@@ -342,7 +342,7 @@ class HardshipIntegrationTest extends WiremockIntegrationTest {
         }
     }
 
-    private static void verifyStubForUpdateHardship(CourtType courtType, Integer repId) {
+    private static void verifyStubForUpdateHardship(Integer repId) {
         verify(exactly(1), putRequestedFor(urlPathMatching("/api/internal/v1/hardship")));
         assertStubForInvokeStoredProcedure(1);
         assertStubForCheckContributionsRule(1);

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/integration/HardshipIntegrationTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/integration/HardshipIntegrationTest.java
@@ -21,6 +21,7 @@ import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.assertS
 import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.assertStubForInvokeStoredProcedure;
 import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.stubForCalculateContributions;
 import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.stubForCheckContributionsRule;
+import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.stubForDetermineMagsRepDecision;
 import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.stubForFindRepOrder;
 import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.stubForGetContributionsSummaries;
 import static uk.gov.justice.laa.crime.orchestration.utils.WiremockStubs.stubForGetUserSummary;
@@ -261,6 +262,8 @@ class HardshipIntegrationTest extends WiremockIntegrationTest {
                                 TestModelDataBuilder.getApiPerformHardshipResponse()))));
 
         stubForInvokeStoredProcedure(objectMapper.writeValueAsString(TestModelDataBuilder.getApplicationDTO()));
+        stubForDetermineMagsRepDecision(
+                objectMapper.writeValueAsString(TestModelDataBuilder.getDetermineMagsRepDecisionResponse()));
         stubForCheckContributionsRule();
         stubForCalculateContributions(
                 objectMapper.writeValueAsString(TestModelDataBuilder.getApiMaatCalculateContributionResponse()));
@@ -292,6 +295,8 @@ class HardshipIntegrationTest extends WiremockIntegrationTest {
                         .withHeader("Content-Type", String.valueOf(MediaType.APPLICATION_JSON))
                         .withBody(objectMapper.writeValueAsString(TestModelDataBuilder.getApiFindHardshipResponse()))));
         stubForInvokeStoredProcedure(objectMapper.writeValueAsString(TestModelDataBuilder.getApplicationDTO()));
+        stubForDetermineMagsRepDecision(
+                objectMapper.writeValueAsString(TestModelDataBuilder.getDetermineMagsRepDecisionResponse()));
         stubForCheckContributionsRule();
         stubForCalculateContributions(
                 objectMapper.writeValueAsString(TestModelDataBuilder.getApiMaatCalculateContributionResponse()));
@@ -335,13 +340,13 @@ class HardshipIntegrationTest extends WiremockIntegrationTest {
             assertStubForInvokeStoredProcedure(4);
         } else {
             assertStubForCheckContributionsRule(1);
-            assertStubForInvokeStoredProcedure(2);
+            assertStubForInvokeStoredProcedure(1);
         }
     }
 
     private static void verifyStubForUpdateHardship(CourtType courtType, Integer repId) {
         verify(exactly(1), putRequestedFor(urlPathMatching("/api/internal/v1/hardship")));
-        assertStubForInvokeStoredProcedure(2);
+        assertStubForInvokeStoredProcedure(1);
         assertStubForCheckContributionsRule(1);
         assertStubForCalculateContributions(1);
         assertStubForGetContributionsSummary(1, repId);

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/HardshipOrchestrationServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/HardshipOrchestrationServiceTest.java
@@ -163,7 +163,7 @@ class HardshipOrchestrationServiceTest {
                 .isEqualTo(getHardshipReviewDTO());
 
         verify(assessmentSummaryService).updateApplication(any(ApplicationDTO.class), any(AssessmentSummaryDTO.class));
-        verify(applicationService, times(2)).updateDateModified(eq(workflowRequest), any());
+        verify(applicationService, times(1)).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -188,7 +188,7 @@ class HardshipOrchestrationServiceTest {
         assertThat(expected.getCrownCourtOverviewDTO().getContribution()).isEqualTo(contributionsDTO);
 
         verify(assessmentSummaryService).updateApplication(any(ApplicationDTO.class), any(AssessmentSummaryDTO.class));
-        verify(applicationService, times(2)).updateDateModified(eq(workflowRequest), any());
+        verify(applicationService, times(1)).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -228,7 +228,7 @@ class HardshipOrchestrationServiceTest {
         verify(proceedingsService).updateApplication(workflowRequest, repOrderDTO);
 
         verify(assessmentSummaryService).updateApplication(any(ApplicationDTO.class), any(AssessmentSummaryDTO.class));
-        verify(applicationService, times(2)).updateDateModified(eq(workflowRequest), any());
+        verify(applicationService, times(1)).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -245,7 +245,7 @@ class HardshipOrchestrationServiceTest {
                         .getHardship()
                         .getCrownCourtHardship())
                 .isEqualTo(expected);
-        verify(applicationService, times(2)).updateDateModified(eq(workflowRequest), any());
+        verify(applicationService, times(1)).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -262,7 +262,7 @@ class HardshipOrchestrationServiceTest {
                         .getHardship()
                         .getCrownCourtHardship())
                 .isEqualTo(expected);
-        verify(applicationService, times(2)).updateDateModified(eq(workflowRequest), any());
+        verify(applicationService, times(1)).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -279,7 +279,7 @@ class HardshipOrchestrationServiceTest {
                         .getHardship()
                         .getMagCourtHardship())
                 .isEqualTo(expected);
-        verify(applicationService, times(2)).updateDateModified(eq(workflowRequest), any());
+        verify(applicationService, times(1)).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -296,7 +296,7 @@ class HardshipOrchestrationServiceTest {
                         .getHardship()
                         .getMagCourtHardship())
                 .isEqualTo(expected);
-        verify(applicationService, times(2)).updateDateModified(eq(workflowRequest), any());
+        verify(applicationService, times(1)).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -326,7 +326,7 @@ class HardshipOrchestrationServiceTest {
 
         assertThatThrownBy(() -> orchestrationService.create(workflowRequest))
                 .isInstanceOf(MaatOrchestrationException.class);
-        verify(applicationService, times(2)).updateDateModified(eq(workflowRequest), any());
+        verify(applicationService, times(1)).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -374,7 +374,7 @@ class HardshipOrchestrationServiceTest {
 
         assertThatThrownBy(() -> orchestrationService.create(workflowRequest))
                 .isInstanceOf(MaatOrchestrationException.class);
-        verify(applicationService, times(2)).updateDateModified(eq(workflowRequest), any());
+        verify(applicationService, times(1)).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -402,7 +402,7 @@ class HardshipOrchestrationServiceTest {
 
         verify(assessmentSummaryService).updateApplication(any(ApplicationDTO.class), any(AssessmentSummaryDTO.class));
 
-        verify(applicationService, times(2)).updateDateModified(eq(workflowRequest), any());
+        verify(applicationService, times(1)).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -433,7 +433,7 @@ class HardshipOrchestrationServiceTest {
 
         verify(assessmentSummaryService).updateApplication(any(ApplicationDTO.class), any(AssessmentSummaryDTO.class));
 
-        verify(applicationService, times(2)).updateDateModified(eq(workflowRequest), any());
+        verify(applicationService, times(1)).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -479,7 +479,7 @@ class HardshipOrchestrationServiceTest {
 
         verify(assessmentSummaryService).updateApplication(applicationDTO, assessmentSummaryDTO);
 
-        verify(applicationService, times(2)).updateDateModified(eq(workflowRequest), any());
+        verify(applicationService, times(1)).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -507,7 +507,7 @@ class HardshipOrchestrationServiceTest {
                         .getCrownCourtHardship())
                 .isEqualTo(expected);
 
-        verify(applicationService, times(2)).updateDateModified(eq(workflowRequest), any());
+        verify(applicationService, times(1)).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -534,7 +534,7 @@ class HardshipOrchestrationServiceTest {
                         .getCrownCourtHardship())
                 .isEqualTo(expected);
 
-        verify(applicationService, times(2)).updateDateModified(eq(workflowRequest), any());
+        verify(applicationService, times(1)).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -562,7 +562,7 @@ class HardshipOrchestrationServiceTest {
                         .getMagCourtHardship())
                 .isEqualTo(expected);
 
-        verify(applicationService, times(2)).updateDateModified(eq(workflowRequest), any());
+        verify(applicationService, times(1)).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -589,7 +589,7 @@ class HardshipOrchestrationServiceTest {
                         .getMagCourtHardship())
                 .isEqualTo(expected);
 
-        verify(applicationService, times(2)).updateDateModified(eq(workflowRequest), any());
+        verify(applicationService, times(1)).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/HardshipOrchestrationServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/HardshipOrchestrationServiceTest.java
@@ -149,8 +149,7 @@ class HardshipOrchestrationServiceTest {
     void givenIsMagsCourtAndNoVariation_whenCreateIsInvoked_thenApplicationDTOIsUpdatedWithNewHardship() {
         WorkflowRequest workflowRequest = setupCreateStubs(CourtType.MAGISTRATE, CurrentStatus.COMPLETE);
 
-        when(maatCourtDataService.invokeStoredProcedure(
-                        any(ApplicationDTO.class), any(UserDTO.class), any(StoredProcedure.class)))
+        when(proceedingsService.determineMagsRepDecision(workflowRequest))
                 .thenReturn(workflowRequest.getApplicationDTO());
         when(contributionService.isVariationRequired(any(ApplicationDTO.class))).thenReturn(false);
 
@@ -164,7 +163,7 @@ class HardshipOrchestrationServiceTest {
                 .isEqualTo(getHardshipReviewDTO());
 
         verify(assessmentSummaryService).updateApplication(any(ApplicationDTO.class), any(AssessmentSummaryDTO.class));
-        verify(applicationService).updateDateModified(eq(workflowRequest), any());
+        verify(applicationService, times(2)).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -174,10 +173,8 @@ class HardshipOrchestrationServiceTest {
         ContributionsDTO contributionsDTO = getContributionsDTO();
         ApplicationDTO applicationDTO = getApplicationDTOWithHardship(CourtType.MAGISTRATE);
         applicationDTO.getCrownCourtOverviewDTO().setContribution(contributionsDTO);
+        when(proceedingsService.determineMagsRepDecision(workflowRequest)).thenReturn(applicationDTO);
         when(contributionService.calculate(workflowRequest)).thenReturn(applicationDTO);
-        when(maatCourtDataService.invokeStoredProcedure(
-                        any(ApplicationDTO.class), any(UserDTO.class), any(StoredProcedure.class)))
-                .thenReturn(applicationDTO);
         when(contributionService.isVariationRequired(any(ApplicationDTO.class))).thenReturn(true);
 
         ApplicationDTO expected = orchestrationService.create(workflowRequest);
@@ -191,7 +188,7 @@ class HardshipOrchestrationServiceTest {
         assertThat(expected.getCrownCourtOverviewDTO().getContribution()).isEqualTo(contributionsDTO);
 
         verify(assessmentSummaryService).updateApplication(any(ApplicationDTO.class), any(AssessmentSummaryDTO.class));
-        verify(applicationService).updateDateModified(eq(workflowRequest), any());
+        verify(applicationService, times(2)).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -231,7 +228,7 @@ class HardshipOrchestrationServiceTest {
         verify(proceedingsService).updateApplication(workflowRequest, repOrderDTO);
 
         verify(assessmentSummaryService).updateApplication(any(ApplicationDTO.class), any(AssessmentSummaryDTO.class));
-        verify(applicationService).updateDateModified(eq(workflowRequest), any());
+        verify(applicationService, times(2)).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -248,7 +245,7 @@ class HardshipOrchestrationServiceTest {
                         .getHardship()
                         .getCrownCourtHardship())
                 .isEqualTo(expected);
-        verify(applicationService).updateDateModified(eq(workflowRequest), any());
+        verify(applicationService, times(2)).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -265,7 +262,7 @@ class HardshipOrchestrationServiceTest {
                         .getHardship()
                         .getCrownCourtHardship())
                 .isEqualTo(expected);
-        verify(applicationService).updateDateModified(eq(workflowRequest), any());
+        verify(applicationService, times(2)).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -282,7 +279,7 @@ class HardshipOrchestrationServiceTest {
                         .getHardship()
                         .getMagCourtHardship())
                 .isEqualTo(expected);
-        verify(applicationService).updateDateModified(eq(workflowRequest), any());
+        verify(applicationService, times(2)).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -299,7 +296,7 @@ class HardshipOrchestrationServiceTest {
                         .getHardship()
                         .getMagCourtHardship())
                 .isEqualTo(expected);
-        verify(applicationService).updateDateModified(eq(workflowRequest), any());
+        verify(applicationService, times(2)).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -329,7 +326,7 @@ class HardshipOrchestrationServiceTest {
 
         assertThatThrownBy(() -> orchestrationService.create(workflowRequest))
                 .isInstanceOf(MaatOrchestrationException.class);
-        verify(applicationService).updateDateModified(eq(workflowRequest), any());
+        verify(applicationService, times(2)).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -377,15 +374,14 @@ class HardshipOrchestrationServiceTest {
 
         assertThatThrownBy(() -> orchestrationService.create(workflowRequest))
                 .isInstanceOf(MaatOrchestrationException.class);
-        verify(applicationService).updateDateModified(eq(workflowRequest), any());
+        verify(applicationService, times(2)).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
     void givenMagsCourtAndNoVariation_whenUpdateIsInvoked_thenApplicationDTOIsUpdatedWithNewHardship() {
         WorkflowRequest workflowRequest = buildWorkflowRequestWithHardship(CourtType.MAGISTRATE);
 
-        when(maatCourtDataService.invokeStoredProcedure(
-                        any(ApplicationDTO.class), any(UserDTO.class), any(StoredProcedure.class)))
+        when(proceedingsService.determineMagsRepDecision(workflowRequest))
                 .thenReturn(workflowRequest.getApplicationDTO());
         when(contributionService.isVariationRequired(any(ApplicationDTO.class))).thenReturn(false);
 
@@ -406,7 +402,7 @@ class HardshipOrchestrationServiceTest {
 
         verify(assessmentSummaryService).updateApplication(any(ApplicationDTO.class), any(AssessmentSummaryDTO.class));
 
-        verify(applicationService).updateDateModified(eq(workflowRequest), any());
+        verify(applicationService, times(2)).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -416,10 +412,8 @@ class HardshipOrchestrationServiceTest {
         ContributionsDTO contributionsDTO = getContributionsDTO();
         ApplicationDTO applicationDTO = workflowRequest.getApplicationDTO();
         applicationDTO.getCrownCourtOverviewDTO().setContribution(contributionsDTO);
+        when(proceedingsService.determineMagsRepDecision(workflowRequest)).thenReturn(applicationDTO);
         when(contributionService.calculate(workflowRequest)).thenReturn(applicationDTO);
-        when(maatCourtDataService.invokeStoredProcedure(
-                        any(ApplicationDTO.class), any(UserDTO.class), any(StoredProcedure.class)))
-                .thenReturn(applicationDTO);
         when(contributionService.isVariationRequired(any(ApplicationDTO.class))).thenReturn(true);
 
         when(assessmentSummaryService.getSummary(any(HardshipReviewDTO.class), any()))
@@ -439,7 +433,7 @@ class HardshipOrchestrationServiceTest {
 
         verify(assessmentSummaryService).updateApplication(any(ApplicationDTO.class), any(AssessmentSummaryDTO.class));
 
-        verify(applicationService).updateDateModified(eq(workflowRequest), any());
+        verify(applicationService, times(2)).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -485,7 +479,7 @@ class HardshipOrchestrationServiceTest {
 
         verify(assessmentSummaryService).updateApplication(applicationDTO, assessmentSummaryDTO);
 
-        verify(applicationService).updateDateModified(eq(workflowRequest), any());
+        verify(applicationService, times(2)).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -513,7 +507,7 @@ class HardshipOrchestrationServiceTest {
                         .getCrownCourtHardship())
                 .isEqualTo(expected);
 
-        verify(applicationService).updateDateModified(eq(workflowRequest), any());
+        verify(applicationService, times(2)).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -540,7 +534,7 @@ class HardshipOrchestrationServiceTest {
                         .getCrownCourtHardship())
                 .isEqualTo(expected);
 
-        verify(applicationService).updateDateModified(eq(workflowRequest), any());
+        verify(applicationService, times(2)).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -568,7 +562,7 @@ class HardshipOrchestrationServiceTest {
                         .getMagCourtHardship())
                 .isEqualTo(expected);
 
-        verify(applicationService).updateDateModified(eq(workflowRequest), any());
+        verify(applicationService, times(2)).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test
@@ -595,7 +589,7 @@ class HardshipOrchestrationServiceTest {
                         .getMagCourtHardship())
                 .isEqualTo(expected);
 
-        verify(applicationService).updateDateModified(eq(workflowRequest), any());
+        verify(applicationService, times(2)).updateDateModified(eq(workflowRequest), any());
     }
 
     @Test


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1734)

We are now calling the modernised endpoint on Crown Court Proceeding instead of a stored procedure.

I added an additional call to updateDateModified on the application service for both Hardship create and update. There was an issue where the date is updated before it calls off to CCP to determine the mags rep decision. The date is updated again there - most of the time the same, but there were intermittent instances where there was a second difference, which was causing an "Application has been modified by another user" error. Hopefully this additional call after that CCP call will help resolve this.

I've also fixed a potential null pointer exception and updated some tests that broke as part of this change.