### PR TITLE
[LCAM-2108] Move Application Tracking logic to single class

### DIFF
--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/ApplicationTrackingMapper.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/mapper/ApplicationTrackingMapper.java
@@ -43,7 +43,8 @@ public class ApplicationTrackingMapper {
             WorkflowRequest workflowRequest,
             RepOrderDTO repOrderDTO,
             AssessmentType assessmentType,
-            RequestSource requestSource) {
+            RequestSource requestSource,
+            Long usn) {
 
         ApplicationTrackingOutputResult request = new ApplicationTrackingOutputResult();
         ApplicationDTO application = workflowRequest.getApplicationDTO();
@@ -54,10 +55,7 @@ public class ApplicationTrackingMapper {
         CrownCourtOverviewDTO crownCourtOverviewDTO = application.getCrownCourtOverviewDTO();
         CrownCourtSummaryDTO crownCourtSummaryDTO = crownCourtOverviewDTO.getCrownCourtSummaryDTO();
 
-        request.setUsn(
-                financialAssessmentDTO.getUsn() != null
-                        ? financialAssessmentDTO.getUsn().intValue()
-                        : null);
+        request.setUsn(usn.intValue());
         request.setMaatRef(application.getRepId().intValue());
         request.setActionKeyId(financialAssessmentDTO.getId());
         request.setCaseId(application.getCaseId());

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/ApplicationTrackingDataService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/ApplicationTrackingDataService.java
@@ -26,23 +26,17 @@ public class ApplicationTrackingDataService {
             AssessmentType assessmentType,
             RequestSource requestSource) {
 
-        Long usn = workflowRequest.getApplicationDTO().getUsn();
+        Long usn;
 
-        // Use the USN from the financialAssessment if there isn't one on the applicationDTO
-        if (usn == null
-                && workflowRequest.getApplicationDTO().getAssessmentDTO() != null
-                && workflowRequest.getApplicationDTO().getAssessmentDTO().getFinancialAssessmentDTO() != null
-                && workflowRequest
-                                .getApplicationDTO()
-                                .getAssessmentDTO()
-                                .getFinancialAssessmentDTO()
-                                .getUsn()
-                        != null) {
-            usn = workflowRequest
-                    .getApplicationDTO()
-                    .getAssessmentDTO()
-                    .getFinancialAssessmentDTO()
-                    .getUsn();
+        switch (requestSource) {
+            case HARDSHIP, MEANS_ASSESSMENT ->
+                usn = workflowRequest
+                        .getApplicationDTO()
+                        .getAssessmentDTO()
+                        .getFinancialAssessmentDTO()
+                        .getUsn();
+            case PASSPORT_IOJ -> usn = workflowRequest.getApplicationDTO().getUsn();
+            default -> throw new IllegalStateException("Unknown request source " + requestSource);
         }
 
         if (usn == null) {

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/ApplicationTrackingDataService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/ApplicationTrackingDataService.java
@@ -3,6 +3,11 @@ package uk.gov.justice.laa.crime.orchestration.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult;
+import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult.AssessmentType;
+import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult.RequestSource;
+import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
+import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
+import uk.gov.justice.laa.crime.orchestration.mapper.ApplicationTrackingMapper;
 import uk.gov.justice.laa.crime.orchestration.service.api.ApplicationTrackingApiService;
 
 import org.springframework.stereotype.Service;
@@ -13,8 +18,40 @@ import org.springframework.stereotype.Service;
 public class ApplicationTrackingDataService {
 
     private final ApplicationTrackingApiService service;
+    private final ApplicationTrackingMapper applicationTrackingMapper;
 
-    public void sendTrackingOutputResult(ApplicationTrackingOutputResult request) {
+    public void sendTrackingOutputResult(
+            WorkflowRequest workflowRequest,
+            RepOrderDTO repOrderDTO,
+            AssessmentType assessmentType,
+            RequestSource requestSource) {
+
+        Long usn = workflowRequest.getApplicationDTO().getUsn();
+
+        // Use the USN from the financialAssessment if there isn't one on the applicationDTO
+        if (usn == null
+                && workflowRequest.getApplicationDTO().getAssessmentDTO() != null
+                && workflowRequest.getApplicationDTO().getAssessmentDTO().getFinancialAssessmentDTO() != null
+                && workflowRequest
+                                .getApplicationDTO()
+                                .getAssessmentDTO()
+                                .getFinancialAssessmentDTO()
+                                .getUsn()
+                        != null) {
+            usn = workflowRequest
+                    .getApplicationDTO()
+                    .getAssessmentDTO()
+                    .getFinancialAssessmentDTO()
+                    .getUsn();
+        }
+
+        if (usn == null) {
+            return;
+        }
+
+        ApplicationTrackingOutputResult request =
+                applicationTrackingMapper.build(workflowRequest, repOrderDTO, assessmentType, requestSource, usn);
+
         service.sendTrackingOutputResult(request);
     }
 }

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/HardshipOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/HardshipOrchestrationService.java
@@ -4,7 +4,6 @@ import io.sentry.Sentry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import uk.gov.justice.laa.crime.common.model.hardship.ApiPerformHardshipResponse;
-import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult;
 import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult.AssessmentType;
 import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult.RequestSource;
 import uk.gov.justice.laa.crime.enums.CourtType;
@@ -189,12 +188,9 @@ public class HardshipOrchestrationService implements AssessmentOrchestrator<Hard
 
         proceedingsService.updateApplication(request, repOrderDTO);
 
-        // Call application.handle_eform_result stored procedure OR Equivalent ATS service endpoint
-        ApplicationTrackingOutputResult applicationTrackingOutputResult = applicationTrackingMapper.build(
+        applicationTrackingDataService.sendTrackingOutputResult(
                 request, repOrderDTO, AssessmentType.CCHARDSHIP, RequestSource.HARDSHIP);
-        if (null != applicationTrackingOutputResult.getUsn()) {
-            applicationTrackingDataService.sendTrackingOutputResult(applicationTrackingOutputResult);
-        }
+
         // Call crown_court.xx_process_activity_and_get_correspondence stored procedure
         request.setApplicationDTO(maatCourtDataService.invokeStoredProcedure(
                 request.getApplicationDTO(),

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/HardshipOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/HardshipOrchestrationService.java
@@ -19,7 +19,6 @@ import uk.gov.justice.laa.crime.orchestration.dto.maat.HardshipReviewDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.validation.UserActionDTO;
 import uk.gov.justice.laa.crime.orchestration.exception.MaatOrchestrationException;
-import uk.gov.justice.laa.crime.orchestration.mapper.ApplicationTrackingMapper;
 import uk.gov.justice.laa.crime.orchestration.mapper.HardshipMapper;
 import uk.gov.justice.laa.crime.orchestration.service.ApplicationService;
 import uk.gov.justice.laa.crime.orchestration.service.ApplicationTrackingDataService;
@@ -47,7 +46,6 @@ public class HardshipOrchestrationService implements AssessmentOrchestrator<Hard
     private final RepOrderService repOrderService;
     private final ApplicationService applicationService;
 
-    private final ApplicationTrackingMapper applicationTrackingMapper;
     private final ApplicationTrackingDataService applicationTrackingDataService;
 
     public HardshipReviewDTO find(int hardshipReviewId) {

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/IojAppealsOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/IojAppealsOrchestrationService.java
@@ -14,7 +14,6 @@ import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.validation.UserActionDTO;
 import uk.gov.justice.laa.crime.orchestration.exception.MaatOrchestrationException;
 import uk.gov.justice.laa.crime.orchestration.exception.RollbackException;
-import uk.gov.justice.laa.crime.orchestration.mapper.ApplicationTrackingMapper;
 import uk.gov.justice.laa.crime.orchestration.mapper.IojAppealMapper;
 import uk.gov.justice.laa.crime.orchestration.service.ApplicationService;
 import uk.gov.justice.laa.crime.orchestration.service.ApplicationTrackingDataService;
@@ -41,7 +40,6 @@ public class IojAppealsOrchestrationService {
     private final ProceedingsService proceedingsService;
     private final RepOrderService repOrderService;
     private final WorkflowPreProcessorService workflowPreProcessorService;
-    private final ApplicationTrackingMapper applicationTrackingMapper;
     private final ApplicationTrackingDataService applicationTrackingDataService;
     private final ApplicationService applicationService;
 

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/IojAppealsOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/IojAppealsOrchestrationService.java
@@ -3,7 +3,6 @@ package uk.gov.justice.laa.crime.orchestration.service.orchestration;
 import io.sentry.Sentry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult;
 import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult.AssessmentType;
 import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult.RequestSource;
 import uk.gov.justice.laa.crime.enums.orchestration.StoredProcedure;
@@ -78,11 +77,9 @@ public class IojAppealsOrchestrationService {
             applicationService.updateDateModified(request, request.getApplicationDTO());
 
             // Call Application Tracking Service endpoint
-            ApplicationTrackingOutputResult applicationTrackingOutputResult = applicationTrackingMapper.build(
+            applicationTrackingDataService.sendTrackingOutputResult(
                     request, repOrderDto, AssessmentType.IOJ, RequestSource.PASSPORT_IOJ);
-            if (null != applicationTrackingOutputResult.getUsn()) {
-                applicationTrackingDataService.sendTrackingOutputResult(applicationTrackingOutputResult);
-            }
+
         } catch (Exception ex) {
             log.error("IoJ Appeal Post Processing failed, rolling back create IoJ Appeal", ex);
             Sentry.captureException(ex);

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/MeansAssessmentOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/MeansAssessmentOrchestrationService.java
@@ -6,7 +6,6 @@ import static uk.gov.justice.laa.crime.orchestration.common.Constants.WRN_MSG_RE
 import io.sentry.Sentry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult;
 import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult.AssessmentType;
 import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult.RequestSource;
 import uk.gov.justice.laa.crime.enums.orchestration.Action;
@@ -170,12 +169,8 @@ public class MeansAssessmentOrchestrationService {
                 ? AssessmentType.MEANS_FULL
                 : AssessmentType.MEANS_INIT;
 
-        ApplicationTrackingOutputResult applicationTrackingOutputResult =
-                applicationTrackingMapper.build(request, repOrderDTO, assessmentType, RequestSource.MEANS_ASSESSMENT);
-
-        if (applicationTrackingOutputResult.getUsn() != null) {
-            applicationTrackingDataService.sendTrackingOutputResult(applicationTrackingOutputResult);
-        }
+        applicationTrackingDataService.sendTrackingOutputResult(
+                request, repOrderDTO, assessmentType, RequestSource.MEANS_ASSESSMENT);
 
         AssessmentSummaryDTO assessmentSummaryDTO = assessmentSummaryService.getSummary(
                 request.getApplicationDTO().getAssessmentDTO().getFinancialAssessmentDTO());

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/MeansAssessmentOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/MeansAssessmentOrchestrationService.java
@@ -20,7 +20,6 @@ import uk.gov.justice.laa.crime.orchestration.dto.validation.UserActionDTO;
 import uk.gov.justice.laa.crime.orchestration.exception.CrimeValidationException;
 import uk.gov.justice.laa.crime.orchestration.exception.MaatOrchestrationException;
 import uk.gov.justice.laa.crime.orchestration.exception.StoredProcedureValidationException;
-import uk.gov.justice.laa.crime.orchestration.mapper.ApplicationTrackingMapper;
 import uk.gov.justice.laa.crime.orchestration.mapper.MeansAssessmentMapper;
 import uk.gov.justice.laa.crime.orchestration.service.ApplicationService;
 import uk.gov.justice.laa.crime.orchestration.service.ApplicationTrackingDataService;
@@ -53,7 +52,6 @@ public class MeansAssessmentOrchestrationService {
     private final WorkflowPreProcessorService workflowPreProcessorService;
     private final IncomeEvidenceService incomeEvidenceService;
     private final ApplicationTrackingDataService applicationTrackingDataService;
-    private final ApplicationTrackingMapper applicationTrackingMapper;
     private final MeansAssessmentMapper meansAssessmentMapper;
     private final MaatCourtDataApiService maatCourtDataApiService;
 

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationService.java
@@ -14,7 +14,6 @@ import uk.gov.justice.laa.crime.orchestration.dto.maat.PassportedDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
 import uk.gov.justice.laa.crime.orchestration.dto.validation.UserActionDTO;
 import uk.gov.justice.laa.crime.orchestration.exception.MaatOrchestrationException;
-import uk.gov.justice.laa.crime.orchestration.mapper.ApplicationTrackingMapper;
 import uk.gov.justice.laa.crime.orchestration.mapper.PassportAssessmentMapper;
 import uk.gov.justice.laa.crime.orchestration.service.ApplicationService;
 import uk.gov.justice.laa.crime.orchestration.service.ApplicationTrackingDataService;
@@ -44,7 +43,6 @@ public class PassportAssessmentOrchestrationService {
     private final MaatCourtDataService maatCourtDataService;
     private final AssessmentSummaryService assessmentSummaryService;
     private final ApplicationService applicationService;
-    private final ApplicationTrackingMapper applicationTrackingMapper;
     private final ApplicationTrackingDataService applicationTrackingDataService;
 
     private void preProcessPassportRequest(WorkflowRequest workflowRequest, RepOrderDTO repOrderDTO) {

--- a/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationService.java
+++ b/maat-orchestration/src/main/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationService.java
@@ -3,7 +3,6 @@ package uk.gov.justice.laa.crime.orchestration.service.orchestration;
 import io.sentry.Sentry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult;
 import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult.AssessmentType;
 import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult.RequestSource;
 import uk.gov.justice.laa.crime.enums.NewWorkReason;
@@ -67,12 +66,8 @@ public class PassportAssessmentOrchestrationService {
     }
 
     private void updateApplicationTracking(WorkflowRequest workflowRequest, RepOrderDTO repOrderDTO) {
-        ApplicationTrackingOutputResult applicationTrackingOutputResult = applicationTrackingMapper.build(
+        applicationTrackingDataService.sendTrackingOutputResult(
                 workflowRequest, repOrderDTO, AssessmentType.PASSPORT, RequestSource.PASSPORT_IOJ);
-
-        if (null != applicationTrackingOutputResult.getUsn()) {
-            applicationTrackingDataService.sendTrackingOutputResult(applicationTrackingOutputResult);
-        }
     }
 
     private void performPostProcessing(

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/MeansAssessmentDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/MeansAssessmentDataBuilder.java
@@ -426,6 +426,7 @@ public class MeansAssessmentDataBuilder {
                 .passportedDTO(getPassportedDTO())
                 .repOrderDecision(getRepOrderDecisionDTO())
                 .iojResult(RESULT_PASS)
+                .usn(Long.valueOf(USN))
                 .build();
     }
 

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/TestModelDataBuilder.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/data/builder/TestModelDataBuilder.java
@@ -712,6 +712,7 @@ public class TestModelDataBuilder {
                 .iojResult(RESULT_PASS)
                 .assessmentSummary(Collections.emptyList())
                 .applicantLinks(getApplicantLinks())
+                .usn(Long.valueOf(USN))
                 .build();
     }
 

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/ApplicationTrackingMapperTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/ApplicationTrackingMapperTest.java
@@ -50,8 +50,12 @@ class ApplicationTrackingMapperTest {
         WorkflowRequest workflowRequest =
                 TestModelDataBuilder.buildWorkflowRequestWithCCHardship(CourtType.CROWN_COURT);
         RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTOWithAssessorName();
-        ApplicationTrackingOutputResult request =
-                mapper.build(workflowRequest, repOrderDTO, AssessmentType.CCHARDSHIP, RequestSource.HARDSHIP);
+        ApplicationTrackingOutputResult request = mapper.build(
+                workflowRequest,
+                repOrderDTO,
+                AssessmentType.CCHARDSHIP,
+                RequestSource.HARDSHIP,
+                Long.valueOf(TestModelDataBuilder.USN));
 
         softly.assertThat(request.getUsn()).isEqualTo(USN.longValue());
         softly.assertThat(request.getMaatRef()).isEqualTo(TestModelDataBuilder.REP_ID.intValue());
@@ -89,9 +93,13 @@ class ApplicationTrackingMapperTest {
                 .setRepOrderDecision(null);
         RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTOWithAssessorName();
 
-        ApplicationTrackingOutputResult request =
-                mapper.build(workflowRequest, repOrderDTO, AssessmentType.CCHARDSHIP, RequestSource.HARDSHIP);
-        softly.assertThat(request.getUsn()).isEqualTo(TestModelDataBuilder.REP_ID.intValue());
+        ApplicationTrackingOutputResult request = mapper.build(
+                workflowRequest,
+                repOrderDTO,
+                AssessmentType.CCHARDSHIP,
+                RequestSource.HARDSHIP,
+                Long.valueOf(TestModelDataBuilder.USN));
+        softly.assertThat(request.getUsn()).isEqualTo(TestModelDataBuilder.USN.intValue());
         softly.assertThat(request.getMaatRef()).isEqualTo(TestModelDataBuilder.REP_ID.intValue());
         softly.assertThat(request.getActionKeyId()).isEqualTo(Constants.FINANCIAL_ASSESSMENT_ID);
         softly.assertThat(request.getCaseId())

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/MeansAssessmentMapperTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/mapper/MeansAssessmentMapperTest.java
@@ -282,7 +282,8 @@ class MeansAssessmentMapperTest {
         AssessmentDTO assessmentDTO = applicationDTO.getAssessmentDTO();
         FinancialAssessmentDTO financialAssessmentDTO = assessmentDTO.getFinancialAssessmentDTO();
         InitialAssessmentDTO initialAssessmentDTO = financialAssessmentDTO.getInitial();
-        softly.assertThat(apiCreateMeansAssessmentRequest.getUsn()).isEqualTo(applicationDTO.getUsn());
+        softly.assertThat(apiCreateMeansAssessmentRequest.getUsn())
+                .isEqualTo(applicationDTO.getUsn().intValue());
         softly.assertThat(apiCreateMeansAssessmentRequest.getReviewType().getCode())
                 .isEqualTo(initialAssessmentDTO.getReviewType().getCode());
     }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/ApplicationTrackingDataServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/ApplicationTrackingDataServiceTest.java
@@ -2,8 +2,15 @@ package uk.gov.justice.laa.crime.orchestration.service;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult;
+import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult.AssessmentType;
+import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult.RequestSource;
+import uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder;
+import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
+import uk.gov.justice.laa.crime.orchestration.dto.maat_api.RepOrderDTO;
+import uk.gov.justice.laa.crime.orchestration.mapper.ApplicationTrackingMapper;
 import uk.gov.justice.laa.crime.orchestration.service.api.ApplicationTrackingApiService;
 
 import org.junit.jupiter.api.Test;
@@ -15,15 +22,74 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith({MockitoExtension.class})
 class ApplicationTrackingDataServiceTest {
 
+    private static final Long FINANCIAL_ASSESSMENT_USN = 54321L;
+
     @Mock
     private ApplicationTrackingApiService applicationTrackingApiService;
+
+    @Mock
+    private ApplicationTrackingMapper applicationTrackingMapper;
 
     @InjectMocks
     private ApplicationTrackingDataService applicationTrackingDataService;
 
     @Test
     void givenAValidInput_whenSendTrackingOutputResultIsInvoked_thenApplicationTrackingApiServiceIsCalled() {
-        applicationTrackingDataService.sendTrackingOutputResult(new ApplicationTrackingOutputResult());
+        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
+        RepOrderDTO repOrderDTO = new RepOrderDTO();
+        AssessmentType assessmentType = AssessmentType.IOJ;
+        RequestSource requestSource = RequestSource.PASSPORT_IOJ;
+
+        when(applicationTrackingMapper.build(
+                        workflowRequest,
+                        repOrderDTO,
+                        assessmentType,
+                        requestSource,
+                        workflowRequest.getApplicationDTO().getUsn()))
+                .thenReturn(new ApplicationTrackingOutputResult());
+
+        applicationTrackingDataService.sendTrackingOutputResult(
+                workflowRequest, repOrderDTO, assessmentType, requestSource);
         verify(applicationTrackingApiService).sendTrackingOutputResult(any(ApplicationTrackingOutputResult.class));
+    }
+
+    @Test
+    void givenAnApplicationDtoUsn_whenSendTrackingOutputResultIsInvoked_thenItPassesThisUsnToTheMapper() {
+        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
+        RepOrderDTO repOrderDTO = new RepOrderDTO();
+        AssessmentType assessmentType = AssessmentType.IOJ;
+        RequestSource requestSource = RequestSource.PASSPORT_IOJ;
+
+        applicationTrackingDataService.sendTrackingOutputResult(
+                workflowRequest, repOrderDTO, assessmentType, requestSource);
+
+        verify(applicationTrackingMapper)
+                .build(
+                        workflowRequest,
+                        repOrderDTO,
+                        assessmentType,
+                        requestSource,
+                        workflowRequest.getApplicationDTO().getUsn());
+    }
+
+    @Test
+    void
+            givenNoApplicationDtoUsn_whenSendTrackingOutputResultIsInvoked_thenItPassesTheFinancialAssessmentDtoUsnToTheMapper() {
+        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
+        workflowRequest.getApplicationDTO().setUsn(null);
+        workflowRequest
+                .getApplicationDTO()
+                .getAssessmentDTO()
+                .getFinancialAssessmentDTO()
+                .setUsn(FINANCIAL_ASSESSMENT_USN);
+        RepOrderDTO repOrderDTO = new RepOrderDTO();
+        AssessmentType assessmentType = AssessmentType.IOJ;
+        RequestSource requestSource = RequestSource.PASSPORT_IOJ;
+
+        applicationTrackingDataService.sendTrackingOutputResult(
+                workflowRequest, repOrderDTO, assessmentType, requestSource);
+
+        verify(applicationTrackingMapper)
+                .build(workflowRequest, repOrderDTO, assessmentType, requestSource, FINANCIAL_ASSESSMENT_USN);
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/ApplicationTrackingDataServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/ApplicationTrackingDataServiceTest.java
@@ -22,6 +22,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith({MockitoExtension.class})
 class ApplicationTrackingDataServiceTest {
 
+    private static final Long APPLICATION_USN = 78943L;
     private static final Long FINANCIAL_ASSESSMENT_USN = 54321L;
 
     @Mock
@@ -54,8 +55,80 @@ class ApplicationTrackingDataServiceTest {
     }
 
     @Test
-    void givenAnApplicationDtoUsn_whenSendTrackingOutputResultIsInvoked_thenItPassesThisUsnToTheMapper() {
+    void
+            givenAHardshipRequestSource_whenSendTrackingOutputResultIsInvoked_thenItPassesTheFinancialAssessmentUsnToTheMapper() {
         WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
+        workflowRequest.getApplicationDTO().setUsn(APPLICATION_USN);
+        workflowRequest
+                .getApplicationDTO()
+                .getAssessmentDTO()
+                .getFinancialAssessmentDTO()
+                .setUsn(FINANCIAL_ASSESSMENT_USN);
+        RepOrderDTO repOrderDTO = new RepOrderDTO();
+        AssessmentType assessmentType = AssessmentType.CCHARDSHIP;
+        RequestSource requestSource = RequestSource.HARDSHIP;
+
+        applicationTrackingDataService.sendTrackingOutputResult(
+                workflowRequest, repOrderDTO, assessmentType, requestSource);
+
+        verify(applicationTrackingMapper)
+                .build(
+                        workflowRequest,
+                        repOrderDTO,
+                        assessmentType,
+                        requestSource,
+                        workflowRequest
+                                .getApplicationDTO()
+                                .getAssessmentDTO()
+                                .getFinancialAssessmentDTO()
+                                .getUsn());
+    }
+
+    @Test
+    void
+            givenAMeansAssessmentRequestSource_whenSendTrackingOutputResultIsInvoked_thenItPassesTheFinancialAssessmentUsnToTheMapper() {
+        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
+        workflowRequest.getApplicationDTO().setUsn(APPLICATION_USN);
+        workflowRequest
+                .getApplicationDTO()
+                .getAssessmentDTO()
+                .getFinancialAssessmentDTO()
+                .setUsn(FINANCIAL_ASSESSMENT_USN);
+        RepOrderDTO repOrderDTO = new RepOrderDTO();
+        AssessmentType assessmentType = AssessmentType.MEANS_INIT;
+        RequestSource requestSource = RequestSource.MEANS_ASSESSMENT;
+
+        applicationTrackingDataService.sendTrackingOutputResult(
+                workflowRequest, repOrderDTO, assessmentType, requestSource);
+
+        verify(applicationTrackingMapper)
+                .build(
+                        workflowRequest,
+                        repOrderDTO,
+                        assessmentType,
+                        requestSource,
+                        workflowRequest
+                                .getApplicationDTO()
+                                .getAssessmentDTO()
+                                .getFinancialAssessmentDTO()
+                                .getUsn());
+    }
+
+    @Test
+    void
+            givenAPassportIojRequestSource_whenSendTrackingOutputResultIsInvoked_thenItPassesTheApplicationUsnToTheMapper() {
+        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
+        workflowRequest.getApplicationDTO().setUsn(APPLICATION_USN);
+        workflowRequest
+                .getApplicationDTO()
+                .getAssessmentDTO()
+                .getFinancialAssessmentDTO()
+                .setUsn(FINANCIAL_ASSESSMENT_USN);
+        workflowRequest
+                .getApplicationDTO()
+                .getAssessmentDTO()
+                .getFinancialAssessmentDTO()
+                .setUsn(FINANCIAL_ASSESSMENT_USN);
         RepOrderDTO repOrderDTO = new RepOrderDTO();
         AssessmentType assessmentType = AssessmentType.IOJ;
         RequestSource requestSource = RequestSource.PASSPORT_IOJ;
@@ -70,26 +143,5 @@ class ApplicationTrackingDataServiceTest {
                         assessmentType,
                         requestSource,
                         workflowRequest.getApplicationDTO().getUsn());
-    }
-
-    @Test
-    void
-            givenNoApplicationDtoUsn_whenSendTrackingOutputResultIsInvoked_thenItPassesTheFinancialAssessmentDtoUsnToTheMapper() {
-        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
-        workflowRequest.getApplicationDTO().setUsn(null);
-        workflowRequest
-                .getApplicationDTO()
-                .getAssessmentDTO()
-                .getFinancialAssessmentDTO()
-                .setUsn(FINANCIAL_ASSESSMENT_USN);
-        RepOrderDTO repOrderDTO = new RepOrderDTO();
-        AssessmentType assessmentType = AssessmentType.IOJ;
-        RequestSource requestSource = RequestSource.PASSPORT_IOJ;
-
-        applicationTrackingDataService.sendTrackingOutputResult(
-                workflowRequest, repOrderDTO, assessmentType, requestSource);
-
-        verify(applicationTrackingMapper)
-                .build(workflowRequest, repOrderDTO, assessmentType, requestSource, FINANCIAL_ASSESSMENT_USN);
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/ApplicationTrackingDataServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/ApplicationTrackingDataServiceTest.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.laa.crime.orchestration.service;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -124,11 +125,6 @@ class ApplicationTrackingDataServiceTest {
                 .getAssessmentDTO()
                 .getFinancialAssessmentDTO()
                 .setUsn(FINANCIAL_ASSESSMENT_USN);
-        workflowRequest
-                .getApplicationDTO()
-                .getAssessmentDTO()
-                .getFinancialAssessmentDTO()
-                .setUsn(FINANCIAL_ASSESSMENT_USN);
         RepOrderDTO repOrderDTO = new RepOrderDTO();
         AssessmentType assessmentType = AssessmentType.IOJ;
         RequestSource requestSource = RequestSource.PASSPORT_IOJ;
@@ -143,5 +139,25 @@ class ApplicationTrackingDataServiceTest {
                         assessmentType,
                         requestSource,
                         workflowRequest.getApplicationDTO().getUsn());
+    }
+
+    @Test
+    void givenNoUsn_whenSendTrackingOutputResult_thenNoTrackingInformationIsMappedOrSent() {
+        WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
+        workflowRequest.getApplicationDTO().setUsn(null);
+        workflowRequest
+                .getApplicationDTO()
+                .getAssessmentDTO()
+                .getFinancialAssessmentDTO()
+                .setUsn(null);
+        RepOrderDTO repOrderDTO = new RepOrderDTO();
+        AssessmentType assessmentType = AssessmentType.IOJ;
+        RequestSource requestSource = RequestSource.PASSPORT_IOJ;
+
+        applicationTrackingDataService.sendTrackingOutputResult(
+                workflowRequest, repOrderDTO, assessmentType, requestSource);
+
+        verify(applicationTrackingMapper, never()).build(any(), any(), any(), any(), any());
+        verify(applicationTrackingApiService, never()).sendTrackingOutputResult(any());
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/HardshipOrchestrationServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/HardshipOrchestrationServiceTest.java
@@ -18,7 +18,8 @@ import static uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataB
 import static uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder.getHardshipReviewDTO;
 
 import uk.gov.justice.laa.crime.common.model.hardship.ApiPerformHardshipResponse;
-import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult;
+import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult.AssessmentType;
+import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult.RequestSource;
 import uk.gov.justice.laa.crime.enums.CourtType;
 import uk.gov.justice.laa.crime.enums.CurrentStatus;
 import uk.gov.justice.laa.crime.enums.orchestration.StoredProcedure;
@@ -211,8 +212,6 @@ class HardshipOrchestrationServiceTest {
                         any(ApplicationDTO.class), any(UserDTO.class), any(StoredProcedure.class)))
                 .thenReturn(applicationDTO);
 
-        when(applicationTrackingMapper.build(any(), any(), any(), any()))
-                .thenReturn(new ApplicationTrackingOutputResult().withUsn(12345));
         when(repOrderService.getRepOrder(any())).thenReturn(repOrderDTO);
 
         ApplicationDTO expected = orchestrationService.create(workflowRequest);
@@ -229,6 +228,9 @@ class HardshipOrchestrationServiceTest {
 
         verify(assessmentSummaryService).updateApplication(any(ApplicationDTO.class), any(AssessmentSummaryDTO.class));
         verify(applicationService, times(1)).updateDateModified(eq(workflowRequest), any());
+        verify(applicationTrackingDataService, times(1))
+                .sendTrackingOutputResult(
+                        workflowRequest, repOrderDTO, AssessmentType.CCHARDSHIP, RequestSource.HARDSHIP);
     }
 
     @Test
@@ -461,8 +463,6 @@ class HardshipOrchestrationServiceTest {
                 .thenReturn(assessmentSummaryDTO);
         when(hardshipMapper.getUserActionDTO(any(), any()))
                 .thenReturn(UserActionDTO.builder().username("mock-u").build());
-        when(applicationTrackingMapper.build(any(), any(), any(), any()))
-                .thenReturn(new ApplicationTrackingOutputResult().withUsn(12345));
         when(repOrderService.getRepOrder(any())).thenReturn(repOrderDTO);
 
         ApplicationDTO expected = orchestrationService.update(workflowRequest);
@@ -480,6 +480,10 @@ class HardshipOrchestrationServiceTest {
         verify(assessmentSummaryService).updateApplication(applicationDTO, assessmentSummaryDTO);
 
         verify(applicationService, times(1)).updateDateModified(eq(workflowRequest), any());
+
+        verify(applicationTrackingDataService, times(1))
+                .sendTrackingOutputResult(
+                        workflowRequest, repOrderDTO, AssessmentType.CCHARDSHIP, RequestSource.HARDSHIP);
     }
 
     @Test

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/IojAppealsOrchestrationServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/IojAppealsOrchestrationServiceTest.java
@@ -8,7 +8,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult;
+import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult.AssessmentType;
+import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult.RequestSource;
 import uk.gov.justice.laa.crime.enums.orchestration.StoredProcedure;
 import uk.gov.justice.laa.crime.orchestration.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.orchestration.dto.WorkflowRequest;
@@ -20,9 +21,9 @@ import uk.gov.justice.laa.crime.orchestration.dto.validation.UserActionDTO;
 import uk.gov.justice.laa.crime.orchestration.exception.CrimeValidationException;
 import uk.gov.justice.laa.crime.orchestration.exception.MaatOrchestrationException;
 import uk.gov.justice.laa.crime.orchestration.exception.RollbackException;
-import uk.gov.justice.laa.crime.orchestration.mapper.ApplicationTrackingMapper;
 import uk.gov.justice.laa.crime.orchestration.mapper.IojAppealMapper;
 import uk.gov.justice.laa.crime.orchestration.service.ApplicationService;
+import uk.gov.justice.laa.crime.orchestration.service.ApplicationTrackingDataService;
 import uk.gov.justice.laa.crime.orchestration.service.AssessmentSummaryService;
 import uk.gov.justice.laa.crime.orchestration.service.ContributionService;
 import uk.gov.justice.laa.crime.orchestration.service.IojAppealService;
@@ -76,7 +77,7 @@ class IojAppealsOrchestrationServiceTest {
     private WorkflowPreProcessorService workflowPreProcessorService;
 
     @Mock
-    private ApplicationTrackingMapper applicationTrackingMapper;
+    private ApplicationTrackingDataService applicationTrackingDataService;
 
     @InjectMocks
     private IojAppealsOrchestrationService iojAppealsOrchestrationService;
@@ -95,7 +96,6 @@ class IojAppealsOrchestrationServiceTest {
                 workflowRequest.getApplicationDTO().getAssessmentDTO().getIojAppeal();
         RepOrderDTO repOrderDTO = TestModelDataBuilder.getTestRepOrderDTO(workflowRequest.getApplicationDTO());
         UserActionDTO userActionDTO = TestModelDataBuilder.getUserActionDTO();
-        ApplicationTrackingOutputResult applicationTrackingOutputResult = new ApplicationTrackingOutputResult();
 
         when(repOrderService.getRepOrder(workflowRequest)).thenReturn(repOrderDTO);
         when(iojAppealMapper.getUserActionDTO(workflowRequest)).thenReturn(userActionDTO);
@@ -104,7 +104,6 @@ class IojAppealsOrchestrationServiceTest {
         when(contributionService.calculate(workflowRequest)).thenReturn(workflowRequest.getApplicationDTO());
         when(maatCourtDataService.invokeStoredProcedure(any(), any(), any()))
                 .thenReturn(workflowRequest.getApplicationDTO());
-        when(applicationTrackingMapper.build(any(), any(), any(), any())).thenReturn(applicationTrackingOutputResult);
 
         AssessmentSummaryDTO assessmentSummaryDTO = TestModelDataBuilder.getAssessmentSummaryDTOFromIojAppealDTO();
         when(assessmentSummaryService.getSummary(iojAppealDTO)).thenReturn(assessmentSummaryDTO);
@@ -131,6 +130,8 @@ class IojAppealsOrchestrationServiceTest {
 
         verify(assessmentSummaryService, times(1)).getSummary(iojAppealDTO);
         verify(assessmentSummaryService).updateApplication(workflowRequest.getApplicationDTO(), assessmentSummaryDTO);
+        verify(applicationTrackingDataService, times(1))
+                .sendTrackingOutputResult(workflowRequest, repOrderDTO, AssessmentType.IOJ, RequestSource.PASSPORT_IOJ);
     }
 
     @Test

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/MeansAssessmentOrchestrationServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/MeansAssessmentOrchestrationServiceTest.java
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.when;
 import static uk.gov.justice.laa.crime.orchestration.common.Constants.WRN_MSG_INCOMPLETE_ASSESSMENT;
 import static uk.gov.justice.laa.crime.orchestration.common.Constants.WRN_MSG_REASSESSMENT;
 
-import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult;
 import uk.gov.justice.laa.crime.enums.orchestration.StoredProcedure;
 import uk.gov.justice.laa.crime.exception.ValidationException;
 import uk.gov.justice.laa.crime.orchestration.data.Constants;
@@ -132,8 +131,6 @@ class MeansAssessmentOrchestrationServiceTest {
                         any(ApplicationDTO.class), any(UserDTO.class), any(StoredProcedure.class)))
                 .thenReturn(applicationDTO);
         when(maatCourtDataApiService.getRepOrderByRepId(anyInt())).thenReturn(repOrderDTO);
-        when(applicationTrackingMapper.build(any(), any(), any(), any()))
-                .thenReturn(new ApplicationTrackingOutputResult().withUsn(123));
 
         ApplicationDTO actual = orchestrationService.create(workflowRequest);
 
@@ -151,7 +148,7 @@ class MeansAssessmentOrchestrationServiceTest {
                         workflowRequest.getUserDTO(),
                         StoredProcedure.PROCESS_ACTIVITY_AND_GET_CORRESPONDENCE);
         verify(assessmentSummaryService, times(1)).getSummary(any(FinancialAssessmentDTO.class));
-        verify(applicationTrackingDataService, times(1)).sendTrackingOutputResult(any());
+        verify(applicationTrackingDataService, times(1)).sendTrackingOutputResult(any(), any(), any(), any());
         verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
 
@@ -162,8 +159,6 @@ class MeansAssessmentOrchestrationServiceTest {
                         any(ApplicationDTO.class), any(UserDTO.class), any(StoredProcedure.class)))
                 .thenReturn(applicationDTO);
         when(maatCourtDataApiService.getRepOrderByRepId(anyInt())).thenReturn(repOrderDTO);
-        when(applicationTrackingMapper.build(any(), any(), any(), any()))
-                .thenReturn(new ApplicationTrackingOutputResult().withUsn(123));
 
         ApplicationDTO actual = orchestrationService.update(workflowRequest);
 
@@ -183,7 +178,7 @@ class MeansAssessmentOrchestrationServiceTest {
                         workflowRequest.getUserDTO(),
                         StoredProcedure.PROCESS_ACTIVITY_AND_GET_CORRESPONDENCE);
         verify(assessmentSummaryService, times(1)).getSummary(any(FinancialAssessmentDTO.class));
-        verify(applicationTrackingDataService, times(1)).sendTrackingOutputResult(any());
+        verify(applicationTrackingDataService, times(1)).sendTrackingOutputResult(any(), any(), any(), any());
         verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
 
@@ -195,8 +190,6 @@ class MeansAssessmentOrchestrationServiceTest {
                 .thenReturn(applicationDTO);
         when(featureDecisionService.isMaatPostAssessmentProcessingEnabled(workflowRequest))
                 .thenReturn(false);
-        when(applicationTrackingMapper.build(any(), any(), any(), any()))
-                .thenReturn(new ApplicationTrackingOutputResult().withUsn(123));
 
         orchestrationService.create(workflowRequest);
 
@@ -213,7 +206,7 @@ class MeansAssessmentOrchestrationServiceTest {
         verify(workflowPreProcessorService, never()).preProcessRequest(any(), any(), any());
         verify(incomeEvidenceService, never()).createEvidence(any(), any());
         verify(proceedingsService, never()).determineMagsRepDecision(any());
-        verify(applicationTrackingDataService, times(1)).sendTrackingOutputResult(any());
+        verify(applicationTrackingDataService, times(1)).sendTrackingOutputResult(any(), any(), any(), any());
 
         verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
@@ -226,8 +219,6 @@ class MeansAssessmentOrchestrationServiceTest {
                 .thenReturn(workflowRequest.getApplicationDTO());
         when(featureDecisionService.isMaatPostAssessmentProcessingEnabled(workflowRequest))
                 .thenReturn(true);
-        when(applicationTrackingMapper.build(any(), any(), any(), any()))
-                .thenReturn(new ApplicationTrackingOutputResult().withUsn(123));
 
         orchestrationService.create(workflowRequest);
 
@@ -247,7 +238,7 @@ class MeansAssessmentOrchestrationServiceTest {
         verify(incomeEvidenceService, times(1)).createEvidence(any(), any());
         verify(proceedingsService, times(1)).determineMagsRepDecision(any());
         verify(contributionService, times(1)).calculate(any());
-        verify(applicationTrackingDataService, times(1)).sendTrackingOutputResult(any());
+        verify(applicationTrackingDataService, times(1)).sendTrackingOutputResult(any(), any(), any(), any());
 
         verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
@@ -260,8 +251,6 @@ class MeansAssessmentOrchestrationServiceTest {
                 .thenReturn(applicationDTO);
         when(featureDecisionService.isMaatPostAssessmentProcessingEnabled(workflowRequest))
                 .thenReturn(false);
-        when(applicationTrackingMapper.build(any(), any(), any(), any()))
-                .thenReturn(new ApplicationTrackingOutputResult().withUsn(123));
 
         orchestrationService.update(workflowRequest);
 
@@ -272,7 +261,7 @@ class MeansAssessmentOrchestrationServiceTest {
         verify(workflowPreProcessorService, never()).preProcessRequest(any(), any(), any());
         verify(incomeEvidenceService, never()).createEvidence(any(), any());
         verify(proceedingsService, never()).determineMagsRepDecision(any());
-        verify(applicationTrackingDataService, times(1)).sendTrackingOutputResult(any());
+        verify(applicationTrackingDataService, times(1)).sendTrackingOutputResult(any(), any(), any(), any());
 
         verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
@@ -285,8 +274,6 @@ class MeansAssessmentOrchestrationServiceTest {
                 .thenReturn(workflowRequest.getApplicationDTO());
         when(featureDecisionService.isMaatPostAssessmentProcessingEnabled(workflowRequest))
                 .thenReturn(true);
-        when(applicationTrackingMapper.build(any(), any(), any(), any()))
-                .thenReturn(new ApplicationTrackingOutputResult().withUsn(123));
 
         orchestrationService.update(workflowRequest);
         verify(maatCourtDataService, never())
@@ -299,7 +286,7 @@ class MeansAssessmentOrchestrationServiceTest {
         verify(incomeEvidenceService, never()).createEvidence(any(), any());
         verify(proceedingsService, times(1)).determineMagsRepDecision(any());
         verify(contributionService, times(1)).calculate(any());
-        verify(applicationTrackingDataService, times(1)).sendTrackingOutputResult(any());
+        verify(applicationTrackingDataService, times(1)).sendTrackingOutputResult(any(), any(), any(), any());
 
         verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
@@ -406,14 +393,12 @@ class MeansAssessmentOrchestrationServiceTest {
                         any(ApplicationDTO.class), any(UserDTO.class), any(StoredProcedure.class)))
                 .thenReturn(workflowRequest.getApplicationDTO());
         when(maatCourtDataApiService.getRepOrderByRepId(anyInt())).thenReturn(repOrderDTO);
-        when(applicationTrackingMapper.build(any(), any(), any(), any()))
-                .thenReturn(new ApplicationTrackingOutputResult().withUsn(123));
 
         orchestrationService.create(workflowRequest);
 
         verify(proceedingsService, times(1)).updateApplication(workflowRequest, repOrderDTO);
         verify(meansAssessmentService, times(0)).rollback(any());
-        verify(applicationTrackingDataService, times(1)).sendTrackingOutputResult(any());
+        verify(applicationTrackingDataService, times(1)).sendTrackingOutputResult(any(), any(), any(), any());
         verify(applicationService).updateDateModified(eq(workflowRequest), any());
     }
 }

--- a/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationServiceTest.java
+++ b/maat-orchestration/src/test/java/uk/gov/justice/laa/crime/orchestration/service/orchestration/PassportAssessmentOrchestrationServiceTest.java
@@ -3,11 +3,11 @@ package uk.gov.justice.laa.crime.orchestration.service.orchestration;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult;
 import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult.AssessmentType;
 import uk.gov.justice.laa.crime.common.model.tracking.ApplicationTrackingOutputResult.RequestSource;
 import uk.gov.justice.laa.crime.enums.RepOrderStatus;
@@ -133,6 +133,12 @@ class PassportAssessmentOrchestrationServiceTest {
 
         verify(assessmentSummaryService).updateApplication(any(ApplicationDTO.class), any(AssessmentSummaryDTO.class));
         verify(applicationService).updateDateModified(any(WorkflowRequest.class), any(ApplicationDTO.class));
+        verify(applicationTrackingDataService, times(1))
+                .sendTrackingOutputResult(
+                        any(WorkflowRequest.class),
+                        any(RepOrderDTO.class),
+                        eq(AssessmentType.PASSPORT),
+                        eq(RequestSource.PASSPORT_IOJ));
     }
 
     @Test
@@ -153,10 +159,6 @@ class PassportAssessmentOrchestrationServiceTest {
                 .setPassportedDTO(PassportAssessmentDataBuilder.getPassportedDTO(Constants.WITHOUT_PARTNER));
         RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTO(RepOrderStatus.CURR.getCode());
         stubCommonCreateInteractions(workflowRequest, repOrderDTO);
-        when(applicationTrackingMapper.build(
-                        workflowRequest, repOrderDTO, AssessmentType.PASSPORT, RequestSource.PASSPORT_IOJ))
-                .thenReturn(TestModelDataBuilder.getApplicationTrackingOutputResult());
-
         ApplicationDTO applicationDTO = passportAssessmentOrchestrationService.create(workflowRequest);
 
         assertThat(applicationDTO).isEqualTo(workflowRequest.getApplicationDTO());
@@ -168,9 +170,6 @@ class PassportAssessmentOrchestrationServiceTest {
         WorkflowRequest workflowRequest = TestModelDataBuilder.buildWorkFlowRequest();
         RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTO(RepOrderStatus.CURR.getCode());
         stubCommonCreateInteractions(workflowRequest, repOrderDTO);
-        when(applicationTrackingMapper.build(
-                        workflowRequest, repOrderDTO, AssessmentType.PASSPORT, RequestSource.PASSPORT_IOJ))
-                .thenReturn(TestModelDataBuilder.getApplicationTrackingOutputResult());
         when(maatCourtDataService.invokeStoredProcedure(
                         any(ApplicationDTO.class),
                         eq(workflowRequest.getUserDTO()),
@@ -196,14 +195,11 @@ class PassportAssessmentOrchestrationServiceTest {
                 .setPassportedDTO(PassportAssessmentDataBuilder.getPassportedDTO(Constants.WITHOUT_PARTNER));
         RepOrderDTO repOrderDTO = TestModelDataBuilder.buildRepOrderDTO(RepOrderStatus.CURR.getCode());
         stubCommonCreateInteractions(workflowRequest, repOrderDTO);
-        when(applicationTrackingMapper.build(
-                        workflowRequest, repOrderDTO, AssessmentType.PASSPORT, RequestSource.PASSPORT_IOJ))
-                .thenReturn(new ApplicationTrackingOutputResult());
 
         ApplicationDTO applicationDTO = passportAssessmentOrchestrationService.create(workflowRequest);
 
         assertThat(applicationDTO).isEqualTo(workflowRequest.getApplicationDTO());
         verifyCommonCreateInteractions();
-        verifyNoInteractions(applicationTrackingDataService);
+        verifyNoInteractions(applicationTrackingMapper);
     }
 }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-2108)

Moved Application Tracking logic to the `ApplicationTrackingDataService`. The original logic had it calling the mapper and then only sending to the Application Tracking Service if a USN is mapped. We now don't bother mapping if there is no USN in the first place.

I've also changed it to use the applicationDTO USN by default, otherwise it'll use the USN on the financialAssessmentDTO if it exists (as opposed to by default as it did previously). This fixes an issue where it wouldn't find the USN for Passport Assessments and IoJ Appeals that didn't have financial assessments.

I did initially attempt to set the USN on the applicationDTO earlier in the process so I wouldn't need to include conditional logic in the `ApplicationTrackingDataService` to determine where the USN was. The problem was some of the stored procedures (e.g. `ASSESSMENT_POST_PROCESSING_PART_1_C3` in the `MeansAssessmentOrchestrationService`) modifies the ApplicationDTO, but doesn't retain the USN if it was set on it prior. There was also a small risk here by modifying it that the stored procedures or behaviour elsewhere could have changed as a result of this further down the line.

Functional tests have passed in UAT:

<img width="587" height="294" alt="Screenshot 2026-06-23 at 14 48 55" src="https://github.com/user-attachments/assets/b7b85bf8-e24b-431a-b2d2-14d6bb097bcb" />
<img width="566" height="285" alt="Screenshot 2026-06-23 at 14 48 59" src="https://github.com/user-attachments/assets/dc5e8e49-dd2e-4924-905f-8b09efa859a0" />



## Checklists

In general these checks apply to most PRs. There will be exceptions, in these cases make it clear what is different and why.
e.g. DRAFT PR because you want early feedback, change only warrants a more targeted run of functional tests, etc.

Some checks can be completed after asking for review, but should be done before merging. Consider what checks will make a reviewers job easier.

### Git housekeeping
- [x] The pull request is not labelled as `WIP/DRAFT`.
- [x] The pull request has a title format of `{JIRA ID} - Description`.
- [x] A link to the Jira ticket is provided along with a description giving context and rationale for the changes, in the `What` section of the PR.
- [x] GitHub is not reporting any conflicts with the `main` branch.
- [x] Nothing unexpected is included in the changes, when compared to the `main` branch.
- [x] All of the pull request triggered checks (such as Build and Test, CodeQL and Snyk) have passed.
- [x] The commit messages have meaningful descriptions.
- [ ] If changes include UI modifications, include before and after screenshots to aid reviewers.

### Change housekeeping
- [ ] Relevant areas in the documentation have been updated to reflect the changes. This may include runbooks, alerts, confluence, etc.
- [x] Attach link / screenshot from successful CI run of UI `@smoke` tests for this branch using [ExecuteUiTests workflow][1].
- [x] Attach link / screenshot from successful CI run of **ALL** API tests for this branch using [ExecuteApiTests workflow][2].

[1]: https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml
[2]: https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteApiTests.yaml
