### PR TITLE
LCAM-2127: update springboot and tomcat versions to fix reported CVE

### DIFF
--- a/maat-orchestration/build.gradle
+++ b/maat-orchestration/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 // springboot tomcat version overide, can be removed when springboot is 3.5.15 or 4+
-// ext['tomcat.version'] = '10.1.55'
+ext['tomcat.version'] = '10.1.55'
 
 group = "uk.gov.justice.laa.crime"
 

--- a/maat-orchestration/build.gradle
+++ b/maat-orchestration/build.gradle
@@ -8,6 +8,9 @@ plugins {
 	id "io.spring.dependency-management" version "1.1.7"
 }
 
+// springboot tomcat version overide, can be removed when springboot is 3.5.15 or 4+
+// ext['tomcat.version'] = '10.1.55'
+
 group = "uk.gov.justice.laa.crime"
 
 java {
@@ -36,7 +39,7 @@ configurations {
 repositories {
 	mavenCentral()
 	maven {
-		url 'https://central.sonatype.com/repository/maven-snapshots/'
+		url = 'https://central.sonatype.com/repository/maven-snapshots/'
 	}
 }
 
@@ -72,9 +75,6 @@ dependencies {
 	compileOnly "org.projectlombok:lombok"
 	annotationProcessor "org.projectlombok:lombok"
 	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
-
-	// ---- Pinned to Resolve Vulnerability CVE-2026-43512 ---
-	implementation "org.apache.tomcat.embed:tomcat-embed-core:10.1.55"
 
 	// ---- Testing ----
 	testImplementation "org.springframework.boot:spring-boot-starter-test"


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-2107)

version updated
springboot:3.5.14
tomcat: 10.1.55
Builds successfully, no SYNK warnings

[failing build](https://app.circleci.com/pipelines/github/ministryofjustice/laa-maat-orchestration/1603/workflows/69cb5d55-7492-41a6-a20d-9c53e5bf96f5/jobs/9678)
[passing build](https://app.circleci.com/pipelines/github/ministryofjustice/laa-maat-orchestration/1604/workflows/09356420-b4f4-43f2-b821-d84025ef58cd/jobs/9686)