### PR TITLE
Lcam 1997 handle missing fields

### DIFF
--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/exception/CrimeValidationExceptionHandler.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/exception/CrimeValidationExceptionHandler.java
@@ -43,7 +43,7 @@ public class CrimeValidationExceptionHandler {
 
     @ExceptionHandler(CrimeValidationException.class)
     public ResponseEntity<ErrorDTO> handleCrimeValidationException(CrimeValidationException ex) {
-        String messages = "\n" + String.join(",\n",ex.getExceptionMessages());
+        String messages = "\n" + String.join(",\n", ex.getExceptionMessages());
         log.error("CrimeValidationException: XXX ", messages, ex);
         return buildErrorResponse(HttpStatus.BAD_REQUEST, new ArrayList<>(ex.getExceptionMessages()));
     }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/exception/CrimeValidationExceptionHandler.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/exception/CrimeValidationExceptionHandler.java
@@ -43,7 +43,8 @@ public class CrimeValidationExceptionHandler {
 
     @ExceptionHandler(CrimeValidationException.class)
     public ResponseEntity<ErrorDTO> handleCrimeValidationException(CrimeValidationException ex) {
-        log.error("CrimeValidationException: ", ex);
+        String messages = "\n" + String.join(",\n",ex.getExceptionMessages());
+        log.error("CrimeValidationException: XXX ", messages, ex);
         return buildErrorResponse(HttpStatus.BAD_REQUEST, new ArrayList<>(ex.getExceptionMessages()));
     }
 

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/exception/CrimeValidationExceptionHandler.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/exception/CrimeValidationExceptionHandler.java
@@ -21,10 +21,12 @@ public class CrimeValidationExceptionHandler {
 
     private final TraceIdHandler traceIdHandler;
 
-    private static ResponseEntity<ErrorDTO> buildErrorResponse(HttpStatus status, List<String> errorMessage) {
+    private static ResponseEntity<ErrorDTO> buildErrorResponse(
+            HttpStatus status, List<String> errorMessage, String traceId) {
         return new ResponseEntity<>(
                 ErrorDTO.builder()
                         .code(status.toString())
+                        .traceId(traceId)
                         .messageList(errorMessage)
                         .build(),
                 status);
@@ -43,9 +45,12 @@ public class CrimeValidationExceptionHandler {
 
     @ExceptionHandler(CrimeValidationException.class)
     public ResponseEntity<ErrorDTO> handleCrimeValidationException(CrimeValidationException ex) {
-        String messages = "\n" + String.join(",\n", ex.getExceptionMessages());
-        log.error("CrimeValidationException: XXX ", messages, ex);
-        return buildErrorResponse(HttpStatus.BAD_REQUEST, new ArrayList<>(ex.getExceptionMessages()));
+        log.error(
+                "CrimeValidationException with errors:\nMessages: {}",
+                String.join("\n", ex.getExceptionMessages()),
+                ex);
+        return buildErrorResponse(
+                HttpStatus.BAD_REQUEST, new ArrayList<>(ex.getExceptionMessages()), traceIdHandler.getTraceId());
     }
 
     @ExceptionHandler(ValidationException.class)

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/IojAppealMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/IojAppealMapper.java
@@ -21,6 +21,7 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Date;
+import java.util.function.Function;
 
 import org.springframework.stereotype.Component;
 
@@ -92,6 +93,16 @@ public class IojAppealMapper {
                 .build();
     }
 
+    /**
+     * NullSafe check.
+     * Check input is NOT-NULL before returning value, else null
+     * Useful for fluent interfaces
+     */
+    static <T, R> R nullSafe(T input, Function<T, R> extractor) {
+        if (input == null) return null;
+        return extractor.apply(input);
+    }
+
     public ApiCreateIojAppealRequest mapIojAppealDtoToApiCreateIojAppealRequest(WorkflowRequest request) {
 
         IOJAppealDTO iojAppealDto =
@@ -104,11 +115,10 @@ public class IojAppealMapper {
                 .toInstant()
                 .atZone(ZoneId.systemDefault())
                 .toLocalDate();
-        LocalDate decisionDate = iojAppealDto
-                .getDecisionDate()
-                .toInstant()
-                .atZone(ZoneId.systemDefault())
-                .toLocalDate();
+
+        LocalDate decisionDate = nullSafe(
+                iojAppealDto.getDecisionDate(),
+                d -> d.toInstant().atZone(ZoneId.systemDefault()).toLocalDate());
 
         IojAppeal iojAppeal = new IojAppeal()
                 .withReceivedDate(receivedDate)
@@ -138,11 +148,12 @@ public class IojAppealMapper {
     }
 
     public UserActionDTO getUserActionDTO(WorkflowRequest request) {
-        NewWorkReason newWorkReason = NewWorkReason.getFrom(request.getApplicationDTO()
+        String code = request.getApplicationDTO()
                 .getAssessmentDTO()
                 .getIojAppeal()
                 .getNewWorkReasonDTO()
-                .getCode());
+                .getCode();
+        NewWorkReason newWorkReason = NewWorkReason.getFrom(code);
 
         return userMapper.getUserActionDTO(request, Action.CREATE_IOJ, newWorkReason);
     }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/IojAppealService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/IojAppealService.java
@@ -9,10 +9,12 @@ import uk.gov.justice.laa.crime.common.model.ioj.ApiRollbackIojAppealResponse;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.IOJAppealDTO;
+import uk.gov.justice.laa.crime.orchestration.exception.CrimeValidationException;
 import uk.gov.justice.laa.crime.orchestration.exception.RollbackException;
 import uk.gov.justice.laa.crime.orchestration.mapper.IojAppealMapper;
-import uk.gov.justice.laa.crime.orchestration.mapper.UserMapper;
 import uk.gov.justice.laa.crime.orchestration.service.api.AssessmentApiService;
+
+import java.util.List;
 
 import org.springframework.stereotype.Service;
 
@@ -23,7 +25,6 @@ public class IojAppealService {
 
     private final AssessmentApiService assessmentApiService;
     private final IojAppealMapper iojAppealMapper;
-    private final UserMapper userMapper;
 
     public IOJAppealDTO find(int appealId) {
         ApiGetIojAppealResponse response = assessmentApiService.findIojAppeal(appealId);
@@ -34,14 +35,19 @@ public class IojAppealService {
     public String create(WorkflowRequest request) {
         ApplicationDTO applicationDTO = request.getApplicationDTO();
         IOJAppealDTO iojAppealDto = applicationDTO.getAssessmentDTO().getIojAppeal();
-
-        ApiCreateIojAppealRequest iojAppealRequest =
-                iojAppealMapper.mapIojAppealDtoToApiCreateIojAppealRequest(request);
+        ApiCreateIojAppealRequest iojAppealRequest = mapCreateRequest(request);
         ApiCreateIojAppealResponse iojAppealResponse = assessmentApiService.createIojAppeal(iojAppealRequest);
-
         iojAppealDto.setIojId(iojAppealResponse.getLegacyAppealId().longValue());
-
         return iojAppealResponse.getAppealId();
+    }
+
+    private ApiCreateIojAppealRequest mapCreateRequest(WorkflowRequest request) {
+        try {
+            return iojAppealMapper.mapIojAppealDtoToApiCreateIojAppealRequest(request);
+        } catch (NullPointerException | IllegalArgumentException ex) {
+            log.error("Failed to map IOJ appeal create request.\nRequest: {}", request, ex);
+            throw new CrimeValidationException(List.of("IOJ appeal request is missing required fields"));
+        }
     }
 
     public void rollback(String appealId, WorkflowRequest request) {

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/IojAppealsOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/IojAppealsOrchestrationService.java
@@ -13,7 +13,6 @@ import uk.gov.justice.laa.crime.orchestration.dto.maat.AssessmentSummaryDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.IOJAppealDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.validation.UserActionDTO;
-import uk.gov.justice.laa.crime.orchestration.exception.CrimeValidationException;
 import uk.gov.justice.laa.crime.orchestration.exception.MaatOrchestrationException;
 import uk.gov.justice.laa.crime.orchestration.exception.RollbackException;
 import uk.gov.justice.laa.crime.orchestration.mapper.ApplicationTrackingMapper;
@@ -27,9 +26,6 @@ import uk.gov.justice.laa.crime.orchestration.service.MaatCourtDataService;
 import uk.gov.justice.laa.crime.orchestration.service.ProceedingsService;
 import uk.gov.justice.laa.crime.orchestration.service.RepOrderService;
 import uk.gov.justice.laa.crime.orchestration.service.WorkflowPreProcessorService;
-
-import java.util.List;
-import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 
@@ -63,21 +59,9 @@ public class IojAppealsOrchestrationService {
             throw new MaatOrchestrationException(request.getApplicationDTO());
         }
 
-        String appealId;
-        try {
-            UserActionDTO userActionDTO = iojAppealMapper.getUserActionDTO(request);
-            workflowPreProcessorService.preProcessRequest(request, repOrderDto, userActionDTO);
-            appealId = iojAppealService.create(request);
-        } catch (NullPointerException npe) {
-            UUID uuid = UUID.randomUUID();
-            log.error(
-                    "Required iojAppeal fields missing in request: UUID: {},\n Exception: {},\n Request: {}",
-                    uuid,
-                    npe,
-                    request);
-            throw new CrimeValidationException(
-                    List.of(String.format("IOJ-Appeal missing required fields, report with %s", uuid)));
-        }
+        UserActionDTO userActionDTO = iojAppealMapper.getUserActionDTO(request);
+        workflowPreProcessorService.preProcessRequest(request, repOrderDto, userActionDTO);
+        String appealId = iojAppealService.create(request);
 
         try {
             proceedingsService.determineMagsRepDecision(request);

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/IojAppealsOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/IojAppealsOrchestrationService.java
@@ -63,11 +63,10 @@ public class IojAppealsOrchestrationService {
             throw new MaatOrchestrationException(request.getApplicationDTO());
         }
 
-        UserActionDTO userActionDTO = iojAppealMapper.getUserActionDTO(request);
-        workflowPreProcessorService.preProcessRequest(request, repOrderDto, userActionDTO);
-
         String appealId;
         try {
+            UserActionDTO userActionDTO = iojAppealMapper.getUserActionDTO(request);
+            workflowPreProcessorService.preProcessRequest(request, repOrderDto, userActionDTO);
             appealId = iojAppealService.create(request);
         } catch (NullPointerException npe) {
             UUID uuid = UUID.randomUUID();

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/IojAppealsOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/IojAppealsOrchestrationService.java
@@ -7,7 +7,6 @@ import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputR
 import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult.AssessmentType;
 import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult.RequestSource;
 import uk.gov.justice.laa.crime.enums.orchestration.StoredProcedure;
-import uk.gov.justice.laa.crime.exception.ValidationException;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.AssessmentSummaryDTO;
@@ -29,8 +28,6 @@ import uk.gov.justice.laa.crime.orchestration.service.ProceedingsService;
 import uk.gov.justice.laa.crime.orchestration.service.RepOrderService;
 import uk.gov.justice.laa.crime.orchestration.service.WorkflowPreProcessorService;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -70,12 +67,17 @@ public class IojAppealsOrchestrationService {
         workflowPreProcessorService.preProcessRequest(request, repOrderDto, userActionDTO);
 
         String appealId;
-        try{
-             appealId = iojAppealService.create(request);
-        } catch (NullPointerException npe){
+        try {
+            appealId = iojAppealService.create(request);
+        } catch (NullPointerException npe) {
             UUID uuid = UUID.randomUUID();
-            log.error("Required iojAppeal fields missing in request: UUID: {},\n Exception: {},\n Request: {}", uuid, npe, request);
-            throw new CrimeValidationException(List.of(String.format("IOJ-Appeal missing required fields, report with %s", uuid)));
+            log.error(
+                    "Required iojAppeal fields missing in request: UUID: {},\n Exception: {},\n Request: {}",
+                    uuid,
+                    npe,
+                    request);
+            throw new CrimeValidationException(
+                    List.of(String.format("IOJ-Appeal missing required fields, report with %s", uuid)));
         }
 
         try {

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/IojAppealsOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/IojAppealsOrchestrationService.java
@@ -7,6 +7,7 @@ import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputR
 import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult.AssessmentType;
 import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult.RequestSource;
 import uk.gov.justice.laa.crime.enums.orchestration.StoredProcedure;
+import uk.gov.justice.laa.crime.exception.ValidationException;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.AssessmentSummaryDTO;
@@ -26,6 +27,9 @@ import uk.gov.justice.laa.crime.orchestration.service.MaatCourtDataService;
 import uk.gov.justice.laa.crime.orchestration.service.ProceedingsService;
 import uk.gov.justice.laa.crime.orchestration.service.RepOrderService;
 import uk.gov.justice.laa.crime.orchestration.service.WorkflowPreProcessorService;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import org.springframework.stereotype.Service;
 
@@ -51,6 +55,9 @@ public class IojAppealsOrchestrationService {
     }
 
     public ApplicationDTO create(WorkflowRequest request) {
+
+        validateRequiredCreateFields(request);
+
         RepOrderDTO repOrderDto = repOrderService.getRepOrder(request);
 
         if (repOrderDto == null) {
@@ -108,5 +115,74 @@ public class IojAppealsOrchestrationService {
         }
 
         return request.getApplicationDTO();
+    }
+
+    /**
+     * Utility function
+     * Adds field to missingFields
+     * returns inverse of failureCondition
+     *
+     * @param fieldName
+     * @param failureCondition
+     * @param list
+     * @return
+     */
+    static boolean checkValid(String fieldName, boolean failureCondition, List<String> list) {
+        if (failureCondition) {
+            list.add(fieldName);
+        }
+        return !failureCondition;
+    }
+
+    /**
+     * Validate fields required to create Appeal.
+     * Service will return status 400, through {@code CrimeValidationExceptionHandler}
+     */
+    private void validateRequiredCreateFields(WorkflowRequest request) {
+        List<String> missingFields = new ArrayList<>();
+
+        ApplicationDTO applicationDTO = request != null ? request.getApplicationDTO() : null;
+        if (checkValid("applicationDTO", applicationDTO == null, missingFields)) {
+            checkValid("applicationDTO.repId", applicationDTO.getRepId() == null, missingFields);
+            checkValid("applicationDTO.dateReceived", applicationDTO.getDateReceived() == null, missingFields);
+            if (checkValid("applicationDTO.assessmentDTO", applicationDTO.getAssessmentDTO() == null, missingFields)) {
+                if (checkValid(
+                        "applicationDTO.assessmentDTO.iojAppeal",
+                        applicationDTO.getAssessmentDTO().getIojAppeal() == null,
+                        missingFields)) {
+                    IOJAppealDTO iojAppeal = applicationDTO.getAssessmentDTO().getIojAppeal();
+                    checkValid(
+                            "applicationDTO.assessmentDTO.iojAppeal.cmuId",
+                            iojAppeal.getCmuId() == null,
+                            missingFields);
+                    checkValid(
+                            "applicationDTO.assessmentDTO.iojAppeal.receivedDate",
+                            iojAppeal.getReceivedDate() == null,
+                            missingFields);
+                    if (checkValid(
+                            "applicationDTO.assessmentDTO.iojAppeal.newWorkReasonDTO",
+                            iojAppeal.getNewWorkReasonDTO() == null,
+                            missingFields)) {
+                        checkValid(
+                                "applicationDTO.assessmentDTO.iojAppeal.newWorkReasonDTO.code",
+                                iojAppeal.getNewWorkReasonDTO().getCode() == null,
+                                missingFields);
+                    }
+                    if (checkValid(
+                            "applicationDTO.assessmentDTO.iojAppeal.appealReason",
+                            iojAppeal.getAppealReason() == null,
+                            missingFields)) {
+                        checkValid(
+                                "applicationDTO.assessmentDTO.iojAppeal.appealReason.code",
+                                iojAppeal.getAppealReason().getCode() == null,
+                                missingFields);
+                    }
+                }
+            }
+        }
+
+        if (!missingFields.isEmpty()) {
+            throw new ValidationException("CreateIoJAppeal request is missing required fields: " + missingFields);
+        }
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/IojAppealsOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/IojAppealsOrchestrationService.java
@@ -14,6 +14,7 @@ import uk.gov.justice.laa.crime.orchestration.dto.maat.AssessmentSummaryDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.IOJAppealDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.validation.UserActionDTO;
+import uk.gov.justice.laa.crime.orchestration.exception.CrimeValidationException;
 import uk.gov.justice.laa.crime.orchestration.exception.MaatOrchestrationException;
 import uk.gov.justice.laa.crime.orchestration.exception.RollbackException;
 import uk.gov.justice.laa.crime.orchestration.mapper.ApplicationTrackingMapper;
@@ -29,7 +30,9 @@ import uk.gov.justice.laa.crime.orchestration.service.RepOrderService;
 import uk.gov.justice.laa.crime.orchestration.service.WorkflowPreProcessorService;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 
@@ -56,8 +59,6 @@ public class IojAppealsOrchestrationService {
 
     public ApplicationDTO create(WorkflowRequest request) {
 
-        validateRequiredCreateFields(request);
-
         RepOrderDTO repOrderDto = repOrderService.getRepOrder(request);
 
         if (repOrderDto == null) {
@@ -68,7 +69,14 @@ public class IojAppealsOrchestrationService {
         UserActionDTO userActionDTO = iojAppealMapper.getUserActionDTO(request);
         workflowPreProcessorService.preProcessRequest(request, repOrderDto, userActionDTO);
 
-        String appealId = iojAppealService.create(request);
+        String appealId;
+        try{
+             appealId = iojAppealService.create(request);
+        } catch (NullPointerException npe){
+            UUID uuid = UUID.randomUUID();
+            log.error("Required iojAppeal fields missing in request: UUID: {},\n Exception: {},\n Request: {}", uuid, npe, request);
+            throw new CrimeValidationException(List.of(String.format("IOJ-Appeal missing required fields, report with %s", uuid)));
+        }
 
         try {
             proceedingsService.determineMagsRepDecision(request);
@@ -115,74 +123,5 @@ public class IojAppealsOrchestrationService {
         }
 
         return request.getApplicationDTO();
-    }
-
-    /**
-     * Utility function
-     * Adds field to missingFields
-     * returns inverse of failureCondition
-     *
-     * @param fieldName
-     * @param failureCondition
-     * @param list
-     * @return
-     */
-    static boolean checkValid(String fieldName, boolean failureCondition, List<String> list) {
-        if (failureCondition) {
-            list.add(fieldName);
-        }
-        return !failureCondition;
-    }
-
-    /**
-     * Validate fields required to create Appeal.
-     * Service will return status 400, through {@code CrimeValidationExceptionHandler}
-     */
-    private void validateRequiredCreateFields(WorkflowRequest request) {
-        List<String> missingFields = new ArrayList<>();
-
-        ApplicationDTO applicationDTO = request != null ? request.getApplicationDTO() : null;
-        if (checkValid("applicationDTO", applicationDTO == null, missingFields)) {
-            checkValid("applicationDTO.repId", applicationDTO.getRepId() == null, missingFields);
-            checkValid("applicationDTO.dateReceived", applicationDTO.getDateReceived() == null, missingFields);
-            if (checkValid("applicationDTO.assessmentDTO", applicationDTO.getAssessmentDTO() == null, missingFields)) {
-                if (checkValid(
-                        "applicationDTO.assessmentDTO.iojAppeal",
-                        applicationDTO.getAssessmentDTO().getIojAppeal() == null,
-                        missingFields)) {
-                    IOJAppealDTO iojAppeal = applicationDTO.getAssessmentDTO().getIojAppeal();
-                    checkValid(
-                            "applicationDTO.assessmentDTO.iojAppeal.cmuId",
-                            iojAppeal.getCmuId() == null,
-                            missingFields);
-                    checkValid(
-                            "applicationDTO.assessmentDTO.iojAppeal.receivedDate",
-                            iojAppeal.getReceivedDate() == null,
-                            missingFields);
-                    if (checkValid(
-                            "applicationDTO.assessmentDTO.iojAppeal.newWorkReasonDTO",
-                            iojAppeal.getNewWorkReasonDTO() == null,
-                            missingFields)) {
-                        checkValid(
-                                "applicationDTO.assessmentDTO.iojAppeal.newWorkReasonDTO.code",
-                                iojAppeal.getNewWorkReasonDTO().getCode() == null,
-                                missingFields);
-                    }
-                    if (checkValid(
-                            "applicationDTO.assessmentDTO.iojAppeal.appealReason",
-                            iojAppeal.getAppealReason() == null,
-                            missingFields)) {
-                        checkValid(
-                                "applicationDTO.assessmentDTO.iojAppeal.appealReason.code",
-                                iojAppeal.getAppealReason().getCode() == null,
-                                missingFields);
-                    }
-                }
-            }
-        }
-
-        if (!missingFields.isEmpty()) {
-            throw new ValidationException("CreateIoJAppeal request is missing required fields: " + missingFields);
-        }
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/controller/IojAppealControllerTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/controller/IojAppealControllerTest.java
@@ -14,6 +14,7 @@ import static uk.gov.justice.laa.crime.util.RequestBuilderUtils.buildRequestWith
 
 import uk.gov.justice.laa.crime.enums.CourtType;
 import uk.gov.justice.laa.crime.error.ErrorMessage;
+import uk.gov.justice.laa.crime.exception.ValidationException;
 import uk.gov.justice.laa.crime.orchestration.config.OrchestrationTestConfiguration;
 import uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
@@ -190,6 +191,25 @@ class IojAppealControllerTest {
         String requestBody = objectMapper.writeValueAsString(TestModelDataBuilder.buildWorkFlowRequest());
         mvc.perform(buildRequestWithTransactionIdGivenContent(HttpMethod.POST, requestBody, ENDPOINT_URL, true))
                 .andExpect(status().isInternalServerError());
+        verify(orchestrationService).create(any(WorkflowRequest.class));
+    }
+
+    @Test
+    void givenRequestMissingCmuId_whenCreateIsInvoked_thenBadRequestResponseIsReturned() throws Exception {
+        when(traceIdHandler.getTraceId()).thenReturn(TEST_TRACE_ID);
+        when(orchestrationService.create(any(WorkflowRequest.class)))
+                .thenThrow(new ValidationException(
+                        "CreateIoJAppeal request is missing required fields: [iojAppeal.cmuId]"));
+
+        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
+        workflowRequest.getApplicationDTO().getAssessmentDTO().getIojAppeal().setCmuId(null);
+        String requestBody = objectMapper.writeValueAsString(workflowRequest);
+
+        mvc.perform(buildRequestWithTransactionIdGivenContent(HttpMethod.POST, requestBody, ENDPOINT_URL, true))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(HttpStatus.BAD_REQUEST.toString()))
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("iojAppeal.cmuId")));
         verify(orchestrationService).create(any(WorkflowRequest.class));
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/IojAppealMapperTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/IojAppealMapperTest.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.laa.crime.orchestration.mapper;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 
 import uk.gov.justice.laa.crime.common.model.ioj.ApiCreateIojAppealRequest;
 import uk.gov.justice.laa.crime.enums.IojAppealAssessor;
@@ -90,5 +91,17 @@ class IojAppealMapperTest {
                 Arguments.of(IojAppealDecisionResult.FAIL.toString(), false),
                 Arguments.of("", false),
                 Arguments.of(null, false));
+    }
+
+    @Test
+    void givenIojAppealDtoWithNullDecisionDate_whenMappingToCreateRequest_thenMappingSucceeds() {
+        WorkflowRequest req = TestModelDataBuilder.buildWorkFlowRequest();
+        req.getApplicationDTO().getAssessmentDTO().getIojAppeal().setDecisionDate(null);
+
+        assertThatCode(() -> {
+                    ApiCreateIojAppealRequest actual = iojAppealMapper.mapIojAppealDtoToApiCreateIojAppealRequest(req);
+                    assertThat(actual.getIojAppeal().getDecisionDate()).isNull();
+                })
+                .doesNotThrowAnyException();
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/IojAppealsOrchestrationServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/IojAppealsOrchestrationServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult;
 import uk.gov.justice.laa.crime.enums.orchestration.StoredProcedure;
 import uk.gov.justice.laa.crime.exception.ValidationException;
@@ -18,6 +19,7 @@ import uk.gov.justice.laa.crime.orchestration.dto.maat.AssessmentSummaryDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.IOJAppealDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.validation.UserActionDTO;
+import uk.gov.justice.laa.crime.orchestration.exception.CrimeValidationException;
 import uk.gov.justice.laa.crime.orchestration.exception.MaatOrchestrationException;
 import uk.gov.justice.laa.crime.orchestration.exception.RollbackException;
 import uk.gov.justice.laa.crime.orchestration.mapper.ApplicationTrackingMapper;
@@ -176,74 +178,30 @@ class IojAppealsOrchestrationServiceTest {
         return Stream.of(runtimeException, rollbackException);
     }
 
-    static Stream<Arguments> requiredFieldNullers() {
-        return Stream.of(
-                Arguments.of("applicationDTO", (Consumer<WorkflowRequest>) req -> req.setApplicationDTO(null)),
-                Arguments.of("applicationDTO.repId", (Consumer<WorkflowRequest>)
-                        req -> req.getApplicationDTO().setRepId(null)),
-                Arguments.of("applicationDTO.dateReceived", (Consumer<WorkflowRequest>)
-                        req -> req.getApplicationDTO().setDateReceived(null)),
-                Arguments.of("applicationDTO.assessmentDTO", (Consumer<WorkflowRequest>)
-                        req -> req.getApplicationDTO().setAssessmentDTO(null)),
-                Arguments.of("assessmentDTO.iojAppeal", (Consumer<WorkflowRequest>)
-                        req -> req.getApplicationDTO().getAssessmentDTO().setIojAppeal(null)),
-                Arguments.of("iojAppeal.cmuId", (Consumer<WorkflowRequest>) req -> req.getApplicationDTO()
-                        .getAssessmentDTO()
-                        .getIojAppeal()
-                        .setCmuId(null)),
-                Arguments.of("iojAppeal.receivedDate", (Consumer<WorkflowRequest>) req -> req.getApplicationDTO()
-                        .getAssessmentDTO()
-                        .getIojAppeal()
-                        .setReceivedDate(null)),
-                Arguments.of("iojAppeal.newWorkReasonDTO", (Consumer<WorkflowRequest>) req -> req.getApplicationDTO()
-                        .getAssessmentDTO()
-                        .getIojAppeal()
-                        .setNewWorkReasonDTO(null)),
-                Arguments.of(
-                        "iojAppeal.newWorkReasonDTO.code", (Consumer<WorkflowRequest>) req -> req.getApplicationDTO()
-                                .getAssessmentDTO()
-                                .getIojAppeal()
-                                .getNewWorkReasonDTO()
-                                .setCode(null)),
-                Arguments.of("iojAppeal.appealReason", (Consumer<WorkflowRequest>) req -> req.getApplicationDTO()
-                        .getAssessmentDTO()
-                        .getIojAppeal()
-                        .setAppealReason(null)),
-                Arguments.of("iojAppeal.appealReason.code", (Consumer<WorkflowRequest>) req -> req.getApplicationDTO()
-                        .getAssessmentDTO()
-                        .getIojAppeal()
-                        .getAppealReason()
-                        .setCode(null)));
-    }
-
-    @ParameterizedTest(name = "missing {0} -> ValidationException")
-    @MethodSource("requiredFieldNullers")
-    void givenRequiredFieldMissing_whenCreateIsInvoked_thenValidationExceptionIsThrown(
-            String expectedFieldName, Consumer<WorkflowRequest> nullField) {
-        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
-        nullField.accept(workflowRequest);
-
-        // make sure each null field causes a validationError
-        assertThatThrownBy(() -> iojAppealsOrchestrationService.create(workflowRequest))
-                .isInstanceOf(ValidationException.class)
-                .hasMessageContaining(expectedFieldName);
-
-        // make sure no downstream calls made it through
-        verify(repOrderService, never()).getRepOrder(any());
-        verify(iojAppealService, never()).create(any());
-    }
-
     @Test
-    void givenMultipleRequiredFieldsMissing_whenCreateIsInvoked_thenAllFieldsAreReportedInOneMessage() {
+    void givenRequiredFieldMissing_whenCreateIsInvoked_thenAllFieldsAreReportedInOneMessage() {
         WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
-        workflowRequest.getApplicationDTO().setRepId(null);
         workflowRequest.getApplicationDTO().getAssessmentDTO().getIojAppeal().setCmuId(null);
         workflowRequest.getApplicationDTO().getAssessmentDTO().getIojAppeal().setNewWorkReasonDTO(null);
 
+        IOJAppealDTO iojAppealDTO = workflowRequest.getApplicationDTO().getAssessmentDTO().getIojAppeal();
+        RepOrderDTO repOrderDTO = TestModelDataBuilder.getTestRepOrderDTO(workflowRequest.getApplicationDTO());
+        UserActionDTO userActionDTO = TestModelDataBuilder.getUserActionDTO();
+        NullPointerException npe = new NullPointerException("We need a triggering exception");
+
+        when(repOrderService.getRepOrder(workflowRequest)).thenReturn(repOrderDTO);
+        when(iojAppealMapper.getUserActionDTO(workflowRequest)).thenReturn(userActionDTO);
+        when(iojAppealService.create(workflowRequest)).thenThrow(npe);
+
         assertThatThrownBy(() -> iojAppealsOrchestrationService.create(workflowRequest))
-                .isInstanceOf(ValidationException.class)
-                .hasMessageContaining("applicationDTO.repId")
-                .hasMessageContaining("iojAppeal.cmuId")
-                .hasMessageContaining("iojAppeal.newWorkReasonDTO");
+                .isInstanceOf(CrimeValidationException.class)
+                .extracting("exceptionMessages", InstanceOfAssertFactories.ITERABLE)
+                .first(InstanceOfAssertFactories.STRING)
+                .startsWith("IOJ-Appeal missing required fields");
+
+        verify(proceedingsService, never()).determineMagsRepDecision(any());
+        verify(contributionService, never()).calculate(any());
+        verify(maatCourtDataService, never()).invokeStoredProcedure(any(),any(),any());
     }
+
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/IojAppealsOrchestrationServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/IojAppealsOrchestrationServiceTest.java
@@ -3,12 +3,14 @@ package uk.gov.justice.laa.crime.orchestration.service.orchestration;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult;
 import uk.gov.justice.laa.crime.enums.orchestration.StoredProcedure;
+import uk.gov.justice.laa.crime.exception.ValidationException;
 import uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
@@ -29,11 +31,13 @@ import uk.gov.justice.laa.crime.orchestration.service.ProceedingsService;
 import uk.gov.justice.laa.crime.orchestration.service.RepOrderService;
 import uk.gov.justice.laa.crime.orchestration.service.WorkflowPreProcessorService;
 
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -170,5 +174,76 @@ class IojAppealsOrchestrationServiceTest {
         RuntimeException runtimeException = new RuntimeException("Runtime Exception on rollback");
         RollbackException rollbackException = new RollbackException(new ApplicationDTO());
         return Stream.of(runtimeException, rollbackException);
+    }
+
+    static Stream<Arguments> requiredFieldNullers() {
+        return Stream.of(
+                Arguments.of("applicationDTO", (Consumer<WorkflowRequest>) req -> req.setApplicationDTO(null)),
+                Arguments.of("applicationDTO.repId", (Consumer<WorkflowRequest>)
+                        req -> req.getApplicationDTO().setRepId(null)),
+                Arguments.of("applicationDTO.dateReceived", (Consumer<WorkflowRequest>)
+                        req -> req.getApplicationDTO().setDateReceived(null)),
+                Arguments.of("applicationDTO.assessmentDTO", (Consumer<WorkflowRequest>)
+                        req -> req.getApplicationDTO().setAssessmentDTO(null)),
+                Arguments.of("assessmentDTO.iojAppeal", (Consumer<WorkflowRequest>)
+                        req -> req.getApplicationDTO().getAssessmentDTO().setIojAppeal(null)),
+                Arguments.of("iojAppeal.cmuId", (Consumer<WorkflowRequest>) req -> req.getApplicationDTO()
+                        .getAssessmentDTO()
+                        .getIojAppeal()
+                        .setCmuId(null)),
+                Arguments.of("iojAppeal.receivedDate", (Consumer<WorkflowRequest>) req -> req.getApplicationDTO()
+                        .getAssessmentDTO()
+                        .getIojAppeal()
+                        .setReceivedDate(null)),
+                Arguments.of("iojAppeal.newWorkReasonDTO", (Consumer<WorkflowRequest>) req -> req.getApplicationDTO()
+                        .getAssessmentDTO()
+                        .getIojAppeal()
+                        .setNewWorkReasonDTO(null)),
+                Arguments.of(
+                        "iojAppeal.newWorkReasonDTO.code", (Consumer<WorkflowRequest>) req -> req.getApplicationDTO()
+                                .getAssessmentDTO()
+                                .getIojAppeal()
+                                .getNewWorkReasonDTO()
+                                .setCode(null)),
+                Arguments.of("iojAppeal.appealReason", (Consumer<WorkflowRequest>) req -> req.getApplicationDTO()
+                        .getAssessmentDTO()
+                        .getIojAppeal()
+                        .setAppealReason(null)),
+                Arguments.of("iojAppeal.appealReason.code", (Consumer<WorkflowRequest>) req -> req.getApplicationDTO()
+                        .getAssessmentDTO()
+                        .getIojAppeal()
+                        .getAppealReason()
+                        .setCode(null)));
+    }
+
+    @ParameterizedTest(name = "missing {0} -> ValidationException")
+    @MethodSource("requiredFieldNullers")
+    void givenRequiredFieldMissing_whenCreateIsInvoked_thenValidationExceptionIsThrown(
+            String expectedFieldName, Consumer<WorkflowRequest> nullField) {
+        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
+        nullField.accept(workflowRequest);
+
+        // make sure each null field causes a validationError
+        assertThatThrownBy(() -> iojAppealsOrchestrationService.create(workflowRequest))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining(expectedFieldName);
+
+        // make sure no downstream calls made it through
+        verify(repOrderService, never()).getRepOrder(any());
+        verify(iojAppealService, never()).create(any());
+    }
+
+    @Test
+    void givenMultipleRequiredFieldsMissing_whenCreateIsInvoked_thenAllFieldsAreReportedInOneMessage() {
+        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
+        workflowRequest.getApplicationDTO().setRepId(null);
+        workflowRequest.getApplicationDTO().getAssessmentDTO().getIojAppeal().setCmuId(null);
+        workflowRequest.getApplicationDTO().getAssessmentDTO().getIojAppeal().setNewWorkReasonDTO(null);
+
+        assertThatThrownBy(() -> iojAppealsOrchestrationService.create(workflowRequest))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("applicationDTO.repId")
+                .hasMessageContaining("iojAppeal.cmuId")
+                .hasMessageContaining("iojAppeal.newWorkReasonDTO");
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/IojAppealsOrchestrationServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/IojAppealsOrchestrationServiceTest.java
@@ -31,6 +31,7 @@ import uk.gov.justice.laa.crime.orchestration.service.ProceedingsService;
 import uk.gov.justice.laa.crime.orchestration.service.RepOrderService;
 import uk.gov.justice.laa.crime.orchestration.service.WorkflowPreProcessorService;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
@@ -182,21 +183,20 @@ class IojAppealsOrchestrationServiceTest {
         workflowRequest.getApplicationDTO().getAssessmentDTO().getIojAppeal().setCmuId(null);
         workflowRequest.getApplicationDTO().getAssessmentDTO().getIojAppeal().setNewWorkReasonDTO(null);
 
-        IOJAppealDTO iojAppealDTO =
-                workflowRequest.getApplicationDTO().getAssessmentDTO().getIojAppeal();
+        String msg = "We need a triggering exception";
         RepOrderDTO repOrderDTO = TestModelDataBuilder.getTestRepOrderDTO(workflowRequest.getApplicationDTO());
         UserActionDTO userActionDTO = TestModelDataBuilder.getUserActionDTO();
-        NullPointerException npe = new NullPointerException("We need a triggering exception");
+        CrimeValidationException cve = new CrimeValidationException(List.of(msg));
 
         when(repOrderService.getRepOrder(workflowRequest)).thenReturn(repOrderDTO);
         when(iojAppealMapper.getUserActionDTO(workflowRequest)).thenReturn(userActionDTO);
-        when(iojAppealService.create(workflowRequest)).thenThrow(npe);
+        when(iojAppealService.create(workflowRequest)).thenThrow(cve);
 
         assertThatThrownBy(() -> iojAppealsOrchestrationService.create(workflowRequest))
                 .isInstanceOf(CrimeValidationException.class)
                 .extracting("exceptionMessages", InstanceOfAssertFactories.ITERABLE)
                 .first(InstanceOfAssertFactories.STRING)
-                .startsWith("IOJ-Appeal missing required fields");
+                .startsWith(msg);
 
         verify(proceedingsService, never()).determineMagsRepDecision(any());
         verify(contributionService, never()).calculate(any());

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/IojAppealsOrchestrationServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/IojAppealsOrchestrationServiceTest.java
@@ -147,6 +147,7 @@ class IojAppealsOrchestrationServiceTest {
                 .isInstanceOf(MaatOrchestrationException.class);
     }
 
+    // bump commit to rerun circleCI
     @ParameterizedTest
     @MethodSource("exceptions")
     void givenPostProcessingFailure_whenCreateIsInvokedAndRollbackUnsuccessful_thenRollbackExceptionIsThrown(

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/IojAppealsOrchestrationServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/IojAppealsOrchestrationServiceTest.java
@@ -8,10 +8,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.assertj.core.api.InstanceOfAssertFactories;
 import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult;
 import uk.gov.justice.laa.crime.enums.orchestration.StoredProcedure;
-import uk.gov.justice.laa.crime.exception.ValidationException;
 import uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
 import uk.gov.justice.laa.crime.orchestration.dto.maat.ApplicationDTO;
@@ -33,13 +31,12 @@ import uk.gov.justice.laa.crime.orchestration.service.ProceedingsService;
 import uk.gov.justice.laa.crime.orchestration.service.RepOrderService;
 import uk.gov.justice.laa.crime.orchestration.service.WorkflowPreProcessorService;
 
-import java.util.function.Consumer;
 import java.util.stream.Stream;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -184,7 +181,8 @@ class IojAppealsOrchestrationServiceTest {
         workflowRequest.getApplicationDTO().getAssessmentDTO().getIojAppeal().setCmuId(null);
         workflowRequest.getApplicationDTO().getAssessmentDTO().getIojAppeal().setNewWorkReasonDTO(null);
 
-        IOJAppealDTO iojAppealDTO = workflowRequest.getApplicationDTO().getAssessmentDTO().getIojAppeal();
+        IOJAppealDTO iojAppealDTO =
+                workflowRequest.getApplicationDTO().getAssessmentDTO().getIojAppeal();
         RepOrderDTO repOrderDTO = TestModelDataBuilder.getTestRepOrderDTO(workflowRequest.getApplicationDTO());
         UserActionDTO userActionDTO = TestModelDataBuilder.getUserActionDTO();
         NullPointerException npe = new NullPointerException("We need a triggering exception");
@@ -201,7 +199,6 @@ class IojAppealsOrchestrationServiceTest {
 
         verify(proceedingsService, never()).determineMagsRepDecision(any());
         verify(contributionService, never()).calculate(any());
-        verify(maatCourtDataService, never()).invokeStoredProcedure(any(),any(),any());
+        verify(maatCourtDataService, never()).invokeStoredProcedure(any(), any(), any());
     }
-
 }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1997)

Added validation for required fields in incoming Request.
Checks all required fields and throws 400 BAD_REQUEST with all missing fields.

Tests added to verify correctness, check all individual fields and that multiple fields are handled together. 
Branch deployed to Test Environment, Functional Tests passing.

MODIFIED: now catches NPEs when thrown, logs NPE with a correlationID and throws a CrimeValidationException with the correlationID, suitable for direct display to user and allows them to report it.